### PR TITLE
feat: add high-level Lua script interface

### DIFF
--- a/django_cachex/__init__.py
+++ b/django_cachex/__init__.py
@@ -4,3 +4,37 @@ try:
     __version__ = version("django-cachex")
 except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
+
+# Re-export commonly used items for convenience
+from django_cachex.exceptions import (
+    CompressorError,
+    ConnectionInterruptedError,
+    ScriptNotRegisteredError,
+    SerializerError,
+)
+from django_cachex.script import (
+    LuaScript,
+    ScriptHelpers,
+    decode_list_or_none_post,
+    decode_list_post,
+    decode_single_post,
+    full_encode_pre,
+    keys_only_pre,
+    noop_post,
+)
+
+__all__ = [
+    "CompressorError",
+    "ConnectionInterruptedError",
+    "LuaScript",
+    "ScriptHelpers",
+    "ScriptNotRegisteredError",
+    "SerializerError",
+    "__version__",
+    "decode_list_or_none_post",
+    "decode_list_post",
+    "decode_single_post",
+    "full_encode_pre",
+    "keys_only_pre",
+    "noop_post",
+]

--- a/django_cachex/exceptions.py
+++ b/django_cachex/exceptions.py
@@ -67,3 +67,29 @@ class SerializerError(Exception):
     When using serializer fallback, this error triggers fallback to the
     next serializer in the list, enabling safe migrations between formats.
     """
+
+
+class ScriptNotRegisteredError(KeyError):
+    """Raised when eval_script is called with an unregistered script name.
+
+    Attributes:
+        name: The script name that was not found.
+
+    Example:
+        Handling missing scripts::
+
+            from django.core.cache import cache
+            from django_cachex.exceptions import ScriptNotRegisteredError
+
+            try:
+                cache.eval_script("unknown_script", keys=["key1"])
+            except ScriptNotRegisteredError as e:
+                logger.error(f"Script not registered: {e.name}")
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"Script '{name}' is not registered")
+
+    def __str__(self) -> str:
+        return f"Script '{self.name}' is not registered"

