### PR TITLE
feat: add expiretime() and set(get=True) support

### DIFF
--- a/django_cachex/types.py
+++ b/django_cachex/types.py
@@ -208,6 +208,8 @@ class CacheProtocol(Protocol):
 
     def pexpire_at(self, key: KeyT, when: AbsExpiryT, version: int | None = None) -> bool: ...
 
+    def expiretime(self, key: KeyT, version: int | None = None) -> int | None: ...
+
     # =========================================================================
     # Key Operations
     # =========================================================================

--- a/tests/cache/test_cache_timeouts_async.py
+++ b/tests/cache/test_cache_timeouts_async.py
@@ -56,6 +56,31 @@ class TestAsyncPTTL:
         assert pttl is not None and pttl < 0
 
 
+class TestAsyncExpireTime:
+    """Tests for aexpiretime() method (Redis 7.0+)."""
+
+    @pytest.mark.asyncio
+    async def test_aexpiretime_returns_unix_timestamp(self, cache: KeyValueCache, mk):
+        import time
+
+        cache.set("aet_key", "data", timeout=3600)
+        result = await cache._cache.aexpiretime(mk("aet_key"))
+        assert result is not None
+        expected = int(time.time()) + 3600
+        assert abs(result - expected) < 5
+
+    @pytest.mark.asyncio
+    async def test_aexpiretime_returns_none_for_persistent_key(self, cache: KeyValueCache, mk):
+        cache.set("aet_persist", "permanent", timeout=None)
+        result = await cache._cache.aexpiretime(mk("aet_persist"))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_aexpiretime_negative_for_nonexistent_key(self, cache: KeyValueCache, mk):
+        result = await cache._cache.aexpiretime(mk("aet_missing"))
+        assert result is not None and result < 0
+
+
 class TestAsyncExpire:
     """Tests for aexpire() method."""
 


### PR DESCRIPTION
## Summary
- Add `expiretime(key)` — native Redis 7.0+ EXPIRETIME command returning the absolute Unix timestamp (seconds) when a key will expire, with sync + async support
- Add `set(get=True)` — Redis 6.2+ SET GET flag that atomically returns the old value while setting a new one, with sync + async support

## Test plan
- [x] `TestExpireTimeOperation` — timestamp correctness, persistent keys, nonexistent keys, after expire_at
- [x] `TestAsyncExpireTime` — async equivalents
- [x] `TestSetWithGet` — old value return, missing key, type changes, with timeout, chaining
- [x] All 648 tests passing