### PR TITLE
feat: atomic CAS operations for admin concurrent edit safety

### DIFF
--- a/django_cachex/admin/cas.py
+++ b/django_cachex/admin/cas.py
@@ -1,0 +1,219 @@
+"""Compare-and-swap helpers for safe admin operations.
+
+Uses Lua scripts to atomically check that a value hasn't changed before
+updating it. This prevents silent overwrites when two users edit the
+same value concurrently in the admin.
+
+Each CAS function returns:
+    1  — success (value matched, update applied)
+    0  — conflict (value changed since page load)
+   -1  — gone (key/field/index no longer exists)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from django_cachex.script import keys_only_pre
+
+if TYPE_CHECKING:
+    from django_cachex.client.cache import KeyValueCache
+
+# =============================================================================
+# SHA1 reader scripts (used at page load to fingerprint current values)
+# =============================================================================
+
+_GET_STRING_SHA1 = """\
+local v = redis.call('GET', KEYS[1])
+if v == false then return false end
+return redis.sha1hex(v)
+"""
+
+_GET_HASH_FIELD_SHA1S = """\
+local fields = redis.call('HGETALL', KEYS[1])
+local result = {}
+for i = 1, #fields, 2 do
+    result[#result+1] = fields[i]
+    result[#result+1] = redis.sha1hex(fields[i+1])
+end
+return result
+"""
+
+_GET_LIST_SHA1S = """\
+local items = redis.call('LRANGE', KEYS[1], 0, -1)
+local result = {}
+for i = 1, #items do
+    result[i] = redis.sha1hex(items[i])
+end
+return result
+"""
+
+# =============================================================================
+# CAS write scripts (used at form submit to atomically check-then-update)
+# =============================================================================
+
+_CAS_STRING_UPDATE = """\
+local v = redis.call('GET', KEYS[1])
+if v == false then return -1 end
+if redis.sha1hex(v) == ARGV[1] then
+    redis.call('SET', KEYS[1], ARGV[2])
+    return 1
+end
+return 0
+"""
+
+_CAS_HASH_UPDATE = """\
+local v = redis.call('HGET', KEYS[1], ARGV[1])
+if v == false then return -1 end
+if redis.sha1hex(v) == ARGV[2] then
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+    return 1
+end
+return 0
+"""
+
+_CAS_ZSET_SCORE_UPDATE = """\
+local v = redis.call('ZSCORE', KEYS[1], ARGV[1])
+if v == false then return -1 end
+if tonumber(v) == tonumber(ARGV[2]) then
+    redis.call('ZADD', KEYS[1], ARGV[3], ARGV[1])
+    return 1
+end
+return 0
+"""
+
+_CAS_LIST_UPDATE = """\
+local v = redis.call('LINDEX', KEYS[1], tonumber(ARGV[1]))
+if v == false then return -1 end
+if redis.sha1hex(v) == ARGV[2] then
+    redis.call('LSET', KEYS[1], tonumber(ARGV[1]), ARGV[3])
+    return 1
+end
+return 0
+"""
+
+
+# =============================================================================
+# SHA1 reader helpers (page load)
+# =============================================================================
+
+
+def get_string_sha1(cache: KeyValueCache, key: str) -> str | None:
+    """Get SHA1 fingerprint of the raw encoded string value."""
+    result = cache.eval_script(_GET_STRING_SHA1, keys=[key], pre_hook=keys_only_pre)
+    if result is None:
+        return None
+    return result.decode() if isinstance(result, bytes) else str(result)
+
+
+def get_hash_field_sha1s(cache: KeyValueCache, key: str) -> dict[str, str]:
+    """Get SHA1 fingerprints of all hash field values.
+
+    Returns:
+        Dict mapping field names to their SHA1 hex strings.
+    """
+    result = cache.eval_script(_GET_HASH_FIELD_SHA1S, keys=[key], pre_hook=keys_only_pre)
+    if not result:
+        return {}
+    sha1s: dict[str, str] = {}
+    for i in range(0, len(result), 2):
+        field = result[i].decode() if isinstance(result[i], bytes) else str(result[i])
+        sha1 = result[i + 1].decode() if isinstance(result[i + 1], bytes) else str(result[i + 1])
+        sha1s[field] = sha1
+    return sha1s
+
+
+def get_list_sha1s(cache: KeyValueCache, key: str) -> list[str]:
+    """Get SHA1 fingerprints of all list elements."""
+    result = cache.eval_script(_GET_LIST_SHA1S, keys=[key], pre_hook=keys_only_pre)
+    if not result:
+        return []
+    return [r.decode() if isinstance(r, bytes) else str(r) for r in result]
+
+
+# =============================================================================
+# CAS update helpers (form submit)
+# =============================================================================
+
+
+def cas_update_string(
+    cache: KeyValueCache,
+    key: str,
+    expected_sha1: str,
+    new_value: Any,
+) -> int:
+    """Atomically update a string value if it hasn't changed.
+
+    Returns:
+        1 = success, 0 = conflict, -1 = key gone.
+    """
+    encoded = cache._cache.encode(new_value)
+    return cache.eval_script(
+        _CAS_STRING_UPDATE,
+        keys=[key],
+        args=[expected_sha1, encoded],
+        pre_hook=keys_only_pre,
+    )
+
+
+def cas_update_hash_field(
+    cache: KeyValueCache,
+    key: str,
+    field: str,
+    expected_sha1: str,
+    new_value: Any,
+) -> int:
+    """Atomically update a hash field value if it hasn't changed.
+
+    Returns:
+        1 = success, 0 = conflict, -1 = field gone.
+    """
+    encoded = cache._cache.encode(new_value)
+    return cache.eval_script(
+        _CAS_HASH_UPDATE,
+        keys=[key],
+        args=[field, expected_sha1, encoded],
+        pre_hook=keys_only_pre,
+    )
+
+
+def cas_update_zset_score(
+    cache: KeyValueCache,
+    key: str,
+    member: Any,
+    expected_score: str,
+    new_score: float,
+) -> int:
+    """Atomically update a sorted set member's score if it hasn't changed.
+
+    Returns:
+        1 = success, 0 = conflict, -1 = member gone.
+    """
+    encoded_member = cache._cache.encode(member)
+    return cache.eval_script(
+        _CAS_ZSET_SCORE_UPDATE,
+        keys=[key],
+        args=[encoded_member, expected_score, new_score],
+        pre_hook=keys_only_pre,
+    )
+
+
+def cas_update_list_element(
+    cache: KeyValueCache,
+    key: str,
+    index: int,
+    expected_sha1: str,
+    new_value: Any,
+) -> int:
+    """Atomically update a list element if it hasn't changed.
+
+    Returns:
+        1 = success, 0 = conflict, -1 = index gone.
+    """
+    encoded = cache._cache.encode(new_value)
+    return cache.eval_script(
+        _CAS_LIST_UPDATE,
+        keys=[key],
+        args=[index, expected_sha1, encoded],
+        pre_hook=keys_only_pre,
+    )

--- a/django_cachex/admin/templates/admin/django_cachex/key/key_detail_hash.html
+++ b/django_cachex/admin/templates/admin/django_cachex/key/key_detail_hash.html
@@ -16,7 +16,47 @@
 <!-- Hash Fields -->
 <fieldset class="module aligned">
     <h2>{% trans 'Hash Fields' %}{% if type_data.length %} ({{ type_data.length }}){% endif %}</h2>
-    {% if type_data.fields %}
+    {% if type_data.field_entries %}
+    <div class="results">
+        <table id="result_list" style="width: 100%;">
+            <thead>
+                <tr>
+                    <th scope="col">{% trans 'Field' %}</th>
+                    <th scope="col">{% trans 'Value' %}</th>
+                    <th scope="col" style="width: 150px;">{% trans 'Actions' %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for field, value, sha1 in type_data.field_entries %}
+                <tr class="{% cycle 'row1' 'row2' %}">
+                    <td><code>{{ field }}</code></td>
+                    <td>
+                        <input type="text" name="field_value" value="{{ value }}" class="vTextField" form="hash-update-{{ forloop.counter0 }}" style="width: 100%; box-sizing: border-box;">
+                    </td>
+                    <td>
+                        <button type="submit" form="hash-update-{{ forloop.counter0 }}" class="button btn-small">{% trans 'Update' %}</button>
+                        <button type="submit" form="hash-delete-{{ forloop.counter0 }}" class="button delete-btn btn-small">{% trans 'Delete' %}</button>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <!-- Forms for hash operations (outside table for valid HTML) -->
+    {% for field, value, sha1 in type_data.field_entries %}
+    <form id="hash-update-{{ forloop.counter0 }}" method="post" style="display: none;">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="hset">
+        <input type="hidden" name="field_name" value="{{ field }}">
+        {% if sha1 %}<input type="hidden" name="original_sha1" value="{{ sha1 }}">{% endif %}
+    </form>
+    <form id="hash-delete-{{ forloop.counter0 }}" method="post" style="display: none;">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="hdel">
+        <input type="hidden" name="field" value="{{ field }}">
+    </form>
+    {% endfor %}
+    {% elif type_data.fields %}
     <div class="results">
         <table id="result_list" style="width: 100%;">
             <thead>
@@ -42,7 +82,6 @@
             </tbody>
         </table>
     </div>
-    <!-- Forms for hash operations (outside table for valid HTML) -->
     {% for field, value in type_data.fields.items %}
     <form id="hash-update-{{ forloop.counter0 }}" method="post" style="display: none;">
         {% csrf_token %}

--- a/django_cachex/admin/templates/admin/django_cachex/key/key_detail_list.html
+++ b/django_cachex/admin/templates/admin/django_cachex/key/key_detail_list.html
@@ -52,7 +52,47 @@
 <!-- List Items -->
 <fieldset class="module aligned">
     <h2>{% trans 'List Items' %}{% if type_data.length %} ({{ type_data.length }}){% endif %}</h2>
-    {% if type_data.items %}
+    {% if type_data.item_entries %}
+    <div class="results">
+        <table id="result_list" style="width: 100%;">
+            <thead>
+                <tr>
+                    <th scope="col" style="width: 60px;">{% trans 'Index' %}</th>
+                    <th scope="col">{% trans 'Value' %}</th>
+                    <th scope="col" style="width: 150px;">{% trans 'Actions' %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for index, item, sha1 in type_data.item_entries %}
+                <tr class="{% cycle 'row1' 'row2' %}">
+                    <td class="quiet">{{ index }}</td>
+                    <td>
+                        <input type="text" name="item_value" value="{{ item }}" class="vTextField" form="list-update-{{ forloop.counter0 }}" style="width: 100%; box-sizing: border-box;">
+                    </td>
+                    <td>
+                        <button type="submit" form="list-update-{{ forloop.counter0 }}" class="button btn-small">{% trans 'Update' %}</button>
+                        <form method="post" style="display: inline;">
+                            {% csrf_token %}
+                            <input type="hidden" name="action" value="lrem">
+                            <input type="hidden" name="item_value" value="{{ item }}">
+                            <button type="submit" class="button delete-btn btn-small" onclick="return confirm('{% trans 'Remove this item?' %}');">{% trans 'Remove' %}</button>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <!-- Forms for list update operations (outside table for valid HTML) -->
+    {% for index, item, sha1 in type_data.item_entries %}
+    <form id="list-update-{{ forloop.counter0 }}" method="post" style="display: none;">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="lset">
+        <input type="hidden" name="index" value="{{ index }}">
+        {% if sha1 %}<input type="hidden" name="original_sha1" value="{{ sha1 }}">{% endif %}
+    </form>
+    {% endfor %}
+    {% elif type_data.items %}
     <div class="results">
         <table id="result_list" style="width: 100%;">
             <thead>

--- a/django_cachex/admin/templates/admin/django_cachex/key/key_detail_string.html
+++ b/django_cachex/admin/templates/admin/django_cachex/key/key_detail_string.html
@@ -11,6 +11,7 @@
     <form method="post" id="key-form">
         {% csrf_token %}
         <input type="hidden" name="action" value="update">
+        {% if string_sha1 %}<input type="hidden" name="original_sha1" value="{{ string_sha1 }}">{% endif %}
         <div class="form-row">
             <div>
                 <label for="id_value" class="{% if not value_is_editable %}readonly{% endif %}">{% trans 'Value:' %}</label>

--- a/django_cachex/admin/templates/admin/django_cachex/key/key_detail_zset.html
+++ b/django_cachex/admin/templates/admin/django_cachex/key/key_detail_zset.html
@@ -70,6 +70,7 @@
         {% csrf_token %}
         <input type="hidden" name="action" value="zadd">
         <input type="hidden" name="member_value" value="{{ member }}">
+        <input type="hidden" name="original_score" value="{{ score }}">
     </form>
     <form id="zset-remove-{{ forloop.counter0 }}" method="post" style="display: none;">
         {% csrf_token %}

--- a/tests/admin/test_cas.py
+++ b/tests/admin/test_cas.py
@@ -1,0 +1,270 @@
+"""Tests for admin CAS (compare-and-swap) operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from django_cachex.admin.cas import (
+    cas_update_hash_field,
+    cas_update_list_element,
+    cas_update_string,
+    cas_update_zset_score,
+    get_hash_field_sha1s,
+    get_list_sha1s,
+    get_string_sha1,
+)
+
+if TYPE_CHECKING:
+    from django_cachex.cache import KeyValueCache
+
+
+class TestStringSHA1:
+    """Test string value SHA1 fingerprinting."""
+
+    def test_get_sha1(self, test_cache: KeyValueCache):
+        test_cache.set("str_key", "hello")
+        sha1 = get_string_sha1(test_cache, "str_key")
+        assert sha1 is not None
+        assert len(sha1) == 40
+
+    def test_get_sha1_nonexistent(self, test_cache: KeyValueCache):
+        sha1 = get_string_sha1(test_cache, "nonexistent")
+        assert sha1 is None
+
+    def test_sha1_changes_with_value(self, test_cache: KeyValueCache):
+        test_cache.set("str_key", "value1")
+        sha1_a = get_string_sha1(test_cache, "str_key")
+
+        test_cache.set("str_key", "value2")
+        sha1_b = get_string_sha1(test_cache, "str_key")
+
+        assert sha1_a != sha1_b
+
+    def test_sha1_stable_for_same_value(self, test_cache: KeyValueCache):
+        test_cache.set("str_key", "same")
+        sha1_a = get_string_sha1(test_cache, "str_key")
+        sha1_b = get_string_sha1(test_cache, "str_key")
+        assert sha1_a == sha1_b
+
+
+class TestHashFieldSHA1s:
+    """Test hash field SHA1 fingerprinting."""
+
+    def test_get_sha1s(self, test_cache: KeyValueCache):
+        test_cache.hset("hash_key", "f1", "v1")
+        test_cache.hset("hash_key", "f2", "v2")
+        sha1s = get_hash_field_sha1s(test_cache, "hash_key")
+        assert len(sha1s) == 2
+        assert "f1" in sha1s
+        assert "f2" in sha1s
+        assert len(sha1s["f1"]) == 40
+
+    def test_get_sha1s_empty(self, test_cache: KeyValueCache):
+        sha1s = get_hash_field_sha1s(test_cache, "nonexistent")
+        assert sha1s == {}
+
+    def test_sha1_changes_with_field_value(self, test_cache: KeyValueCache):
+        test_cache.hset("hash_key", "f1", "v1")
+        sha1_a = get_hash_field_sha1s(test_cache, "hash_key")["f1"]
+
+        test_cache.hset("hash_key", "f1", "v2")
+        sha1_b = get_hash_field_sha1s(test_cache, "hash_key")["f1"]
+
+        assert sha1_a != sha1_b
+
+
+class TestListSHA1s:
+    """Test list element SHA1 fingerprinting."""
+
+    def test_get_sha1s(self, test_cache: KeyValueCache):
+        test_cache.rpush("list_key", "a", "b", "c")
+        sha1s = get_list_sha1s(test_cache, "list_key")
+        assert len(sha1s) == 3
+        assert all(len(s) == 40 for s in sha1s)
+
+    def test_get_sha1s_empty(self, test_cache: KeyValueCache):
+        sha1s = get_list_sha1s(test_cache, "nonexistent")
+        assert sha1s == []
+
+    def test_different_elements_different_sha1s(self, test_cache: KeyValueCache):
+        test_cache.rpush("list_key", "x", "y")
+        sha1s = get_list_sha1s(test_cache, "list_key")
+        assert sha1s[0] != sha1s[1]
+
+
+class TestCASStringUpdate:
+    """Test atomic string value CAS updates."""
+
+    def test_success(self, test_cache: KeyValueCache):
+        test_cache.set("cas_str", "original")
+        sha1 = get_string_sha1(test_cache, "cas_str")
+
+        result = cas_update_string(test_cache, "cas_str", sha1, "updated")
+        assert result == 1
+        assert test_cache.get("cas_str") == "updated"
+
+    def test_conflict(self, test_cache: KeyValueCache):
+        test_cache.set("cas_str", "original")
+        sha1 = get_string_sha1(test_cache, "cas_str")
+
+        # Another process modifies the value
+        test_cache.set("cas_str", "modified_by_other")
+
+        result = cas_update_string(test_cache, "cas_str", sha1, "my_update")
+        assert result == 0
+        # Value should remain as the other process set it
+        assert test_cache.get("cas_str") == "modified_by_other"
+
+    def test_key_gone(self, test_cache: KeyValueCache):
+        test_cache.set("cas_str", "original")
+        sha1 = get_string_sha1(test_cache, "cas_str")
+
+        test_cache.delete("cas_str")
+
+        result = cas_update_string(test_cache, "cas_str", sha1, "updated")
+        assert result == -1
+
+    def test_complex_value(self, test_cache: KeyValueCache):
+        """Test CAS with a complex JSON-serializable value."""
+        original = {"key": "value", "nested": [1, 2, 3]}
+        test_cache.set("cas_complex", original)
+        sha1 = get_string_sha1(test_cache, "cas_complex")
+
+        new_value = {"key": "updated", "nested": [4, 5, 6]}
+        result = cas_update_string(test_cache, "cas_complex", sha1, new_value)
+        assert result == 1
+        assert test_cache.get("cas_complex") == new_value
+
+
+class TestCASHashFieldUpdate:
+    """Test atomic hash field CAS updates."""
+
+    def test_success(self, test_cache: KeyValueCache):
+        test_cache.hset("cas_hash", "field1", "original")
+        sha1s = get_hash_field_sha1s(test_cache, "cas_hash")
+
+        result = cas_update_hash_field(test_cache, "cas_hash", "field1", sha1s["field1"], "updated")
+        assert result == 1
+        assert test_cache.hget("cas_hash", "field1") == "updated"
+
+    def test_conflict(self, test_cache: KeyValueCache):
+        test_cache.hset("cas_hash", "field1", "original")
+        sha1s = get_hash_field_sha1s(test_cache, "cas_hash")
+
+        # Another process modifies the field
+        test_cache.hset("cas_hash", "field1", "modified_by_other")
+
+        result = cas_update_hash_field(test_cache, "cas_hash", "field1", sha1s["field1"], "my_update")
+        assert result == 0
+        assert test_cache.hget("cas_hash", "field1") == "modified_by_other"
+
+    def test_field_gone(self, test_cache: KeyValueCache):
+        test_cache.hset("cas_hash", "field1", "original")
+        sha1s = get_hash_field_sha1s(test_cache, "cas_hash")
+
+        test_cache.hdel("cas_hash", "field1")
+
+        result = cas_update_hash_field(test_cache, "cas_hash", "field1", sha1s["field1"], "updated")
+        assert result == -1
+
+    def test_other_fields_unaffected(self, test_cache: KeyValueCache):
+        test_cache.hset("cas_hash", "f1", "v1")
+        test_cache.hset("cas_hash", "f2", "v2")
+        sha1s = get_hash_field_sha1s(test_cache, "cas_hash")
+
+        result = cas_update_hash_field(test_cache, "cas_hash", "f1", sha1s["f1"], "new_v1")
+        assert result == 1
+        assert test_cache.hget("cas_hash", "f2") == "v2"
+
+
+class TestCASZsetScoreUpdate:
+    """Test atomic sorted set score CAS updates."""
+
+    def test_success(self, test_cache: KeyValueCache):
+        test_cache.zadd("cas_zset", {"member1": 10.0})
+        score = test_cache.zscore("cas_zset", "member1")
+
+        result = cas_update_zset_score(test_cache, "cas_zset", "member1", str(score), 20.0)
+        assert result == 1
+        assert test_cache.zscore("cas_zset", "member1") == 20.0
+
+    def test_conflict(self, test_cache: KeyValueCache):
+        test_cache.zadd("cas_zset", {"member1": 10.0})
+        score = test_cache.zscore("cas_zset", "member1")
+
+        # Another process changes the score
+        test_cache.zadd("cas_zset", {"member1": 99.0})
+
+        result = cas_update_zset_score(test_cache, "cas_zset", "member1", str(score), 20.0)
+        assert result == 0
+        assert test_cache.zscore("cas_zset", "member1") == 99.0
+
+    def test_member_gone(self, test_cache: KeyValueCache):
+        test_cache.zadd("cas_zset", {"member1": 10.0})
+        score = test_cache.zscore("cas_zset", "member1")
+
+        test_cache.zrem("cas_zset", "member1")
+
+        result = cas_update_zset_score(test_cache, "cas_zset", "member1", str(score), 20.0)
+        assert result == -1
+
+
+class TestCASListElementUpdate:
+    """Test atomic list element CAS updates."""
+
+    def test_success(self, test_cache: KeyValueCache):
+        test_cache.rpush("cas_list", "a", "b", "c")
+        sha1s = get_list_sha1s(test_cache, "cas_list")
+
+        result = cas_update_list_element(test_cache, "cas_list", 1, sha1s[1], "B")
+        assert result == 1
+        assert test_cache.lindex("cas_list", 1) == "B"
+
+    def test_conflict_value_changed(self, test_cache: KeyValueCache):
+        test_cache.rpush("cas_list", "a", "b", "c")
+        sha1s = get_list_sha1s(test_cache, "cas_list")
+
+        # Another process modifies element at index 1
+        test_cache.lset("cas_list", 1, "modified")
+
+        result = cas_update_list_element(test_cache, "cas_list", 1, sha1s[1], "my_update")
+        assert result == 0
+        assert test_cache.lindex("cas_list", 1) == "modified"
+
+    def test_conflict_index_shifted(self, test_cache: KeyValueCache):
+        test_cache.rpush("cas_list", "a", "b", "c")
+        sha1s = get_list_sha1s(test_cache, "cas_list")
+
+        # Another process inserts at head, shifting indices
+        test_cache.lpush("cas_list", "z")
+
+        # Index 1 now has "a" (was "b"), SHA1 won't match
+        result = cas_update_list_element(test_cache, "cas_list", 1, sha1s[1], "my_update")
+        assert result == 0
+
+    @pytest.mark.parametrize("count", [0, 1])
+    def test_index_gone(self, test_cache: KeyValueCache, count: int):
+        test_cache.rpush("cas_list", *["x"] * (count + 1))
+        sha1s = get_list_sha1s(test_cache, "cas_list")
+
+        # Remove all elements
+        test_cache.delete("cas_list")
+
+        result = cas_update_list_element(test_cache, "cas_list", count, sha1s[count], "updated")
+        assert result == -1
+
+    def test_first_and_last_elements(self, test_cache: KeyValueCache):
+        test_cache.rpush("cas_list", "first", "middle", "last")
+        sha1s = get_list_sha1s(test_cache, "cas_list")
+
+        # Update first
+        result = cas_update_list_element(test_cache, "cas_list", 0, sha1s[0], "FIRST")
+        assert result == 1
+
+        # Update last
+        result = cas_update_list_element(test_cache, "cas_list", 2, sha1s[2], "LAST")
+        assert result == 1
+
+        assert test_cache.lrange("cas_list", 0, -1) == ["FIRST", "middle", "LAST"]


### PR DESCRIPTION
## Summary

- Adds compare-and-swap (CAS) protection via Lua scripts for the 4 admin operations vulnerable to race conditions: **string update**, **hash field update**, **zset score update**, and **list element update**
- SHA1 fingerprints (via `redis.sha1hex()`) are computed at page load and embedded in hidden form fields, then verified atomically before writes — if the value changed since page load, the update is rejected with a conflict warning
- Adds inline **list element editing** (LSET) to the admin UI, which was previously missing
- Includes 27 new tests covering success, conflict, and key-gone paths for all CAS operations

### Files changed

| File | What |
|------|------|
| `django_cachex/admin/cas.py` | New — Lua scripts + Python CAS helpers |
| `django_cachex/admin/helpers.py` | Adds SHA1 fingerprints to type data |
| `django_cachex/admin/views/key_detail.py` | CAS logic for update handlers + new `lset` action |
| `key_detail_string.html` | Hidden `original_sha1` field |
| `key_detail_hash.html` | Inline edit with CAS + fallback for non-CAS backends |
| `key_detail_zset.html` | Hidden `original_score` field |
| `key_detail_list.html` | Inline edit with CAS + fallback for non-CAS backends |
| `tests/admin/test_cas.py` | New — 27 tests for all CAS operations |

## Test plan

- [x] All 27 new CAS unit tests pass
- [x] All 446 existing tests pass (no regressions)
- [x] Manual test: open same key in two tabs, edit in tab 1, submit, then edit+submit in tab 2 → should show conflict warning

Closes #6