--- a/django_cachex/script.py
+++ b/django_cachex/script.py
@@ -1,0 +1,315 @@
+"""Lua script support for django-cachex.
+
+This module provides a high-level interface for registering and executing
+Lua scripts with automatic key prefixing and value encoding/decoding.
+
+Example:
+    Register and execute a rate limiting script::
+
+        from django.core.cache import cache
+        from django_cachex.script import keys_only_pre
+
+        cache.register_script(
+            "rate_limit",
+            '''
+            local current = redis.call('INCR', KEYS[1])
+            if current == 1 then
+                redis.call('EXPIRE', KEYS[1], ARGV[1])
+            end
+            return current
+            ''',
+            num_keys=1,
+            pre_func=keys_only_pre,
+        )
+
+        count = cache.eval_script("rate_limit", keys=["user:123:req"], args=[60])
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+
+@dataclass
+class ScriptHelpers:
+    """Helper functions passed to pre/post processing hooks.
+
+    Provides access to the cache's key prefixing and value encoding
+    functions for use in Lua script processing hooks.
+
+    Attributes:
+        make_key: Function to apply cache key prefix and version.
+        encode: Function to encode a value (serialize + compress).
+        decode: Function to decode a value (decompress + deserialize).
+        version: The key version to use for prefixing.
+
+    Example:
+        Using helpers in a custom pre_func::
+
+            def my_pre(helpers, keys, args):
+                # Prefix all keys
+                processed_keys = helpers.make_keys(keys)
+                # Encode value arguments
+                processed_args = helpers.encode_values(args)
+                return processed_keys, processed_args
+    """
+
+    make_key: Callable[[Any, int | None], Any]
+    encode: Callable[[Any], bytes | int]
+    decode: Callable[[Any], Any]
+    version: int | None
+
+    def make_keys(self, keys: Sequence[Any]) -> list[Any]:
+        """Apply key prefixing to multiple keys.
+
+        Args:
+            keys: Sequence of cache keys to prefix.
+
+        Returns:
+            List of prefixed keys.
+        """
+        return [self.make_key(k, self.version) for k in keys]
+
+    def encode_values(self, values: Sequence[Any]) -> list[bytes | int]:
+        """Encode multiple values for storage.
+
+        Args:
+            values: Sequence of values to encode.
+
+        Returns:
+            List of encoded values.
+        """
+        return [self.encode(v) for v in values]
+
+    def decode_values(self, values: Sequence[Any]) -> list[Any]:
+        """Decode multiple values from storage.
+
+        Args:
+            values: Sequence of encoded values.
+
+        Returns:
+            List of decoded values.
+        """
+        return [self.decode(v) for v in values]
+
+
+@dataclass
+class LuaScript:
+    """Registered Lua script with metadata and processing hooks.
+
+    Attributes:
+        name: Unique identifier for the script.
+        script: The Lua script source code.
+        num_keys: Expected number of KEYS arguments (for documentation).
+        pre_func: Optional function to process keys/args before execution.
+            Signature: (helpers, keys, args) -> (processed_keys, processed_args)
+        post_func: Optional function to process result after execution.
+            Signature: (helpers, result) -> processed_result
+
+    Example:
+        Creating a script with encoding::
+
+            from django_cachex.script import LuaScript, full_encode_pre, decode_single_post
+
+            script = LuaScript(
+                name="get_and_set",
+                script='''
+                    local old = redis.call('GET', KEYS[1])
+                    redis.call('SET', KEYS[1], ARGV[1])
+                    return old
+                ''',
+                num_keys=1,
+                pre_func=full_encode_pre,
+                post_func=decode_single_post,
+            )
+    """
+
+    name: str
+    script: str
+    num_keys: int | None = None
+    pre_func: Callable[[ScriptHelpers, Sequence[Any], Sequence[Any]], tuple[list[Any], list[Any]]] | None = None
+    post_func: Callable[[ScriptHelpers, Any], Any] | None = None
+
+    # Cached SHA hash (populated on first execution)
+    _sha: str | None = field(default=None, repr=False, compare=False)
+
+
+# =============================================================================
+# Pre-built pre_func helpers
+# =============================================================================
+
+
+def keys_only_pre(
+    helpers: ScriptHelpers,
+    keys: Sequence[Any],
+    args: Sequence[Any],
+) -> tuple[list[Any], list[Any]]:
+    """Pre-processor that only prefixes keys, leaves args unchanged.
+
+    Use this when your script works with raw values (numbers, strings)
+    that don't need encoding.
+
+    Args:
+        helpers: Script helper functions.
+        keys: Original keys.
+        args: Original args.
+
+    Returns:
+        Tuple of (prefixed_keys, unchanged_args).
+
+    Example:
+        Rate limiting script that works with integers::
+
+            cache.register_script(
+                "rate_limit",
+                '''
+                local current = redis.call('INCR', KEYS[1])
+                if current == 1 then
+                    redis.call('EXPIRE', KEYS[1], ARGV[1])
+                end
+                return current
+                ''',
+                pre_func=keys_only_pre,
+            )
+    """
+    return helpers.make_keys(keys), list(args)
+
+
+def full_encode_pre(
+    helpers: ScriptHelpers,
+    keys: Sequence[Any],
+    args: Sequence[Any],
+) -> tuple[list[Any], list[Any]]:
+    """Pre-processor that prefixes keys AND encodes all args.
+
+    Use this when your script stores/retrieves serialized Python objects
+    that should be encoded the same way as regular cache values.
+
+    Args:
+        helpers: Script helper functions.
+        keys: Original keys.
+        args: Original args (will be serialized).
+
+    Returns:
+        Tuple of (prefixed_keys, encoded_args).
+
+    Example:
+        Script that stores serialized objects::
+
+            cache.register_script(
+                "store_if_missing",
+                '''
+                if redis.call('EXISTS', KEYS[1]) == 0 then
+                    redis.call('SET', KEYS[1], ARGV[1])
+                    return 1
+                end
+                return 0
+                ''',
+                pre_func=full_encode_pre,
+            )
+    """
+    return helpers.make_keys(keys), helpers.encode_values(args)
+
+
+# =============================================================================
+# Pre-built post_func helpers
+# =============================================================================
+
+
+def decode_single_post(helpers: ScriptHelpers, result: Any) -> Any:
+    """Post-processor for a single encoded value result.
+
+    Returns None if result is None, otherwise decodes the value.
+
+    Args:
+        helpers: Script helper functions.
+        result: Raw result from script (encoded bytes or None).
+
+    Returns:
+        Decoded Python object, or None.
+
+    Example:
+        Script that returns a single cached value::
+
+            cache.register_script(
+                "get_and_delete",
+                '''
+                local value = redis.call('GET', KEYS[1])
+                redis.call('DEL', KEYS[1])
+                return value
+                ''',
+                pre_func=keys_only_pre,
+                post_func=decode_single_post,
+            )
+    """
+    if result is None:
+        return None
+    return helpers.decode(result)
+
+
+def decode_list_post(helpers: ScriptHelpers, result: Any) -> list[Any]:
+    """Post-processor for a list of encoded values.
+
+    Returns empty list if result is None, otherwise decodes each value.
+
+    Args:
+        helpers: Script helper functions.
+        result: Raw result from script (list of encoded bytes or None).
+
+    Returns:
+        List of decoded Python objects.
+
+    Example:
+        Script that returns multiple values::
+
+            cache.register_script(
+                "mget_and_delete",
+                '''
+                local values = redis.call('MGET', unpack(KEYS))
+                redis.call('DEL', unpack(KEYS))
+                return values
+                ''',
+                pre_func=keys_only_pre,
+                post_func=decode_list_post,
+            )
+    """
+    if result is None:
+        return []
+    return helpers.decode_values(result)
+
+
+def decode_list_or_none_post(helpers: ScriptHelpers, result: Any) -> list[Any] | None:
+    """Post-processor for an optional list of encoded values.
+
+    Returns None if result is None, otherwise decodes each value.
+
+    Args:
+        helpers: Script helper functions.
+        result: Raw result from script (list of encoded bytes or None).
+
+    Returns:
+        List of decoded Python objects, or None.
+    """
+    if result is None:
+        return None
+    return helpers.decode_values(result)
+
+
+def noop_post(_helpers: ScriptHelpers, result: Any) -> Any:
+    """Post-processor that returns result unchanged.
+
+    Use this when the script returns raw values (numbers, strings)
+    that don't need decoding.
+
+    Args:
+        _helpers: Script helper functions (unused).
+        result: Raw result from script.
+
+    Returns:
+        Unchanged result.
+    """
+    return result

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -94,6 +94,64 @@ List operations for ordered, indexable collections:
 | `lpos(key, element, ...)` | Find element position in list |
 | `lmove(src, dst, src_side, dst_side)` | Atomically move element between lists |
 
+### Lua Script Methods
+
+Lua script registration and execution:
+
+| Method | Description |
+|--------|-------------|
+| `register_script(name, script, ...)` | Register a Lua script |
+| `eval_script(name, keys=(), args=())` | Execute a registered script |
+| `aeval_script(name, keys=(), args=())` | Execute a registered script (async) |
+
+#### register_script
+
+```python
+cache.register_script(
+    name,           # Unique script name
+    script,         # Lua script source
+    num_keys=None,  # Expected KEYS count (documentation only)
+    pre_func=None,  # Pre-processing hook: (helpers, keys, args) -> (keys, args)
+    post_func=None, # Post-processing hook: (helpers, result) -> result
+)
+```
+
+#### eval_script / aeval_script
+
+```python
+result = cache.eval_script(
+    name,           # Registered script name
+    keys=(),        # KEYS to pass to script
+    args=(),        # ARGV to pass to script
+    version=None,   # Key version for prefixing
+)
+```
+
+#### Pre-built Helpers
+
+| Helper | Description |
+|--------|-------------|
+| `keys_only_pre` | Prefix keys, leave args unchanged |
+| `full_encode_pre` | Prefix keys AND encode all args |
+| `decode_single_post` | Decode a single returned value |
+| `decode_list_post` | Decode a list of returned values |
+| `decode_list_or_none_post` | Decode list or return None |
+| `noop_post` | Return result unchanged |
+
+#### ScriptHelpers
+
+The helpers object passed to pre/post functions:
+
+| Attribute/Method | Description |
+|------------------|-------------|
+| `make_key(key, version)` | Apply cache key prefix |
+| `make_keys(keys)` | Prefix multiple keys |
+| `encode(value)` | Encode a value (serialize + compress) |
+| `encode_values(values)` | Encode multiple values |
+| `decode(value)` | Decode a value |
+| `decode_values(values)` | Decode multiple values |
+| `version` | Current key version |
+
 ### Set Method Options
 
 ```python

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.1.0b3 (January 2026)
+
+### New Features
+
+- **Lua Script Interface**: High-level API for registering and executing Lua scripts with automatic key prefixing and value encoding/decoding
+  - `cache.register_script()` to register scripts with pre/post processing hooks
+  - `cache.eval_script()` and `cache.aeval_script()` for sync/async execution
+  - `pipe.eval_script()` for pipeline support
+  - Pre-built helpers: `keys_only_pre`, `full_encode_pre`, `decode_single_post`, `decode_list_post`
+  - `ScriptHelpers` class exposes `make_key`, `encode`, `decode` for custom hooks
+  - Automatic SHA caching with NOSCRIPT fallback
+
+### New Classes
+
+- `LuaScript` - Dataclass for registered scripts with metadata
+- `ScriptHelpers` - Helper functions passed to pre/post processing hooks
+- `ScriptNotRegisteredError` - Exception for unregistered script names
+
 ## 0.1.0 (January 2026)
 
 Initial release of django-cachex.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-cachex"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = "Full featured Valkey and Redis cache backend for Django"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_cache_scripts.py
+++ b/tests/test_cache_scripts.py
@@ -1,0 +1,378 @@
+"""Tests for Lua script operations."""
+
+import pytest
+
+from django_cachex.cache import KeyValueCache
+from django_cachex.exceptions import ScriptNotRegisteredError
+from django_cachex.script import (
+    LuaScript,
+    ScriptHelpers,
+    decode_list_post,
+    decode_single_post,
+    full_encode_pre,
+    keys_only_pre,
+    noop_post,
+)
+
+
+class TestScriptRegistration:
+    """Test script registration functionality."""
+
+    def test_register_script_returns_lua_script(self, cache: KeyValueCache):
+        """Test that register_script returns a LuaScript object."""
+        script = cache.register_script(
+            "test_script",
+            "return 1",
+        )
+        assert isinstance(script, LuaScript)
+        assert script.name == "test_script"
+        assert script.script == "return 1"
+
+    def test_register_script_with_all_options(self, cache: KeyValueCache):
+        """Test register_script with all optional arguments."""
+        script = cache.register_script(
+            "full_script",
+            "return KEYS[1]",
+            num_keys=1,
+            pre_func=keys_only_pre,
+            post_func=noop_post,
+        )
+        assert script.num_keys == 1
+        assert script.pre_func is keys_only_pre
+        assert script.post_func is noop_post
+
+    def test_register_script_overwrites_existing(self, cache: KeyValueCache):
+        """Test that registering with same name overwrites."""
+        cache.register_script("overwrite_test", "return 1")
+        script = cache.register_script("overwrite_test", "return 2")
+        assert script.script == "return 2"
+
+    def test_eval_script_not_registered_raises(self, cache: KeyValueCache):
+        """Test that eval_script raises for unregistered scripts."""
+        with pytest.raises(ScriptNotRegisteredError) as exc_info:
+            cache.eval_script("nonexistent_script")
+        assert exc_info.value.name == "nonexistent_script"
+        assert "nonexistent_script" in str(exc_info.value)
+
+
+class TestScriptExecution:
+    """Test script execution functionality."""
+
+    def test_eval_script_simple(self, cache: KeyValueCache):
+        """Test simple script execution."""
+        cache.register_script("simple_return", "return 42")
+        result = cache.eval_script("simple_return")
+        assert result == 42
+
+    def test_eval_script_with_keys_and_args(self, cache: KeyValueCache):
+        """Test script execution with keys and args."""
+        cache.register_script(
+            "incr_by",
+            """
+            local current = redis.call('GET', KEYS[1]) or 0
+            local new = tonumber(current) + tonumber(ARGV[1])
+            redis.call('SET', KEYS[1], new)
+            return new
+            """,
+            pre_func=keys_only_pre,
+        )
+
+        result = cache.eval_script("incr_by", keys=["counter"], args=[10])
+        assert result == 10
+
+        result = cache.eval_script("incr_by", keys=["counter"], args=[5])
+        assert result == 15
+
+    def test_eval_script_with_pre_func(self, cache: KeyValueCache):
+        """Test script with pre_func for key prefixing."""
+        cache.register_script(
+            "set_and_get",
+            """
+            redis.call('SET', KEYS[1], ARGV[1])
+            return redis.call('GET', KEYS[1])
+            """,
+            pre_func=keys_only_pre,
+        )
+
+        result = cache.eval_script("set_and_get", keys=["mykey"], args=["myvalue"])
+        assert result == b"myvalue"
+
+    def test_eval_script_with_encoding(self, cache: KeyValueCache):
+        """Test script with full encoding of values."""
+        cache.register_script(
+            "store_object",
+            """
+            redis.call('SET', KEYS[1], ARGV[1])
+            return redis.call('GET', KEYS[1])
+            """,
+            pre_func=full_encode_pre,
+            post_func=decode_single_post,
+        )
+
+        test_obj = {"name": "test", "value": 123}
+        result = cache.eval_script("store_object", keys=["objkey"], args=[test_obj])
+        assert result == test_obj
+
+    def test_eval_script_caches_sha(self, cache: KeyValueCache):
+        """Test that script SHA is cached after first execution."""
+        script = cache.register_script("cached_sha", "return 'cached'")
+        assert script._sha is None
+
+        cache.eval_script("cached_sha")
+        assert script._sha is not None
+
+        # Second execution should use cached SHA
+        first_sha = script._sha
+        cache.eval_script("cached_sha")
+        assert script._sha == first_sha
+
+    def test_eval_script_noscript_fallback(self, cache: KeyValueCache):
+        """Test that NOSCRIPT error triggers reload."""
+        script = cache.register_script("noscript_test", "return 'reloaded'")
+
+        # Execute to cache SHA
+        cache.eval_script("noscript_test")
+        assert script._sha is not None
+
+        # Flush scripts to simulate NOSCRIPT scenario
+        cache._cache.script_flush()
+
+        # Should reload and succeed
+        result = cache.eval_script("noscript_test")
+        assert result == b"reloaded"
+
+    def test_eval_script_with_version(self, cache: KeyValueCache):
+        """Test script execution with explicit version."""
+        cache.register_script(
+            "versioned_set",
+            """
+            redis.call('SET', KEYS[1], ARGV[1])
+            return 1
+            """,
+            pre_func=keys_only_pre,
+        )
+
+        # Set with version 1
+        cache.eval_script("versioned_set", keys=["vkey"], args=["v1"], version=1)
+        # Set with version 2
+        cache.eval_script("versioned_set", keys=["vkey"], args=["v2"], version=2)
+
+        # Get should return different values for different versions
+        v1_val = cache.get("vkey", version=1)
+        v2_val = cache.get("vkey", version=2)
+
+        # Values should be different (different prefixed keys)
+        assert v1_val == b"v1"
+        assert v2_val == b"v2"
+
+
+class TestScriptHelpers:
+    """Test ScriptHelpers functionality."""
+
+    def test_script_helpers_make_keys(self, cache: KeyValueCache):
+        """Test ScriptHelpers.make_keys method."""
+        helpers = ScriptHelpers(
+            make_key=cache.make_and_validate_key,
+            encode=cache._cache.encode,
+            decode=cache._cache.decode,
+            version=1,
+        )
+
+        keys = helpers.make_keys(["key1", "key2"])
+        assert len(keys) == 2
+        # Keys should be prefixed
+        assert keys[0] != "key1"
+        assert keys[1] != "key2"
+
+    def test_script_helpers_encode_decode(self, cache: KeyValueCache):
+        """Test ScriptHelpers encode/decode methods."""
+        helpers = ScriptHelpers(
+            make_key=cache.make_and_validate_key,
+            encode=cache._cache.encode,
+            decode=cache._cache.decode,
+            version=1,
+        )
+
+        original = {"key": "value", "number": 42}
+        encoded = helpers.encode_values([original])
+        decoded = helpers.decode_values(encoded)
+
+        assert decoded[0] == original
+
+
+class TestPreBuiltFunctions:
+    """Test pre-built pre_func and post_func implementations."""
+
+    def test_keys_only_pre(self, cache: KeyValueCache):
+        """Test keys_only_pre helper."""
+        helpers = ScriptHelpers(
+            make_key=cache.make_and_validate_key,
+            encode=cache._cache.encode,
+            decode=cache._cache.decode,
+            version=1,
+        )
+
+        keys = ["k1", "k2"]
+        args = [1, 2, "three"]
+
+        proc_keys, proc_args = keys_only_pre(helpers, keys, args)
+
+        # Keys should be prefixed
+        assert proc_keys[0] != "k1"
+        # Args should be unchanged
+        assert proc_args == [1, 2, "three"]
+
+    def test_full_encode_pre(self, cache: KeyValueCache):
+        """Test full_encode_pre helper."""
+        helpers = ScriptHelpers(
+            make_key=cache.make_and_validate_key,
+            encode=cache._cache.encode,
+            decode=cache._cache.decode,
+            version=1,
+        )
+
+        keys = ["k1"]
+        args = [{"obj": "value"}]
+
+        proc_keys, proc_args = full_encode_pre(helpers, keys, args)
+
+        # Keys should be prefixed
+        assert proc_keys[0] != "k1"
+        # Args should be encoded
+        assert proc_args[0] != args[0]
+        assert isinstance(proc_args[0], bytes)
+
+    def test_decode_single_post(self, cache: KeyValueCache):
+        """Test decode_single_post helper."""
+        helpers = ScriptHelpers(
+            make_key=cache.make_and_validate_key,
+            encode=cache._cache.encode,
+            decode=cache._cache.decode,
+            version=1,
+        )
+
+        original = {"test": "value"}
+        encoded = helpers.encode(original)
+
+        decoded = decode_single_post(helpers, encoded)
+        assert decoded == original
+
+        # None should return None
+        assert decode_single_post(helpers, None) is None
+
+    def test_decode_list_post(self, cache: KeyValueCache):
+        """Test decode_list_post helper."""
+        helpers = ScriptHelpers(
+            make_key=cache.make_and_validate_key,
+            encode=cache._cache.encode,
+            decode=cache._cache.decode,
+            version=1,
+        )
+
+        originals = [{"a": 1}, {"b": 2}]
+        encoded = [helpers.encode(o) for o in originals]
+
+        decoded = decode_list_post(helpers, encoded)
+        assert decoded == originals
+
+        # None should return empty list
+        assert decode_list_post(helpers, None) == []
+
+
+class TestPipelineScripts:
+    """Test script execution in pipelines."""
+
+    def test_pipeline_eval_script(self, cache: KeyValueCache):
+        """Test eval_script in pipeline."""
+        cache.register_script("pipe_incr", "return redis.call('INCR', KEYS[1])", pre_func=keys_only_pre)
+
+        with cache.pipeline() as pipe:
+            pipe.eval_script("pipe_incr", keys=["pipe_counter"])
+            pipe.eval_script("pipe_incr", keys=["pipe_counter"])
+            pipe.eval_script("pipe_incr", keys=["pipe_counter"])
+            results = pipe.execute()
+
+        assert results == [1, 2, 3]
+
+    def test_pipeline_eval_script_mixed(self, cache: KeyValueCache):
+        """Test mixing eval_script with other operations."""
+        cache.register_script(
+            "pipe_set",
+            "redis.call('SET', KEYS[1], ARGV[1]); return 'ok'",
+            pre_func=keys_only_pre,
+        )
+
+        with cache.pipeline() as pipe:
+            pipe.set("regular_key", "regular_value")
+            pipe.eval_script("pipe_set", keys=["script_key"], args=["script_value"])
+            pipe.get("regular_key")
+            results = pipe.execute()
+
+        assert results[0] is True  # set
+        assert results[1] == b"ok"  # script
+        assert results[2] == "regular_value"  # get
+
+    def test_pipeline_eval_script_with_post_func(self, cache: KeyValueCache):
+        """Test pipeline eval_script with post_func decoder."""
+        cache.register_script(
+            "pipe_get_obj",
+            """
+            redis.call('SET', KEYS[1], ARGV[1])
+            return redis.call('GET', KEYS[1])
+            """,
+            pre_func=full_encode_pre,
+            post_func=decode_single_post,
+        )
+
+        test_obj = {"data": [1, 2, 3]}
+
+        with cache.pipeline() as pipe:
+            pipe.eval_script("pipe_get_obj", keys=["objkey"], args=[test_obj])
+            results = pipe.execute()
+
+        assert results[0] == test_obj
+
+    def test_pipeline_eval_script_not_registered(self, cache: KeyValueCache):
+        """Test that unregistered script raises in pipeline."""
+        with pytest.raises(ScriptNotRegisteredError), cache.pipeline() as pipe:
+            pipe.eval_script("not_registered", keys=["key"])
+
+    def test_pipeline_eval_script_chaining(self, cache: KeyValueCache):
+        """Test that eval_script returns self for chaining."""
+        cache.register_script("chain_test", "return 1")
+
+        pipe = cache.pipeline()
+        result = pipe.eval_script("chain_test").eval_script("chain_test")
+        assert result is pipe
+
+
+@pytest.mark.asyncio
+class TestAsyncScriptExecution:
+    """Test async script execution functionality."""
+
+    async def test_aeval_script_simple(self, cache: KeyValueCache):
+        """Test simple async script execution."""
+        cache.register_script("async_return", "return 'async'")
+        result = await cache.aeval_script("async_return")
+        assert result == b"async"
+
+    async def test_aeval_script_with_encoding(self, cache: KeyValueCache):
+        """Test async script with encoding."""
+        cache.register_script(
+            "async_store",
+            """
+            redis.call('SET', KEYS[1], ARGV[1])
+            return redis.call('GET', KEYS[1])
+            """,
+            pre_func=full_encode_pre,
+            post_func=decode_single_post,
+        )
+
+        test_obj = {"async": True, "value": 42}
+        result = await cache.aeval_script("async_store", keys=["async_key"], args=[test_obj])
+        assert result == test_obj
+
+    async def test_aeval_script_not_registered(self, cache: KeyValueCache):
+        """Test that aeval_script raises for unregistered scripts."""
+        with pytest.raises(ScriptNotRegisteredError):
+            await cache.aeval_script("nonexistent_async")

--- a/uv.lock
+++ b/uv.lock
@@ -401,7 +401,7 @@ wheels = [
 
 [[package]]
 name = "django-cachex"
-version = "0.1.0b2"
+version = "0.1.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Add register_script/eval_script/aeval_script API with automatic key prefixing and value encoding/decoding via pre/post processing hooks.

- LuaScript dataclass for registered scripts with metadata
- ScriptHelpers provides make_key, encode, decode for custom hooks
- Pre-built helpers: keys_only_pre, full_encode_pre, decode_*_post
- Pipeline support via pipe.eval_script()
- Automatic SHA caching with NOSCRIPT fallback
- ScriptNotRegisteredError for unregistered script names

Bump version to 0.1.0b3