### PR TITLE
docs: fix docstring and documentation content inaccuracies

### DIFF
--- a/django_cachex/admin/__init__.py
+++ b/django_cachex/admin/__init__.py
@@ -1,5 +1,1 @@
-"""
-django_cachex.admin - Admin interface for cache inspection.
-
-Add 'django_cachex.admin' to INSTALLED_APPS to enable the cache admin.
-"""
+"""Admin interface for cache inspection."""

--- a/django_cachex/admin/admin.py
+++ b/django_cachex/admin/admin.py
@@ -1,9 +1,4 @@
-"""
-Django admin classes for cache management.
-
-This module provides ModelAdmin classes for managing caches
-and cache keys through Django's admin interface.
-"""
+"""Django admin classes for cache management."""
 
 from __future__ import annotations
 
@@ -30,12 +25,7 @@ else:
 
 @admin.register(Cache)
 class CacheAdmin(_CacheBase):
-    """
-    Admin for caches.
-
-    - changelist_view: Lists all caches (from settings.CACHES)
-    - change_view: Shows cache details (info + slowlog combined)
-    """
+    """Admin for caches."""
 
     _cachex_help_messages: ClassVar[dict[str, str]] = {
         "cache_list": mark_safe(
@@ -124,15 +114,7 @@ class CacheAdmin(_CacheBase):
 
 @admin.register(Key)
 class KeyAdmin(_KeyBase):
-    """
-    Admin for cache keys.
-
-    - changelist_view: Browse keys for a cache (requires ?cache=<name> parameter)
-    - change_view: View/edit a specific key
-    - add_view: Add a new key to a cache
-
-    This admin is accessed via CacheAdmin and is hidden from the sidebar.
-    """
+    """Admin for cache keys, accessed via CacheAdmin and hidden from the sidebar."""
 
     _cachex_help_messages: ClassVar[dict[str, str]] = {
         "key_list": mark_safe(

--- a/django_cachex/admin/helpers.py
+++ b/django_cachex/admin/helpers.py
@@ -1,9 +1,4 @@
-"""
-Helper functions for cache admin views.
-
-These functions provide additional logic on top of the cache interface
-that views can use. They're intentionally simple functions, not a service class.
-"""
+"""Helper functions for cache admin views."""
 
 from __future__ import annotations
 
@@ -23,20 +18,7 @@ if TYPE_CHECKING:
 
 
 def get_cache(cache_name: str) -> Any:
-    """Get a cache backend, wrapping if needed for admin compatibility.
-
-    For django-cachex backends, returns the cache directly.
-    For Django builtin backends, wraps them first.
-
-    Args:
-        cache_name: The name of the cache in CACHES setting.
-
-    Returns:
-        A cache backend with cachex extensions available.
-
-    Raises:
-        ValueError: If the cache is not configured.
-    """
+    """Get a cache backend, wrapping if needed for admin compatibility."""
     cache_config = settings.CACHES.get(cache_name)
     if not cache_config:
         msg = f"Cache '{cache_name}' is not configured in CACHES setting."
@@ -54,22 +36,7 @@ def get_cache(cache_name: str) -> Any:
 
 
 def get_metadata(cache: Any, cache_config: Mapping[str, Any]) -> dict[str, Any]:
-    """Get cache metadata with parsed server information.
-
-    Combines cache.info() with configuration metadata for display
-    in the cache admin.
-
-    Args:
-        cache: The cache backend (native or wrapped).
-        cache_config: The cache configuration dict from settings.CACHES.
-
-    Returns:
-        Dict with backend, location, key_prefix, version, and
-        parsed server/memory/clients/stats/keyspace sections.
-
-    Raises:
-        NotSupportedError: If info() is not supported.
-    """
+    """Get cache metadata with parsed server information."""
     # Get location from config
     location = cache_config.get("LOCATION", "")
     if isinstance(location, list):
@@ -154,17 +121,7 @@ def get_metadata(cache: Any, cache_config: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def get_type_data(cache: Any, key: str, key_type: str | None = None) -> dict[str, Any]:
-    """Get type-specific data for a key.
-
-    Args:
-        cache: The cache backend.
-        key: The cache key.
-        key_type: Optional type hint (avoids extra type() call).
-
-    Returns:
-        Dict with type-specific data (items for lists, members for sets, etc.)
-        Empty dict if not supported.
-    """
+    """Get type-specific data for a key."""
     try:
         if key_type is None:
             key_type = cache.type(key)
@@ -198,16 +155,7 @@ def get_type_data(cache: Any, key: str, key_type: str | None = None) -> dict[str
 
 
 def get_size(cache: Any, key: str, key_type: str | None = None) -> int | None:
-    """Get the size/length of a key.
-
-    Args:
-        cache: The cache backend.
-        key: The cache key.
-        key_type: Optional type hint.
-
-    Returns:
-        Size/length or None if not supported.
-    """
+    """Get the size/length of a key."""
     try:
         if key_type is None:
             key_type = cache.type(key)
@@ -271,18 +219,7 @@ def _parse_slowlog_entry(entry: Any) -> dict[str, Any]:
 
 
 def get_slowlog(cache: Any, count: int = 25) -> dict[str, Any]:
-    """Get slow query log entries.
-
-    Args:
-        cache: The cache backend.
-        count: Number of entries to retrieve.
-
-    Returns:
-        Dict with entries, length, error fields.
-
-    Raises:
-        NotSupportedError: If slowlog is not supported.
-    """
+    """Get slow query log entries."""
     result: dict[str, Any] = {
         "entries": [],
         "length": 0,

--- a/django_cachex/admin/models.py
+++ b/django_cachex/admin/models.py
@@ -8,12 +8,7 @@ from django.db import models
 
 
 class Cache(models.Model):
-    """
-    Fake model representing a Django cache backend.
-
-    This model is not managed by Django (no migrations, no database table).
-    It provides a hook for Django admin to display caches.
-    """
+    """Unmanaged model representing a Django cache backend for admin display."""
 
     # Fake primary key - corresponds to cache name
     name = models.CharField(max_length=255, primary_key=True)
@@ -82,13 +77,7 @@ class Cache(models.Model):
 
     @property
     def support_level(self) -> str:
-        """Determine the support level for this cache backend.
-
-        Returns:
-            - "cachex": Full support (django-cachex backends)
-            - "wrapped": Django core builtin backends (wrapped for almost full support)
-            - "limited": Custom/unknown backends with limited support
-        """
+        """Determine the support level for this cache backend."""
         # Check for _cachex_support attribute on the cache backend (set by wrap_cache
         # or native django-cachex backends)
         cache = self._get_cache()
@@ -130,12 +119,7 @@ class Cache(models.Model):
 
 
 class Key(models.Model):
-    """
-    Fake model representing a cache key.
-
-    This model is not managed by Django (no migrations, no database table).
-    Keys are identified by a composite of (cache_name, key_name).
-    """
+    """Unmanaged model representing a cache key, identified by (cache_name, key_name)."""
 
     # Composite identifier: cache_name:key_name
     id = models.CharField(max_length=2048, primary_key=True)
@@ -156,23 +140,12 @@ class Key(models.Model):
 
     @classmethod
     def make_pk(cls, cache_name: str, key_name: str) -> str:
-        """Create a primary key from cache name and key name.
-
-        Format: cache_name:key_name
-
-        Note: We don't URL-encode here because Django's {% url %} template tag
-        handles URL encoding automatically. The key_name can contain any
-        characters including colons - parse_pk uses split(':', 1) to only
-        split on the first colon.
-        """
+        """Create a primary key from cache name and key name."""
         return f"{cache_name}:{key_name}"
 
     @classmethod
     def parse_pk(cls, pk: str) -> tuple[str, str]:
-        """Parse a primary key into (cache_name, key_name).
-
-        Splits on the first colon only, so key names can contain colons.
-        """
+        """Parse a primary key into (cache_name, key_name)."""
         parts = pk.split(":", 1)
         if len(parts) == 2:
             return parts[0], parts[1]

--- a/django_cachex/admin/views/__init__.py
+++ b/django_cachex/admin/views/__init__.py
@@ -1,10 +1,4 @@
-"""
-Views for the django-cachex cache admin.
-
-Provides cache inspection and management functionality.
-These views can be configured with different template prefixes and URL builders
-to support both the standard Django admin and alternative admin themes like Unfold.
-"""
+"""Views for the django-cachex cache admin."""
 
 from .base import (
     ADMIN_CONFIG,

--- a/django_cachex/admin/views/base.py
+++ b/django_cachex/admin/views/base.py
@@ -52,17 +52,7 @@ def key_add_url(cache_name: str) -> str:
 
 
 class ViewConfig:
-    """Configuration for cache admin views.
-
-    Holds template prefix and help messages for views. Supports both Django admin
-    and alternative admin themes (like Unfold).
-
-    Args:
-        template_prefix: Base path for templates (e.g., "admin/django_cachex")
-        template_overrides: Dict mapping canonical names to actual template paths.
-            Use this when template names differ between themes.
-        help_messages: Dict mapping view names to HTML help content.
-    """
+    """Configuration for cache admin views, supporting Django admin and alternative themes."""
 
     def __init__(
         self,
@@ -75,10 +65,7 @@ class ViewConfig:
         self.help_messages = help_messages or {}
 
     def template(self, name: str) -> str:
-        """Get the full template path for a template name.
-
-        Checks template_overrides first, then falls back to prefix + name.
-        """
+        """Get the full template path for a template name."""
         if name in self.template_overrides:
             return f"{self.template_prefix}/{self.template_overrides[name]}"
         return f"{self.template_prefix}/{name}"
@@ -108,21 +95,7 @@ def show_help(
 
 
 def is_json_serializable(value: Any) -> bool:
-    """Check if a value can be safely serialized to JSON and back without loss.
-
-    This performs a round-trip check to ensure the value can be serialized
-    to JSON and deserialized back to an equivalent Python object.
-
-    Returns True for: None, bool, int, float, str, and dicts/lists containing only
-    these types. Returns False for: bytes, datetime, custom objects, or any value
-    where the round-trip changes the data.
-
-    Args:
-        value: The Python value to check.
-
-    Returns:
-        True if the value can round-trip through JSON without information loss.
-    """
+    """Check if a value can be safely round-tripped through JSON without loss."""
     try:
         serialized = json.dumps(value)
         deserialized = json.loads(serialized)
@@ -132,16 +105,7 @@ def is_json_serializable(value: Any) -> bool:
 
 
 def format_value_for_display(value: Any) -> tuple[str, bool]:
-    """Format a value for display in the admin UI.
-
-    Args:
-        value: The Python value to format.
-
-    Returns:
-        A tuple of (display_string, is_editable).
-        - JSON-serializable values are displayed as formatted JSON and are editable.
-        - Non-JSON-serializable values are displayed using repr() and are read-only.
-    """
+    """Format a value for display in the admin UI, returning (display_string, is_editable)."""
     if value is None:
         return "null", True
 

--- a/django_cachex/admin/views/key_detail.py
+++ b/django_cachex/admin/views/key_detail.py
@@ -34,10 +34,7 @@ def _key_detail_view(  # noqa: C901, PLR0911, PLR0912, PLR0915
     key: str,
     config: ViewConfig,
 ) -> HttpResponse:
-    """View for displaying the details of a specific cache key.
-
-    This is the internal implementation; use key_detail() for the decorated admin view.
-    """
+    """Display details of a specific cache key and handle mutations."""
     cache = get_cache(cache_name)
 
     # Handle POST requests (update or delete)

--- a/django_cachex/compat.py
+++ b/django_cachex/compat.py
@@ -8,12 +8,7 @@ from django.utils.module_loading import import_string
 
 
 def create_serializer(config: str | type | Any | None, **kwargs: Any) -> Any:
-    """Create a serializer instance from config.
-
-    Args:
-        config: A dotted path string, a class, an instance, or None for default pickle
-        **kwargs: Keyword arguments to pass to serializer constructor
-    """
+    """Create a serializer from a dotted path, class, instance, or None (default: pickle)."""
     if config is None:
         config = "django_cachex.serializers.pickle.PickleSerializer"
 
@@ -27,12 +22,7 @@ def create_serializer(config: str | type | Any | None, **kwargs: Any) -> Any:
 
 
 def create_compressor(config: str | type | Any, **kwargs: Any) -> Any:
-    """Create a compressor instance from config.
-
-    Args:
-        config: A dotted path string, a class, or an instance
-        **kwargs: Keyword arguments to pass to compressor constructor
-    """
+    """Create a compressor from a dotted path, class, or instance."""
     if isinstance(config, str):
         config = import_string(config)
 

--- a/django_cachex/compressors/base.py
+++ b/django_cachex/compressors/base.py
@@ -11,17 +11,7 @@ from typing import Any
 class BaseCompressor:
     """Base class for cache value compressors.
 
-    Django's redis cache backend does not include compression support.
-    This is a django-cachex-ng extension that follows the same pattern as
-    serializers: any object with ``compress`` and ``decompress`` methods works.
-
-    Compression is skipped for values smaller than ``min_length`` bytes to avoid
-    overhead on small values where compression provides little benefit.
-
-    Args:
-        min_length: Minimum value size in bytes before compression is applied.
-                    Values smaller than this are returned uncompressed.
-                    Defaults to 256 bytes.
+    Compression is skipped for values of ``min_length`` bytes or fewer.
     """
 
     min_length: int = 256

--- a/django_cachex/compressors/lzma.py
+++ b/django_cachex/compressors/lzma.py
@@ -6,12 +6,7 @@ from django_cachex.exceptions import CompressorError
 
 
 class LzmaCompressor(BaseCompressor):
-    """LZMA compressor with configurable preset level.
-
-    Args:
-        preset: Compression level from 0 (fastest) to 9 (best compression).
-                Defaults to 4.
-    """
+    """LZMA compressor with configurable preset level."""
 
     preset: int = 4
 

--- a/django_cachex/compressors/zlib.py
+++ b/django_cachex/compressors/zlib.py
@@ -6,12 +6,7 @@ from django_cachex.exceptions import CompressorError
 
 
 class ZlibCompressor(BaseCompressor):
-    """Zlib compressor with configurable compression level.
-
-    Args:
-        level: Compression level from 0 (no compression) to 9 (best compression).
-               Defaults to 6.
-    """
+    """Zlib compressor with configurable compression level."""
 
     level: int = 6
 

--- a/django_cachex/exceptions.py
+++ b/django_cachex/exceptions.py
@@ -5,11 +5,7 @@
 #
 # django-redis was used as inspiration for this project.
 
-"""Exceptions for django-cachex.
-
-This module defines exceptions that may be raised during cache operations.
-Users can catch these to handle specific error conditions.
-"""
+"""Exceptions for django-cachex."""
 
 import socket
 
@@ -53,46 +49,19 @@ _ResponseError = tuple(_response_errors) if _response_errors else (Exception,)
 class CompressorError(Exception):
     """Raised when compression or decompression fails.
 
-    This can occur when:
-    - The data is corrupted and cannot be decompressed
-    - The compressor is misconfigured
-    - The compression library encounters an error
-
-    When using compressor fallback, this error triggers fallback to the
-    next compressor in the list.
+    Caught by the client's fallback logic to try the next compressor in the chain.
     """
 
 
 class SerializerError(Exception):
     """Raised when serialization or deserialization fails.
 
-    This can occur when:
-    - The data format doesn't match the expected serializer format
-    - The data is corrupted
-    - The serializer encounters an incompatible type
-
-    When using serializer fallback, this error triggers fallback to the
-    next serializer in the list, enabling safe migrations between formats.
+    Caught by the client's fallback logic to try the next serializer in the chain.
     """
 
 
 class ScriptNotRegisteredError(KeyError):
-    """Raised when eval_script is called with an unregistered script name.
-
-    Attributes:
-        name: The script name that was not found.
-
-    Example:
-        Handling missing scripts::
-
-            from django.core.cache import cache
-            from django_cachex.exceptions import ScriptNotRegisteredError
-
-            try:
-                cache.eval_script("unknown_script", keys=["key1"])
-            except ScriptNotRegisteredError as e:
-                logger.error(f"Script not registered: {e.name}")
-    """
+    """Raised when eval_script is called with an unregistered script name."""
 
     def __init__(self, name: str) -> None:
         self.name = name
@@ -103,26 +72,7 @@ class ScriptNotRegisteredError(KeyError):
 
 
 class NotSupportedError(Exception):
-    """Raised when an operation is not supported by the cache backend.
-
-    This exception is used by the cache admin interface when a cache
-    backend (or its wrapper) does not support a particular operation.
-    Views catch this exception to display user-friendly warning messages.
-
-    Attributes:
-        operation: The operation that is not supported.
-        backend: Optional name of the backend that doesn't support it.
-
-    Example:
-        Handling unsupported operations::
-
-            from django_cachex.exceptions import NotSupportedError
-
-            try:
-                service.ttl(key)
-            except NotSupportedError:
-                messages.warning(request, "TTL not supported for this backend.")
-    """
+    """Raised when an operation is not supported by the cache backend."""
 
     def __init__(self, operation: str, backend: str | None = None) -> None:
         self.operation = operation

--- a/django_cachex/omit_exception.py
+++ b/django_cachex/omit_exception.py
@@ -14,18 +14,12 @@ def omit_exception(
     method: Callable | None = None,
     return_value: Any | None = None,
 ) -> Callable:
-    """Decorator that intercepts connection errors and ignores them if configured.
+    """Decorator that catches backend errors (connection, timeout, response) based on _ignore_exceptions setting.
 
-    When applied to a cache method (sync or async), this decorator catches
-    connection and timeout errors from the underlying library (redis-py or
-    valkey-py) and either ignores them (returning return_value) or re-raises,
-    depending on the cache's _ignore_exceptions setting.
+    Supports both sync and async methods. When ignoring, returns ``return_value``.
 
-    Args:
-        method: The method to wrap (when used without parentheses)
-        return_value: Value to return when exception is ignored (default: None)
+    Usage::
 
-    Usage:
         @omit_exception
         def set(self, key, value): ...
 

--- a/django_cachex/script.py
+++ b/django_cachex/script.py
@@ -38,24 +38,8 @@ if TYPE_CHECKING:
 class ScriptHelpers:
     """Helper functions passed to pre/post processing hooks.
 
-    Provides access to the cache's key prefixing and value encoding
-    functions for use in Lua script processing hooks.
-
-    Attributes:
-        make_key: Function to apply cache key prefix and version.
-        encode: Function to encode a value (serialize + compress).
-        decode: Function to decode a value (decompress + deserialize).
-        version: The key version to use for prefixing.
-
-    Example:
-        Using helpers in a custom pre_func::
-
-            def my_pre(helpers, keys, args):
-                # Prefix all keys
-                processed_keys = helpers.make_keys(keys)
-                # Encode value arguments
-                processed_args = helpers.encode_values(args)
-                return processed_keys, processed_args
+    Provides access to the cache's key prefixing and value encoding/decoding
+    for use in Lua script processing hooks.
     """
 
     make_key: Callable[[Any, int | None], Any]
@@ -64,36 +48,15 @@ class ScriptHelpers:
     version: int | None
 
     def make_keys(self, keys: Sequence[Any]) -> list[Any]:
-        """Apply key prefixing to multiple keys.
-
-        Args:
-            keys: Sequence of cache keys to prefix.
-
-        Returns:
-            List of prefixed keys.
-        """
+        """Apply key prefixing to multiple keys."""
         return [self.make_key(k, self.version) for k in keys]
 
     def encode_values(self, values: Sequence[Any]) -> list[bytes | int]:
-        """Encode multiple values for storage.
-
-        Args:
-            values: Sequence of values to encode.
-
-        Returns:
-            List of encoded values.
-        """
+        """Encode multiple values for storage."""
         return [self.encode(v) for v in values]
 
     def decode_values(self, values: Sequence[Any]) -> list[Any]:
-        """Decode multiple values from storage.
-
-        Args:
-            values: Sequence of encoded values.
-
-        Returns:
-            List of decoded values.
-        """
+        """Decode multiple values from storage."""
         return [self.decode(v) for v in values]
 
 
@@ -102,30 +65,8 @@ class LuaScript:
     """Registered Lua script with metadata and processing hooks.
 
     Attributes:
-        name: Unique identifier for the script.
-        script: The Lua script source code.
-        num_keys: Expected number of KEYS arguments (for documentation).
-        pre_func: Optional function to process keys/args before execution.
-            Signature: (helpers, keys, args) -> (processed_keys, processed_args)
-        post_func: Optional function to process result after execution.
-            Signature: (helpers, result) -> processed_result
-
-    Example:
-        Creating a script with encoding::
-
-            from django_cachex.script import LuaScript, full_encode_pre, decode_single_post
-
-            script = LuaScript(
-                name="get_and_set",
-                script='''
-                    local old = redis.call('GET', KEYS[1])
-                    redis.call('SET', KEYS[1], ARGV[1])
-                    return old
-                ''',
-                num_keys=1,
-                pre_func=full_encode_pre,
-                post_func=decode_single_post,
-            )
+        pre_func: (helpers, keys, args) -> (processed_keys, processed_args)
+        post_func: (helpers, result) -> processed_result
     """
 
     name: str
@@ -148,34 +89,7 @@ def keys_only_pre(
     keys: Sequence[Any],
     args: Sequence[Any],
 ) -> tuple[list[Any], list[Any]]:
-    """Pre-processor that only prefixes keys, leaves args unchanged.
-
-    Use this when your script works with raw values (numbers, strings)
-    that don't need encoding.
-
-    Args:
-        helpers: Script helper functions.
-        keys: Original keys.
-        args: Original args.
-
-    Returns:
-        Tuple of (prefixed_keys, unchanged_args).
-
-    Example:
-        Rate limiting script that works with integers::
-
-            cache.register_script(
-                "rate_limit",
-                '''
-                local current = redis.call('INCR', KEYS[1])
-                if current == 1 then
-                    redis.call('EXPIRE', KEYS[1], ARGV[1])
-                end
-                return current
-                ''',
-                pre_func=keys_only_pre,
-            )
-    """
+    """Pre-processor that prefixes keys, leaves args unchanged."""
     return helpers.make_keys(keys), list(args)
 
 
@@ -184,34 +98,7 @@ def full_encode_pre(
     keys: Sequence[Any],
     args: Sequence[Any],
 ) -> tuple[list[Any], list[Any]]:
-    """Pre-processor that prefixes keys AND encodes all args.
-
-    Use this when your script stores/retrieves serialized Python objects
-    that should be encoded the same way as regular cache values.
-
-    Args:
-        helpers: Script helper functions.
-        keys: Original keys.
-        args: Original args (will be serialized).
-
-    Returns:
-        Tuple of (prefixed_keys, encoded_args).
-
-    Example:
-        Script that stores serialized objects::
-
-            cache.register_script(
-                "store_if_missing",
-                '''
-                if redis.call('EXISTS', KEYS[1]) == 0 then
-                    redis.call('SET', KEYS[1], ARGV[1])
-                    return 1
-                end
-                return 0
-                ''',
-                pre_func=full_encode_pre,
-            )
-    """
+    """Pre-processor that prefixes keys and encodes all args."""
     return helpers.make_keys(keys), helpers.encode_values(args)
 
 
@@ -221,95 +108,26 @@ def full_encode_pre(
 
 
 def decode_single_post(helpers: ScriptHelpers, result: Any) -> Any:
-    """Post-processor for a single encoded value result.
-
-    Returns None if result is None, otherwise decodes the value.
-
-    Args:
-        helpers: Script helper functions.
-        result: Raw result from script (encoded bytes or None).
-
-    Returns:
-        Decoded Python object, or None.
-
-    Example:
-        Script that returns a single cached value::
-
-            cache.register_script(
-                "get_and_delete",
-                '''
-                local value = redis.call('GET', KEYS[1])
-                redis.call('DEL', KEYS[1])
-                return value
-                ''',
-                pre_func=keys_only_pre,
-                post_func=decode_single_post,
-            )
-    """
+    """Post-processor that decodes a single value result. Returns None if result is None."""
     if result is None:
         return None
     return helpers.decode(result)
 
 
 def decode_list_post(helpers: ScriptHelpers, result: Any) -> list[Any]:
-    """Post-processor for a list of encoded values.
-
-    Returns empty list if result is None, otherwise decodes each value.
-
-    Args:
-        helpers: Script helper functions.
-        result: Raw result from script (list of encoded bytes or None).
-
-    Returns:
-        List of decoded Python objects.
-
-    Example:
-        Script that returns multiple values::
-
-            cache.register_script(
-                "mget_and_delete",
-                '''
-                local values = redis.call('MGET', unpack(KEYS))
-                redis.call('DEL', unpack(KEYS))
-                return values
-                ''',
-                pre_func=keys_only_pre,
-                post_func=decode_list_post,
-            )
-    """
+    """Post-processor that decodes a list of values. Returns [] if result is None."""
     if result is None:
         return []
     return helpers.decode_values(result)
 
 
 def decode_list_or_none_post(helpers: ScriptHelpers, result: Any) -> list[Any] | None:
-    """Post-processor for an optional list of encoded values.
-
-    Returns None if result is None, otherwise decodes each value.
-
-    Args:
-        helpers: Script helper functions.
-        result: Raw result from script (list of encoded bytes or None).
-
-    Returns:
-        List of decoded Python objects, or None.
-    """
+    """Post-processor that decodes a list of values. Returns None if result is None."""
     if result is None:
         return None
     return helpers.decode_values(result)
 
 
 def noop_post(_helpers: ScriptHelpers, result: Any) -> Any:
-    """Post-processor that returns result unchanged.
-
-    Use this when the script returns raw values (numbers, strings)
-    that don't need decoding.
-
-    Args:
-        _helpers: Script helper functions (unused).
-        result: Raw result from script.
-
-    Returns:
-        Unchanged result.
-    """
+    """Post-processor that returns result unchanged."""
     return result

--- a/django_cachex/serializers/base.py
+++ b/django_cachex/serializers/base.py
@@ -11,30 +11,7 @@ from typing import Any
 class BaseSerializer:
     """Base class for cache value serializers.
 
-    This interface is duck-type compatible with Django's RedisSerializer from
-    ``django.core.cache.backends.redis``. Django does not define a base class;
-    any object with ``dumps`` and ``loads`` methods works as a serializer.
-
-    Django's RedisSerializer structure (as of Django 6.0)::
-
-        class RedisSerializer:
-            def __init__(self, protocol=None):
-                self.protocol = pickle.HIGHEST_PROTOCOL if protocol is None else protocol
-
-            def dumps(self, obj):
-                if type(obj) is int:
-                    return obj  # Don't pickle integers for atomic incr/decr
-                return pickle.dumps(obj, self.protocol)
-
-            def loads(self, data):
-                try:
-                    return int(data)
-                except ValueError:
-                    return pickle.loads(data)
-
-    Our serializers accept ``**kwargs`` for configuration (e.g., ``protocol`` for
-    pickle version). The ``create_serializer()`` function in ``django_cachex.compat``
-    passes the Django cache OPTIONS as kwargs.
+    Duck-type compatible with Django's RedisSerializer (dumps/loads interface).
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/django_cachex/serializers/json.py
+++ b/django_cachex/serializers/json.py
@@ -15,35 +15,7 @@ from django_cachex.serializers.base import BaseSerializer
 
 
 class JSONSerializer(BaseSerializer):
-    """JSON-based serializer using Django's DjangoJSONEncoder.
-
-    Serializes values to JSON format, which is human-readable and interoperable
-    but limited to JSON-compatible types (strings, numbers, lists, dicts, bools, None).
-
-    By default uses Django's DjangoJSONEncoder which adds support for:
-    - datetime, date, time objects
-    - timedelta (as total seconds)
-    - Decimal (as string)
-    - UUID (as string)
-    - Promise (lazy strings)
-
-    Attributes:
-        encoder_class: The JSON encoder class to use. Defaults to DjangoJSONEncoder.
-            Can be overridden by subclasses for custom encoding.
-
-    Example:
-        Configure in Django settings::
-
-            CACHES = {
-                "default": {
-                    "BACKEND": "django_cachex.cache.RedisCache",
-                    "LOCATION": "redis://localhost:6379/1",
-                    "OPTIONS": {
-                        "serializer": "django_cachex.serializers.json.JSONSerializer",
-                    }
-                }
-            }
-    """
+    """JSON-based serializer using Django's DjangoJSONEncoder."""
 
     encoder_class = DjangoJSONEncoder
 

--- a/django_cachex/serializers/msgpack.py
+++ b/django_cachex/serializers/msgpack.py
@@ -15,35 +15,7 @@ from django_cachex.serializers.base import BaseSerializer
 
 
 class MessagePackSerializer(BaseSerializer):
-    """MessagePack-based serializer for efficient binary serialization.
-
-    MessagePack is a binary format that is more compact and faster than JSON,
-    while supporting similar data types. It's a good choice when performance
-    and storage efficiency are priorities.
-
-    Requires the ``msgpack`` package to be installed::
-
-        pip install msgpack
-
-    Note:
-        MessagePack has different type support than pickle or JSON:
-        - Supports: None, bool, int, float, str, bytes, list, dict
-        - Does NOT support: datetime, Decimal, custom objects (without extension)
-        - For complex types, consider using pickle or a custom serializer
-
-    Example:
-        Configure in Django settings::
-
-            CACHES = {
-                "default": {
-                    "BACKEND": "django_cachex.cache.RedisCache",
-                    "LOCATION": "redis://localhost:6379/1",
-                    "OPTIONS": {
-                        "serializer": "django_cachex.serializers.msgpack.MessagePackSerializer",
-                    }
-                }
-            }
-    """
+    """MessagePack-based serializer for efficient binary serialization."""
 
     def dumps(self, obj: Any) -> bytes | int:
         return msgpack.dumps(obj)

--- a/django_cachex/serializers/pickle.py
+++ b/django_cachex/serializers/pickle.py
@@ -8,12 +8,7 @@ from django_cachex.serializers.base import BaseSerializer
 
 
 class PickleSerializer(BaseSerializer):
-    """Pickle-based serializer matching Django's RedisSerializer interface.
-
-    Args:
-        protocol: Pickle protocol version (default: pickle.DEFAULT_PROTOCOL).
-                  Matches Django's RedisSerializer parameter name.
-    """
+    """Pickle-based serializer matching Django's RedisSerializer interface."""
 
     def __init__(self, *, protocol: int | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/django_cachex/types.py
+++ b/django_cachex/types.py
@@ -1,12 +1,7 @@
 """Type aliases for django-cachex.
 
-These types are designed to be 100% compatible with:
-- redis-py's type system (redis.typing)
-- valkey-py's type system (valkey.typing)
-- Django's cache backend types
-
-By defining these ourselves, we avoid a runtime dependency on redis-py/valkey-py
-just for type annotations.
+Compatible with redis-py and valkey-py type systems, defined locally
+to avoid a runtime dependency on either library for type annotations.
 """
 
 from __future__ import annotations
@@ -54,15 +49,8 @@ _set = set
 class CacheProtocol(Protocol):
     """Protocol defining the public interface for django-cachex cache backends.
 
-    This protocol captures all public methods of KeyValueCache, including:
-    - Django BaseCache interface (get, set, delete, etc.)
-    - Async variants (aget, aset, adelete, etc.)
-    - TTL operations (ttl, pttl, expire, persist, etc.)
-    - Data structures (hash, list, set, sorted set operations)
-    - Advanced operations (pipeline, lock, scripts)
-
-    Since protocols cannot inherit from regular classes, this replicates
-    the BaseCache interface plus all django-cachex extensions.
+    Covers Django's BaseCache interface plus all django-cachex extensions
+    (TTL, data structures, pipelines, locks, Lua scripts).
     """
 
     # Support level: "cachex" (native), "wrapped" (Django builtin), "limited" (unknown)

--- a/django_cachex/unfold/__init__.py
+++ b/django_cachex/unfold/__init__.py
@@ -1,9 +1,1 @@
-"""
-django_cachex.unfold - Unfold theme integration for cache admin.
-
-Add 'django_cachex.unfold' to INSTALLED_APPS (after 'unfold') to enable
-the unfold-styled cache admin interface.
-
-This app provides the same functionality as django_cachex.admin but with
-templates optimized for the django-unfold theme.
-"""
+"""Unfold theme integration for cache admin."""

--- a/django_cachex/unfold/admin.py
+++ b/django_cachex/unfold/admin.py
@@ -1,9 +1,4 @@
-"""
-Django admin classes for cache management with Unfold theme.
-
-This module provides ModelAdmin classes that use the Unfold admin theme
-while sharing view logic with the standard admin module via ViewConfig.
-"""
+"""Django admin classes for cache management with Unfold theme."""
 
 from __future__ import annotations
 
@@ -66,11 +61,7 @@ with contextlib.suppress(admin.sites.NotRegistered):  # type: ignore[attr-define
 
 @admin.register(Cache)
 class CacheAdmin(_CacheBase):
-    """
-    Unfold-themed admin for caches.
-
-    Uses shared view logic with unfold templates.
-    """
+    """Unfold-themed admin for caches."""
 
     # Caches are defined in settings — add/delete don't apply
     def has_add_permission(self, request: HttpRequest) -> bool:
@@ -120,11 +111,7 @@ class CacheAdmin(_CacheBase):
 
 @admin.register(Key)
 class KeyAdmin(_KeyBase):
-    """
-    Unfold-themed admin for cache keys.
-
-    Uses shared view logic with unfold templates.
-    """
+    """Unfold-themed admin for cache keys."""
 
     # Hide from sidebar — accessed via Cache
     def has_module_permission(self, request: HttpRequest) -> bool:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@
 
 - Python 3.12+
 - Django 5.2+
-- valkey-py 6+ or redis-py 6+
+- valkey-py 6.1+ or redis-py 6+
 - Valkey server 7+ or Redis server 6+
 
 ## Install with uv
@@ -25,4 +25,4 @@ uv add django-cachex[libvalkey]
 uv add django-cachex[hiredis]
 ```
 
-These packages provide C-based parsers that can significantly improve performance when parsing replies.
+These provide C-based parsers that significantly improve performance.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -23,12 +23,12 @@ CACHES = {
 | `RedisClusterCache` | Redis Cluster sharding |
 
 !!! note "Valkey and Redis Compatibility"
-    Valkey and Redis are probably still fully compatible, meaning you could use either backend with either server.
-    We recommend Valkey as it remains fully open source.
+    Valkey and Redis are protocol-compatible, so either backend works with either server.
+    Valkey is recommended as it remains fully open source.
 
 ## Connection URL Formats
 
-django-cachex uses the valkey-py/redis-py native URL notation for connection strings:
+Uses the valkey-py/redis-py native URL notation:
 
 - `valkey://[[username]:[password]]@localhost:6379/0` - Valkey TCP connection
 - `redis://[[username]:[password]]@localhost:6379/0` - Redis TCP connection
@@ -38,14 +38,14 @@ django-cachex uses the valkey-py/redis-py native URL notation for connection str
 
 ### Database Selection
 
-There are two ways to specify the database number:
+Two ways to specify the database number:
 
 1. Query string: `valkey://localhost?db=0`
 2. Path (for `valkey://` or `redis://` scheme): `valkey://localhost/0`
 
 ## Configure as Session Backend
 
-Django can use any cache backend as session storage:
+Use django-cachex as a session backend:
 
 ```python
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
@@ -65,9 +65,9 @@ value = cache.get("key")
 cache.hset("user:1", "name", "Alice")
 cache.zrange("leaderboard", 0, 10)
 
-# Async versions
+# Async versions (standard Django methods)
 await cache.aget("key")
-await cache.ahset("user:1", "name", "Alice")
+await cache.aset("key", "value", timeout=300)
 ```
 
 ## Raw Client Access

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # django-cachex
 
-Cache extensions for django, including full featured Valkey and Redis cache backend for Django and a built-in admin interface.
+Full featured Valkey and Redis cache backend for Django with a built-in admin interface.
 
 [![PyPI version](https://img.shields.io/pypi/v/django-cachex.svg?style=flat)](https://pypi.org/project/django-cachex/)
 [![Python versions](https://img.shields.io/pypi/pyversions/django-cachex.svg)](https://pypi.org/project/django-cachex/)
@@ -13,8 +13,7 @@ Cache extensions for django, including full featured Valkey and Redis cache back
 - **Built-in admin interface** - Browse, search, edit, and delete cache keys from Django admin
 - **Unified Valkey and Redis support** - Single package for both backends
 - **Extended data structures** - Hashes, lists, sets, sorted sets
-- **Async support** - Async versions of all extended methods
-- **Mixing sync & async support** - Async cache still works in sync code
+- **Sync and async support** - All extended methods available in both sync and async
 - **TTL and pattern operations** - `ttl()`, `expire()`, `keys()`, `delete_pattern()`
 - **Lua script support** - Register and execute Lua scripts with automatic key prefixing
 - **Distributed locking** - `cache.lock()` for cross-process synchronization
@@ -26,7 +25,7 @@ Cache extensions for django, including full featured Valkey and Redis cache back
 
 - Python 3.12+
 - Django 5.2+
-- valkey-py 6.0+ or redis-py 6.0+
+- valkey-py 6.1+ or redis-py 6.0+
 
 ## Quick Start
 
@@ -58,11 +57,11 @@ INSTALLED_APPS = [
 
 ## Acknowledgments
 
-This project was inspired by [django-redis](https://github.com/jazzband/django-redis) and Django's official [Redis cache backend](https://docs.djangoproject.com/en/stable/topics/cache/#redis). Some utility code for serializers and compressors is derived from django-redis, licensed under BSD-3-Clause. The admin functionality was inspired by [django-redisboard](https://github.com/ionelmc/django-redisboard). All of the aboved I used in production, noticed some flaws over the years, and for one reason or another a new package ended up the best way for progress for me here.
+This project was inspired by [django-redis](https://github.com/jazzband/django-redis) and Django's official [Redis cache backend](https://docs.djangoproject.com/en/stable/topics/cache/#redis). Some utility code for serializers and compressors is derived from django-redis, licensed under BSD-3-Clause. The admin functionality was inspired by [django-redisboard](https://github.com/ionelmc/django-redisboard).
 
 The Unfold theme integration optionally uses [django-unfold](https://unfoldadmin.com/).
 
-I also want to mention [django-valkey](https://github.com/amirreza8002/django-valkey) and [dj-cache-panel](https://github.com/vinitkumar/dj-cache-panel), which I never really used, but are newer and interesting efforts of similar goals as this package has.
+See also [django-valkey](https://github.com/amirreza8002/django-valkey) and [dj-cache-panel](https://github.com/vinitkumar/dj-cache-panel) for related projects with similar goals.
 
 ## License
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -13,7 +13,7 @@
 "BACKEND": "django_cachex.cache.RedisCache"
 ```
 
-All Django options work unchanged. You gain extended features (data structures, TTL ops, locking, compression, unified Valkey/Redis support).
+All existing Django cache options work unchanged.
 
 ## From django-valkey
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -131,7 +131,7 @@ with cache.lock("process-payments", timeout=30):
 
 ## Development Without a Server
 
-For simple local development without running a server, [fakeredis](https://github.com/cunla/fakeredis-py) provides an in-memory implementation:
+For local development without a running server, [fakeredis](https://github.com/cunla/fakeredis-py) provides an in-memory implementation:
 
 ```python
 # settings_dev.py

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -38,16 +38,16 @@ Initial stable release of django-cachex.
 
 ### Data Structure Operations
 
-- **Hash operations**: `hset`, `hdel`, `hexists`, `hget`, `hgetall`, `hincrby`, `hincrbyfloat`, `hlen`, `hmget`, `hmset`, `hsetnx`, `hvals`
-- **Sorted set operations**: `zadd`, `zcard`, `zcount`, `zincrby`, `zrange`, `zrangebyscore`, `zrank`, `zrevrank`, `zrem`, `zremrangebyrank`, `zscore`, `zmscore`
-- **List operations**: `llen`, `lpush`, `rpush`, `lpop`, `rpop`, `lindex`, `lrange`, `lset`, `ltrim`, `lpos`, `lmove`
-- **Set operations**: `sadd`, `srem`, `smembers`, `sismember`, `smismember`, `scard`, `spop`, `srandmember`, `sdiff`, `sinter`, `sunion`
+- **Hash operations**: `hset`, `hdel`, `hexists`, `hget`, `hgetall`, `hincrby`, `hincrbyfloat`, `hkeys`, `hlen`, `hmget`, `hmset`, `hsetnx`, `hvals`
+- **Sorted set operations**: `zadd`, `zcard`, `zcount`, `zincrby`, `zrange`, `zrevrange`, `zrangebyscore`, `zrevrangebyscore`, `zrank`, `zrevrank`, `zrem`, `zremrangebyrank`, `zremrangebyscore`, `zscore`, `zmscore`, `zpopmin`, `zpopmax`
+- **List operations**: `llen`, `lpush`, `rpush`, `lpop`, `rpop`, `lindex`, `lrange`, `lset`, `ltrim`, `lrem`, `lpos`, `linsert`, `lmove`, `blpop`, `brpop`, `blmove`
+- **Set operations**: `sadd`, `srem`, `smembers`, `sismember`, `smismember`, `scard`, `spop`, `srandmember`, `smove`, `sdiff`, `sdiffstore`, `sinter`, `sinterstore`, `sunion`, `sunionstore`, `sscan`, `sscan_iter`
 
 ### Requirements
 
 - Python 3.12+
 - Django 5.2+
-- valkey-py 6+ or redis-py 6+
+- valkey-py 6.1+ or redis-py 6+
 
 ---
 

--- a/docs/user-guide/admin.md
+++ b/docs/user-guide/admin.md
@@ -1,6 +1,6 @@
 # Cache Admin
 
-django-cachex provides a Django admin interface for inspecting and managing caches. It allows you to browse cache keys, view their values, and perform operations like adding, editing, and deleting cache entries.
+django-cachex provides a Django admin interface for browsing cache keys, viewing values, and adding, editing, or deleting entries.
 
 ## Installation
 
@@ -57,86 +57,47 @@ The admin uses Django's built-in permission system. Superusers have full access.
 
 ## Support Levels
 
-Different cache backends have different levels of support in the Cache Admin:
+Different cache backends have different levels of support:
 
 | Badge | Level | Description |
 |-------|-------|-------------|
-| **cachex** | Full Support | django-cachex backends (`ValkeyCache`, `RedisCache`, etc.) with full access to all features including key listing, pattern search, TTL inspection, and all data type operations. |
-| **wrapped** | Wrapped Support | Django builtin backends (`LocMemCache`, `DatabaseCache`, etc.). Most features available through wrapper compatibility. |
-| **limited** | Limited Support | Custom or unknown cache backends. Basic operations may work but key listing and advanced features may not be available. |
+| **cachex** | Full Support | django-cachex backends (`ValkeyCache`, `RedisCache`, etc.) -- all features including key listing, pattern search, TTL inspection, and data type operations. |
+| **wrapped** | Wrapped Support | Django builtin backends (`LocMemCache`, `DatabaseCache`, etc.) -- most features available through wrapper compatibility. |
+| **limited** | Limited Support | Custom or unknown backends -- basic operations may work but key listing and advanced features may not be available. |
 
 ### Using Redis/Valkey?
 
-If you are using Django's builtin Redis backend (`django.core.cache.backends.redis.RedisCache`), consider switching to django-cachex's `ValkeyCache` or `RedisCache` backends for full admin functionality including:
-
-- Key browsing and pattern search
-- TTL inspection and modification
-- Native Redis data type support (lists, sets, hashes, sorted sets)
-- Server info and memory statistics
-
-See the [quickstart guide](../getting-started/quickstart.md) for migration instructions.
+If you are using Django's builtin Redis backend (`django.core.cache.backends.redis.RedisCache`), consider switching to django-cachex's `ValkeyCache` or `RedisCache` backends for full admin functionality: key browsing, pattern search, TTL inspection, native data type support, and server statistics. See the [quickstart guide](../getting-started/quickstart.md) for migration instructions.
 
 ## Views
 
 ### Caches (Index)
 
-The main view lists all configured caches with:
+Lists all configured caches showing name, backend class, location, and support level.
 
-- **Cache Name**: The alias used in `settings.CACHES`
-- **Backend**: The full backend class path
-- **Location**: Connection string or path
-- **Support Level**: Badge indicating feature availability
-
-**Actions:**
-
-- **Flush selected caches**: Delete all entries from selected caches (available for backends that support it)
+**Actions:** Flush selected caches (delete all entries).
 
 ### Key Browser
 
-Click on a cache name to browse its keys. Features include:
+Click a cache name to browse its keys with wildcard search (`*`), data type display, TTL, and pagination.
 
-- **Search**: Use wildcards (`*`) to filter keys (e.g., `user:*`, `*:session`)
-- **Key Type**: Shows Redis/Valkey data types (string, list, set, hash, zset)
-- **TTL**: Shows remaining time-to-live for each key
-- **Pagination**: Browse large key sets with configurable page size
-
-**Actions:**
-
-- **Delete selected keys**: Remove multiple keys at once
-- **Add key**: Create a new cache entry (top-right button)
+**Actions:** Delete selected keys, add new key.
 
 ### Key Detail
 
-View and edit a specific key:
-
-- **Value Display**: Shows the key's value (formatted JSON for objects/arrays)
-- **Type Information**: For complex types (list, hash, set, zset), shows the data structure
-- **TTL**: Shows remaining expiry time
-- **Edit**: Modify value and timeout
-- **Delete**: Remove the key
+View and edit a specific key's value (formatted JSON for objects/arrays), data type, and TTL. Supports editing values/timeout and deleting the key.
 
 ### Cache Info
 
-View server information and statistics:
-
-- **Configuration**: Backend, location, key prefix, version
-- **Server**: Version, operating system, uptime
-- **Memory**: Used memory, peak memory, max memory, eviction policy
-- **Clients**: Connected clients, blocked clients
-- **Statistics**: Total connections, commands processed, hit/miss rates
-- **Keyspace**: Per-database key counts and TTL statistics
+View server information: configuration, server version/uptime, memory usage, connected clients, command statistics, and keyspace data.
 
 ### Add Key
 
-Create a new cache entry:
-
-- **Key Name**: Unique identifier for the cache entry
-- **Value**: JSON objects/arrays are parsed automatically, plain text for strings
-- **Timeout**: Optional expiration time in seconds (leave empty for cache default)
+Create a new cache entry with key name, value (JSON objects/arrays are parsed automatically), and optional timeout in seconds.
 
 ## Backend Abilities
 
-The admin adapts its interface based on what each backend supports:
+The admin adapts based on backend capabilities:
 
 | Feature | cachex | LocMemCache | DatabaseCache | FileBasedCache | limited |
 |---------|--------|-------------|---------------|----------------|---------|
@@ -153,7 +114,7 @@ The admin adapts its interface based on what each backend supports:
 
 ## Tips
 
-- **Pattern Search**: Use `*` as a wildcard. For example, `user:*` finds all keys starting with "user:".
-- **JSON Values**: When editing, you can enter valid JSON to store objects or arrays.
-- **Help Button**: Each view has a help button that shows context-specific tips.
+- **Pattern Search**: Use `*` as a wildcard (e.g., `user:*` finds all keys starting with "user:").
+- **JSON Values**: Enter valid JSON when editing to store objects or arrays.
+- **Help Button**: Each view has a help button with context-specific tips.
 - **Refresh**: Use the refresh action to update key lists and statistics.

--- a/docs/user-guide/cluster.md
+++ b/docs/user-guide/cluster.md
@@ -4,7 +4,7 @@ For basic cluster setup, see [Configuration](configuration.md#cluster-configurat
 
 ## Slot Handling
 
-Valkey/Redis Cluster distributes keys across 16384 hash slots. django-cachex handles this differently for Django cache methods vs direct commands:
+Valkey/Redis Cluster distributes keys across 16,384 hash slots. django-cachex handles Django cache methods and direct commands differently:
 
 **Django cache methods** (`get_many`, `set_many`, `delete_many`, `keys`, `clear`) are cluster-aware and handle cross-slot operations automatically.
 
@@ -12,7 +12,7 @@ Valkey/Redis Cluster distributes keys across 16384 hash slots. django-cachex han
 
 ## Hash Tags
 
-Force keys to the same slot using hash tags - the substring between `{` and `}`:
+Force keys to the same slot using hash tags (the substring between `{` and `}`):
 
 ```python
 # Same slot (hash tag is "user:123")

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-Complete reference for all django-cachex configuration options.
+Reference for all django-cachex configuration options.
 
 ## Basic Configuration
 
@@ -33,12 +33,11 @@ CACHES = {
 All backends are in `django_cachex.cache`.
 
 !!! note "Valkey and Redis Compatibility"
-    Valkey and Redis are probably still fully compatible, meaning you could use either backend with either server.
-    We recommend Valkey as it remains fully open source.
+    Valkey and Redis are likely still fully compatible, so either backend works with either server. Valkey is recommended as it remains fully open source.
 
 ## LOCATION
 
-Server URL(s). Supports multiple formats:
+Server URL(s):
 
 ```python
 # Single server (Valkey)
@@ -158,15 +157,6 @@ Compression is only applied to values larger than `min_length` bytes (default: 2
 }
 ```
 
-### Connection Lifecycle
-
-```python
-"OPTIONS": {
-    # Close connections after each request
-    "close_connection": True,
-}
-```
-
 ## Authentication
 
 ### Password in URL
@@ -177,7 +167,7 @@ Compression is only applied to values larger than `min_length` bytes (default: 2
 
 ### Password with Special Characters
 
-For passwords with special characters, pass separately:
+For passwords with special characters, pass via OPTIONS:
 
 ```python
 "LOCATION": "valkey://127.0.0.1:6379/1",


### PR DESCRIPTION
Review all docstrings against implementations and fix content errors:

Source code fixes:
- close()/aclose(): "No-op" -> delegates to client
- ttl()/pttl(): document return semantics (None=no expiry, -2=not found)
- spop() return type: Set -> list | None (matches implementation)
- encode()/decode(): document int passthrough behavior
- incr()/aincr(): document ValueError on missing key
- set_many(): document timeout=0 deletes, None=no expiry
- BaseCompressor: "smaller than" -> "or fewer" (off-by-one)
- omit_exception: "connection/timeout" -> includes response errors
- CompressorError/SerializerError: clarify fallback handled by client
- Cluster pipeline(): document transactions not supported
- _get_connection_pool_index: "read from any" -> "any replica"

Documentation fixes:
- async.md: fix all examples calling methods on cache that only exist on cache._cache (would fail at runtime)
- async.md: remove nonexistent desc param, use zrevrange instead
- quickstart.md: fix ahset example (doesn't exist on cache object)
- advanced.md: replace nonexistent PICKLE_VERSION with serializer option
- api.md: TTL returns None not -1 for no expiry
- api.md: add key-prefixing note for client-level async methods
- installation.md/changelog.md: valkey-py 6+ -> 6.1+ (matches pyproject)
- changelog.md: add missing list/set operations