### PR TITLE
feat: add PostgreSQL cache backend using UNLOGGED tables

### DIFF
--- a/django_cachex/cache/__init__.py
+++ b/django_cachex/cache/__init__.py
@@ -13,6 +13,7 @@ from django_cachex.cache.default import (
     RedisCache,
     ValkeyCache,
 )
+from django_cachex.cache.postgres import PostgreSQLCache
 from django_cachex.cache.sentinel import (
     KeyValueSentinelCache,
     RedisSentinelCache,
@@ -23,6 +24,7 @@ __all__ = [
     "KeyValueCache",
     "KeyValueClusterCache",
     "KeyValueSentinelCache",
+    "PostgreSQLCache",
     "RedisCache",
     "RedisClusterCache",
     "RedisSentinelCache",

--- a/django_cachex/cache/postgres.py
+++ b/django_cachex/cache/postgres.py
@@ -1,0 +1,63 @@
+"""PostgreSQL cache backend using UNLOGGED tables."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from django_cachex.cache.default import KeyValueCache
+from django_cachex.client.postgres import PostgreSQLCacheClient
+from django_cachex.exceptions import NotSupportedError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class PostgreSQLCache(KeyValueCache):
+    """Django cache backend using PostgreSQL UNLOGGED tables.
+
+    Setup::
+
+        INSTALLED_APPS = [
+            ...,
+            "django_cachex.postgres",   # creates tables via migrate
+        ]
+
+        CACHES = {
+            "default": {
+                "BACKEND": "django_cachex.cache.PostgreSQLCache",
+                "LOCATION": "cachex",         # must match model db_table prefix
+                "OPTIONS": {
+                    "DATABASE": "default",    # Django DATABASES alias
+                },
+            }
+        }
+
+    Then run ``manage.py migrate`` to create the UNLOGGED tables.
+    """
+
+    _class = PostgreSQLCacheClient  # type: ignore[assignment]
+    _cachex_support = "cachex"
+
+    def eval_script(
+        self,
+        script: str,
+        *,
+        keys: Sequence[Any] = (),
+        args: Sequence[Any] = (),
+        pre_hook: Any = None,
+        post_hook: Any = None,
+        version: int | None = None,
+    ) -> Any:
+        raise NotSupportedError("eval_script", "PostgreSQL")
+
+    async def aeval_script(
+        self,
+        script: str,
+        *,
+        keys: Sequence[Any] = (),
+        args: Sequence[Any] = (),
+        pre_hook: Any = None,
+        post_hook: Any = None,
+        version: int | None = None,
+    ) -> Any:
+        raise NotSupportedError("eval_script", "PostgreSQL")

--- a/django_cachex/client/__init__.py
+++ b/django_cachex/client/__init__.py
@@ -11,6 +11,7 @@ from django_cachex.client.default import (
     ValkeyCacheClient,
 )
 from django_cachex.client.pipeline import Pipeline
+from django_cachex.client.postgres import PostgreSQLCacheClient
 
 # Sentinel cache clients
 from django_cachex.client.sentinel import (
@@ -24,6 +25,7 @@ __all__ = [
     "KeyValueClusterCacheClient",
     "KeyValueSentinelCacheClient",
     "Pipeline",
+    "PostgreSQLCacheClient",
     "RedisCacheClient",
     "RedisClusterCacheClient",
     "RedisSentinelCacheClient",

--- a/django_cachex/client/postgres.py
+++ b/django_cachex/client/postgres.py
@@ -1,0 +1,2616 @@
+"""PostgreSQL cache client for django-cachex.
+
+Provides a PostgreSQL-backed cache client that implements the same interface as
+KeyValueCacheClient, using Django's database connections and UNLOGGED tables to
+provide Redis-like caching with data structures (hashes, lists, sets, sorted sets).
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from asgiref.sync import sync_to_async
+
+from django_cachex.compat import create_compressor, create_serializer
+from django_cachex.exceptions import CompressorError, NotSupportedError, SerializerError
+from django_cachex.types import KeyType
+
+if TYPE_CHECKING:
+    import builtins
+    from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
+
+    from django_cachex.types import AbsExpiryT, ExpiryT, KeyT
+
+# Type IDs matching the schema
+_TYPE_STRING = 0
+_TYPE_HASH = 1
+_TYPE_LIST = 2
+_TYPE_SET = 3
+_TYPE_ZSET = 4
+
+_TYPE_ID_TO_KEYTYPE: dict[int, KeyType] = {
+    _TYPE_STRING: KeyType.STRING,
+    _TYPE_HASH: KeyType.HASH,
+    _TYPE_LIST: KeyType.LIST,
+    _TYPE_SET: KeyType.SET,
+    _TYPE_ZSET: KeyType.ZSET,
+}
+
+_KEYTYPE_TO_TYPE_ID: dict[str, int] = {
+    "string": _TYPE_STRING,
+    "hash": _TYPE_HASH,
+    "list": _TYPE_LIST,
+    "set": _TYPE_SET,
+    "zset": _TYPE_ZSET,
+}
+
+_BACKEND_NAME = "PostgreSQL"
+
+
+def _async(method_name: str) -> Any:
+    """Create an async wrapper for a sync method."""
+
+    async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        return await sync_to_async(getattr(self, method_name))(*args, **kwargs)
+
+    wrapper.__name__ = f"a{method_name}"
+    return wrapper
+
+
+def _not_supported(operation: str) -> Any:
+    """Create a method that raises NotSupportedError."""
+
+    def method(self: Any, *args: Any, **kwargs: Any) -> Any:
+        raise NotSupportedError(operation, _BACKEND_NAME)
+
+    method.__name__ = operation
+    return method
+
+
+def _parse_score_bound(value: float | str) -> tuple[bool, float]:
+    """Parse a Redis-style score bound.
+
+    Returns (inclusive, numeric_value). Handles '-inf', '+inf', 'inf',
+    and '(' prefix for exclusive bounds.
+    """
+    if isinstance(value, str):
+        s = value.strip()
+        if s == "-inf":
+            return True, float("-inf")
+        if s in ("+inf", "inf"):
+            return True, float("inf")
+        if s.startswith("("):
+            return False, float(s[1:])
+        return True, float(s)
+    return True, float(value)
+
+
+class PostgreSQLCacheClient:
+    """PostgreSQL-backed cache client implementing the KeyValueCacheClient interface.
+
+    Uses Django's database connections and UNLOGGED tables to provide Redis-like
+    caching with data structures (hashes, lists, sets, sorted sets).
+    """
+
+    _default_scan_itersize: int = 100
+
+    def __init__(
+        self,
+        servers: list[str],
+        serializer: str | list | builtins.type[Any] | None = None,
+        pool_class: str | builtins.type[Any] | None = None,
+        parser_class: str | builtins.type[Any] | None = None,
+        async_pool_class: str | builtins.type[Any] | None = None,
+        **options: Any,
+    ) -> None:
+        """Initialize the PostgreSQL cache client."""
+        self._table = servers[0]
+        self._db_alias = options.pop("DATABASE", "default")
+
+        # Ignore Redis-specific options silently
+        options.pop("compressor_config", None)
+
+        # Setup compressors
+        compressor_config = options.get("compressor")
+        self._compressors = self._create_compressors(compressor_config)
+
+        # Setup serializers
+        serializer_config = (
+            serializer
+            if serializer is not None
+            else options.get("serializer", "django_cachex.serializers.pickle.PickleSerializer")
+        )
+        self._serializers = self._create_serializers(serializer_config)
+
+        self._options = options
+
+    # =========================================================================
+    # Serializer/Compressor Setup
+    # =========================================================================
+
+    def _create_serializers(self, config: str | list | builtins.type[Any] | Any) -> list:
+        """Create serializer instance(s) from config."""
+        if isinstance(config, list):
+            return [create_serializer(item) for item in config]
+        return [create_serializer(config)]
+
+    def _create_compressors(self, config: str | list | builtins.type[Any] | Any | None) -> list:
+        """Create compressor instance(s) from config."""
+        if config is None:
+            return []
+        if isinstance(config, list):
+            return [create_compressor(item) for item in config]
+        return [create_compressor(config)]
+
+    def _decompress(self, value: bytes) -> bytes:
+        """Decompress with fallback support for multiple compressors."""
+        for compressor in self._compressors:
+            try:
+                return compressor.decompress(value)
+            except CompressorError:
+                continue
+        return value
+
+    def _deserialize(self, value: bytes) -> Any:
+        """Deserialize with fallback support for multiple serializers."""
+        last_error: SerializerError | None = None
+        for serializer in self._serializers:
+            try:
+                return serializer.loads(value)
+            except SerializerError as e:
+                last_error = e
+                continue
+
+        if last_error is not None:
+            raise last_error
+        raise SerializerError("No serializers configured")
+
+    # =========================================================================
+    # Encoding/Decoding
+    # =========================================================================
+
+    def encode(self, value: Any) -> bytes | int:
+        """Encode a value for storage (serialize + compress). Plain ints pass through unchanged."""
+        if isinstance(value, bool) or not isinstance(value, int):
+            value = self._serializers[0].dumps(value)
+            if self._compressors:
+                return self._compressors[0].compress(value)
+            return value
+        return value
+
+    def decode(self, value: Any) -> Any:
+        """Decode a value from storage. Returns int directly if parseable, otherwise decompress + deserialize."""
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            if isinstance(value, memoryview):
+                value = bytes(value)
+            value = self._decompress(value)
+            return self._deserialize(value)
+
+    # =========================================================================
+    # Database helpers
+    # =========================================================================
+
+    @property
+    def _conn(self) -> Any:
+        """Get the Django database connection."""
+        from django.db import connections
+
+        return connections[self._db_alias]
+
+    def _now(self) -> datetime:
+        """Get current time, matching Django's USE_TZ setting."""
+        from django.utils import timezone
+
+        return timezone.now()
+
+    def _make_expiry(self, timeout: float | None) -> datetime | None | int:
+        """Convert a timeout to an expiry timestamp.
+
+        Returns None for no expiry, 0 for immediate deletion, datetime for future expiry.
+        """
+        if timeout is None:
+            return None
+        if timeout == 0:
+            return 0
+        return self._now() + timedelta(seconds=timeout)
+
+    def _expiry_filter(self) -> str:
+        """SQL fragment to filter out expired keys."""
+        return "AND (expires_at IS NULL OR expires_at > NOW())"
+
+    def _ensure_key(self, cursor: Any, key: KeyT, type_id: int) -> None:
+        """Ensure key exists in main table with the correct type.
+
+        Handles expired keys (treats as non-existent) and type transitions
+        (cleans up old auxiliary data before changing type).
+        """
+        cursor.execute(
+            f"SELECT type, expires_at FROM {self._table} WHERE key = %s",
+            [key],
+        )
+        row = cursor.fetchone()
+
+        if row is not None:
+            old_type, expires_at = row
+            now = self._now()
+            expired = expires_at is not None and expires_at <= now
+
+            if expired:
+                # Expired key: remove completely and treat as new
+                self._delete_all_key_data(cursor, key)
+                cursor.execute(f"DELETE FROM {self._table} WHERE key = %s", [key])
+            elif old_type != type_id:
+                # Type change: clean up old auxiliary data
+                self._delete_key_data(cursor, key, old_type)
+
+        # Upsert key with correct type
+        cursor.execute(
+            f"""
+            INSERT INTO {self._table} (key, type)
+            VALUES (%s, %s)
+            ON CONFLICT (key)
+            DO UPDATE SET type = EXCLUDED.type, value = NULL
+            WHERE {self._table}.type != EXCLUDED.type
+            """,
+            [key, type_id],
+        )
+
+    def _delete_key_data(self, cursor: Any, key: KeyT, type_id: int) -> None:
+        """Delete data from auxiliary tables based on type."""
+        if type_id == _TYPE_HASH:
+            cursor.execute(f"DELETE FROM {self._table}_hashes WHERE key = %s", [key])
+        elif type_id == _TYPE_LIST:
+            cursor.execute(f"DELETE FROM {self._table}_lists WHERE key = %s", [key])
+        elif type_id == _TYPE_SET:
+            cursor.execute(f"DELETE FROM {self._table}_sets WHERE key = %s", [key])
+        elif type_id == _TYPE_ZSET:
+            cursor.execute(f"DELETE FROM {self._table}_zsets WHERE key = %s", [key])
+
+    def _delete_all_key_data(self, cursor: Any, key: KeyT) -> None:
+        """Delete data from all auxiliary tables for a key."""
+        for suffix in ("_hashes", "_lists", "_sets", "_zsets"):
+            cursor.execute(f"DELETE FROM {self._table}{suffix} WHERE key = %s", [key])
+
+    def _get_key_type(self, cursor: Any, key: KeyT) -> int | None:
+        """Get the type of a key, returning None if key doesn't exist or is expired."""
+        cursor.execute(
+            f"SELECT type FROM {self._table} WHERE key = %s {self._expiry_filter()}",
+            [key],
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    def _to_bytea(self, encoded: bytes | int) -> bytes:
+        """Convert an encoded value to bytes suitable for BYTEA storage."""
+        if isinstance(encoded, int):
+            return str(encoded).encode()
+        return encoded
+
+    def _glob_to_sql(self, pattern: str) -> tuple[str, bool]:  # noqa: C901, PLR0912
+        """Convert a Redis glob pattern to SQL.
+
+        Returns (sql_pattern, use_regex).
+        If the pattern contains bracket expressions, returns a regex for use with ~.
+        Otherwise returns a LIKE pattern.
+        """
+        if "[" in pattern:
+            # Use PostgreSQL regex
+            regex = ""
+            i = 0
+            while i < len(pattern):
+                c = pattern[i]
+                if c == "*":
+                    regex += ".*"
+                elif c == "?":
+                    regex += "."
+                elif c == "[":
+                    # Find the closing bracket
+                    j = pattern.index("]", i + 1)
+                    regex += pattern[i : j + 1]
+                    i = j
+                elif c in r"\.+^${}()|":
+                    regex += "\\" + c
+                else:
+                    regex += c
+                i += 1
+            return "^" + regex + "$", True
+
+        # Use LIKE pattern
+        # First escape existing % and _ in the original
+        like = ""
+        for c in pattern:
+            if c == "%":
+                like += "\\%"
+            elif c == "_":
+                like += "\\_"
+            elif c == "*":
+                like += "%"
+            elif c == "?":
+                like += "_"
+            elif c == "\\":
+                like += "\\\\"
+            else:
+                like += c
+        return like, False
+
+    # =========================================================================
+    # Core Cache Operations
+    # =========================================================================
+
+    def set(self, key: KeyT, value: Any, timeout: int | None) -> None:
+        """Set a value in the cache."""
+        if timeout == 0:
+            self.delete(key)
+            return
+
+        encoded = self.encode(value)
+        bytea = self._to_bytea(encoded)
+        expiry = self._make_expiry(timeout)
+
+        with self._conn.cursor() as cursor:
+            # Delete any auxiliary data if the key existed with a different type
+            self._delete_all_key_data(cursor, key)
+            cursor.execute(
+                f"""
+                INSERT INTO {self._table} (key, type, value, expires_at)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (key)
+                DO UPDATE SET type = EXCLUDED.type, value = EXCLUDED.value, expires_at = EXCLUDED.expires_at
+                """,
+                [key, _TYPE_STRING, bytea, expiry],
+            )
+
+    def get(self, key: KeyT) -> Any:
+        """Fetch a value from the cache."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT value FROM {self._table} WHERE key = %s AND type = %s {self._expiry_filter()}",
+                [key, _TYPE_STRING],
+            )
+            row = cursor.fetchone()
+            if row is None or row[0] is None:
+                return None
+            return self.decode(row[0])
+
+    def add(self, key: KeyT, value: Any, timeout: int | None) -> bool:
+        """Set a value only if the key doesn't exist."""
+        encoded = self.encode(value)
+        bytea = self._to_bytea(encoded)
+
+        if timeout == 0:
+            # Check if it would have been set (key doesn't exist), but then delete
+            with self._conn.cursor() as cursor:
+                cursor.execute(
+                    f"SELECT 1 FROM {self._table} WHERE key = %s {self._expiry_filter()}",
+                    [key],
+                )
+                return cursor.fetchone() is None
+
+        expiry = self._make_expiry(timeout)
+        with self._conn.cursor() as cursor:
+            # Clean up expired entry first
+            cursor.execute(
+                f"DELETE FROM {self._table} WHERE key = %s AND expires_at IS NOT NULL AND expires_at <= NOW()",
+                [key],
+            )
+            cursor.execute(
+                f"""
+                INSERT INTO {self._table} (key, type, value, expires_at)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (key) DO NOTHING
+                """,
+                [key, _TYPE_STRING, bytea, expiry],
+            )
+            return cursor.rowcount > 0
+
+    def set_with_flags(  # noqa: PLR0911
+        self,
+        key: KeyT,
+        value: Any,
+        timeout: int | None,
+        *,
+        nx: bool = False,
+        xx: bool = False,
+        get: bool = False,
+    ) -> bool | Any:
+        """Set a value with nx/xx/get flags."""
+        if timeout == 0:
+            if get:
+                return None
+            return False
+
+        encoded = self.encode(value)
+        bytea = self._to_bytea(encoded)
+        expiry = self._make_expiry(timeout)
+
+        with self._conn.cursor() as cursor:
+            old_value = None
+            if get:
+                cursor.execute(
+                    f"SELECT value FROM {self._table} WHERE key = %s AND type = %s {self._expiry_filter()}",
+                    [key, _TYPE_STRING],
+                )
+                row = cursor.fetchone()
+                old_value = row[0] if row else None
+
+            if nx:
+                # Clean up expired entry first
+                cursor.execute(
+                    f"DELETE FROM {self._table} WHERE key = %s AND expires_at IS NOT NULL AND expires_at <= NOW()",
+                    [key],
+                )
+                self._delete_all_key_data(cursor, key)
+                cursor.execute(
+                    f"""
+                    INSERT INTO {self._table} (key, type, value, expires_at)
+                    VALUES (%s, %s, %s, %s)
+                    ON CONFLICT (key) DO NOTHING
+                    """,
+                    [key, _TYPE_STRING, bytea, expiry],
+                )
+                if get:
+                    return self.decode(old_value) if old_value is not None else None
+                return cursor.rowcount > 0
+
+            if xx:
+                cursor.execute(
+                    f"""
+                    UPDATE {self._table}
+                    SET type = %s, value = %s, expires_at = %s
+                    WHERE key = %s {self._expiry_filter()}
+                    """,
+                    [_TYPE_STRING, bytea, expiry, key],
+                )
+                updated = cursor.rowcount > 0
+                if updated:
+                    self._delete_all_key_data(cursor, key)
+                if get:
+                    return self.decode(old_value) if old_value is not None else None
+                return updated
+
+            # Plain set
+            self._delete_all_key_data(cursor, key)
+            cursor.execute(
+                f"""
+                INSERT INTO {self._table} (key, type, value, expires_at)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (key)
+                DO UPDATE SET type = EXCLUDED.type, value = EXCLUDED.value, expires_at = EXCLUDED.expires_at
+                """,
+                [key, _TYPE_STRING, bytea, expiry],
+            )
+            if get:
+                return self.decode(old_value) if old_value is not None else None
+            return True
+
+    def delete(self, key: KeyT) -> bool:
+        """Remove a key from the cache."""
+        with self._conn.cursor() as cursor:
+            self._delete_all_key_data(cursor, key)
+            cursor.execute(f"DELETE FROM {self._table} WHERE key = %s", [key])
+            return cursor.rowcount > 0
+
+    def has_key(self, key: KeyT) -> bool:
+        """Check if a key exists."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT 1 FROM {self._table} WHERE key = %s {self._expiry_filter()}",
+                [key],
+            )
+            return cursor.fetchone() is not None
+
+    def touch(self, key: KeyT, timeout: int | None) -> bool:
+        """Update the timeout on a key."""
+        if timeout is None:
+            return self.persist(key)
+        expiry = self._make_expiry(timeout)
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"UPDATE {self._table} SET expires_at = %s WHERE key = %s {self._expiry_filter()}",
+                [expiry, key],
+            )
+            return cursor.rowcount > 0
+
+    def get_many(self, keys: Iterable[KeyT]) -> dict[KeyT, Any]:
+        """Retrieve many keys."""
+        keys = list(keys)
+        if not keys:
+            return {}
+
+        with self._conn.cursor() as cursor:
+            placeholders = ", ".join(["%s"] * len(keys))
+            cursor.execute(
+                f"SELECT key, value FROM {self._table} WHERE key IN ({placeholders}) AND type = %s {self._expiry_filter()}",
+                [*keys, _TYPE_STRING],
+            )
+            result = {}
+            for row in cursor.fetchall():
+                if row[1] is not None:
+                    result[row[0]] = self.decode(row[1])
+            return result
+
+    def set_many(self, data: Mapping[KeyT, Any], timeout: int | None) -> list:
+        """Set multiple values."""
+        if not data:
+            return []
+
+        if timeout == 0:
+            self.delete_many(list(data.keys()))
+            return []
+
+        expiry = self._make_expiry(timeout)
+        with self._conn.cursor() as cursor:
+            for key, value in data.items():
+                encoded = self.encode(value)
+                bytea = self._to_bytea(encoded)
+                self._delete_all_key_data(cursor, key)
+                cursor.execute(
+                    f"""
+                    INSERT INTO {self._table} (key, type, value, expires_at)
+                    VALUES (%s, %s, %s, %s)
+                    ON CONFLICT (key)
+                    DO UPDATE SET type = EXCLUDED.type, value = EXCLUDED.value, expires_at = EXCLUDED.expires_at
+                    """,
+                    [key, _TYPE_STRING, bytea, expiry],
+                )
+        return []
+
+    def delete_many(self, keys: Sequence[KeyT]) -> int:
+        """Remove multiple keys."""
+        if not keys:
+            return 0
+
+        with self._conn.cursor() as cursor:
+            placeholders = ", ".join(["%s"] * len(keys))
+            for suffix in ("_hashes", "_lists", "_sets", "_zsets"):
+                cursor.execute(
+                    f"DELETE FROM {self._table}{suffix} WHERE key IN ({placeholders})",
+                    list(keys),
+                )
+            cursor.execute(
+                f"DELETE FROM {self._table} WHERE key IN ({placeholders})",
+                list(keys),
+            )
+            return cursor.rowcount
+
+    def incr(self, key: KeyT, delta: int = 1) -> int:
+        """Increment a value."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT value FROM {self._table} WHERE key = %s AND type = %s {self._expiry_filter()} FOR UPDATE",
+                [key, _TYPE_STRING],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                raise ValueError(f"Key {key!r} not found")
+
+            try:
+                current = int(row[0])
+            except (ValueError, TypeError) as e:
+                raise ValueError(f"Value at key {key!r} is not an integer") from e
+
+            new_val = current + delta
+            cursor.execute(
+                f"UPDATE {self._table} SET value = %s WHERE key = %s",
+                [str(new_val).encode(), key],
+            )
+            return new_val
+
+    def clear(self) -> bool:
+        """Delete all keys from the cache tables."""
+        with self._conn.cursor() as cursor:
+            for suffix in ("_hashes", "_lists", "_sets", "_zsets"):
+                cursor.execute(f"DELETE FROM {self._table}{suffix}")
+            cursor.execute(f"DELETE FROM {self._table}")
+        return True
+
+    def close(self, **kwargs: Any) -> None:
+        """No-op. Connections managed by Django."""
+
+    async def aclose(self, **kwargs: Any) -> None:
+        """No-op. Connections managed by Django."""
+
+    def type(self, key: KeyT) -> KeyType | None:
+        """Get the data type of a key."""
+        with self._conn.cursor() as cursor:
+            type_id = self._get_key_type(cursor, key)
+            if type_id is None:
+                return None
+            return _TYPE_ID_TO_KEYTYPE.get(type_id)
+
+    # =========================================================================
+    # TTL Operations
+    # =========================================================================
+
+    def ttl(self, key: KeyT) -> int | None:
+        """Get TTL in seconds. Returns None if no expiry, -2 if key doesn't exist."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT expires_at FROM {self._table} WHERE key = %s {self._expiry_filter()}",
+                [key],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return -2
+            if row[0] is None:
+                return None
+            remaining = (row[0] - self._now()).total_seconds()
+            return max(0, int(remaining))
+
+    def pttl(self, key: KeyT) -> int | None:
+        """Get TTL in milliseconds. Returns None if no expiry, -2 if key doesn't exist."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT expires_at FROM {self._table} WHERE key = %s {self._expiry_filter()}",
+                [key],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return -2
+            if row[0] is None:
+                return None
+            remaining = (row[0] - self._now()).total_seconds() * 1000
+            return max(0, int(remaining))
+
+    def expiretime(self, key: KeyT) -> int | None:
+        """Get the absolute Unix timestamp (seconds) when a key will expire."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT expires_at FROM {self._table} WHERE key = %s {self._expiry_filter()}",
+                [key],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return -2
+            if row[0] is None:
+                return None
+            return int(row[0].timestamp())
+
+    def expire(self, key: KeyT, timeout: ExpiryT) -> bool:
+        """Set expiry on a key."""
+        if isinstance(timeout, timedelta):
+            timeout = int(timeout.total_seconds())
+        expiry = self._now() + timedelta(seconds=timeout)
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"UPDATE {self._table} SET expires_at = %s WHERE key = %s {self._expiry_filter()}",
+                [expiry, key],
+            )
+            return cursor.rowcount > 0
+
+    def pexpire(self, key: KeyT, timeout: ExpiryT) -> bool:
+        """Set expiry in milliseconds."""
+        if isinstance(timeout, timedelta):
+            ms = timeout.total_seconds() * 1000
+        else:
+            ms = int(timeout)
+        expiry = self._now() + timedelta(milliseconds=ms)
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"UPDATE {self._table} SET expires_at = %s WHERE key = %s {self._expiry_filter()}",
+                [expiry, key],
+            )
+            return cursor.rowcount > 0
+
+    def expireat(self, key: KeyT, when: AbsExpiryT) -> bool:
+        """Set expiry at absolute time."""
+        if isinstance(when, int):
+            expiry = datetime.fromtimestamp(when, tz=UTC)
+        else:
+            expiry = when
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"UPDATE {self._table} SET expires_at = %s WHERE key = %s {self._expiry_filter()}",
+                [expiry, key],
+            )
+            return cursor.rowcount > 0
+
+    def pexpireat(self, key: KeyT, when: AbsExpiryT) -> bool:
+        """Set expiry at absolute time in milliseconds."""
+        if isinstance(when, int):
+            expiry = datetime.fromtimestamp(when / 1000.0, tz=UTC)
+        else:
+            expiry = when
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"UPDATE {self._table} SET expires_at = %s WHERE key = %s {self._expiry_filter()}",
+                [expiry, key],
+            )
+            return cursor.rowcount > 0
+
+    def persist(self, key: KeyT) -> bool:
+        """Remove expiry from a key."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"UPDATE {self._table} SET expires_at = NULL WHERE key = %s {self._expiry_filter()}",
+                [key],
+            )
+            return cursor.rowcount > 0
+
+    # =========================================================================
+    # Key Operations
+    # =========================================================================
+
+    def keys(self, pattern: str) -> list[str]:
+        """Get all keys matching pattern."""
+        sql_pattern, use_regex = self._glob_to_sql(pattern)
+        with self._conn.cursor() as cursor:
+            if use_regex:
+                cursor.execute(
+                    f"SELECT key FROM {self._table} WHERE key ~ %s {self._expiry_filter()} ORDER BY key",
+                    [sql_pattern],
+                )
+            else:
+                cursor.execute(
+                    f"SELECT key FROM {self._table} WHERE key LIKE %s {self._expiry_filter()} ORDER BY key",
+                    [sql_pattern],
+                )
+            return [row[0] for row in cursor.fetchall()]
+
+    def iter_keys(self, pattern: str, itersize: int | None = None) -> Iterator[str]:
+        """Iterate keys matching pattern."""
+        if itersize is None:
+            itersize = self._default_scan_itersize
+
+        cursor_val = 0
+        while True:
+            next_cursor, batch = self.scan(cursor=cursor_val, match=pattern, count=itersize)
+            yield from batch
+            if next_cursor == 0:
+                break
+            cursor_val = next_cursor
+
+    def scan(
+        self,
+        cursor: int = 0,
+        match: str | None = None,
+        count: int | None = None,
+        _type: str | None = None,
+    ) -> tuple[int, list[str]]:
+        """Perform a single SCAN iteration using OFFSET-based pagination."""
+        if count is None:
+            count = self._default_scan_itersize
+
+        conditions = [self._expiry_filter().lstrip("AND ")]
+        params: list[Any] = []
+
+        if match is not None:
+            sql_pattern, use_regex = self._glob_to_sql(match)
+            if use_regex:
+                conditions.append("key ~ %s")
+            else:
+                conditions.append("key LIKE %s")
+            params.append(sql_pattern)
+
+        if _type is not None:
+            type_id = _KEYTYPE_TO_TYPE_ID.get(_type)
+            if type_id is not None:
+                conditions.append("type = %s")
+                params.append(type_id)
+
+        where = " AND ".join(conditions)
+        params.extend([count, cursor])
+
+        with self._conn.cursor() as db_cursor:
+            db_cursor.execute(
+                f"SELECT key FROM {self._table} WHERE {where} ORDER BY key LIMIT %s OFFSET %s",
+                params,
+            )
+            keys = [row[0] for row in db_cursor.fetchall()]
+
+        next_offset = cursor + len(keys)
+        if len(keys) < count:
+            next_offset = 0
+        return next_offset, keys
+
+    def delete_pattern(self, pattern: str, itersize: int | None = None) -> int:
+        """Delete all keys matching pattern."""
+        if itersize is None:
+            itersize = self._default_scan_itersize
+
+        total = 0
+        while True:
+            # Always scan from offset 0 since deleting shifts OFFSET positions
+            _, batch = self.scan(cursor=0, match=pattern, count=itersize)
+            if not batch:
+                break
+            total += self.delete_many(batch)
+        return total
+
+    def rename(self, src: KeyT, dst: KeyT) -> bool:
+        """Rename a key."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT type FROM {self._table} WHERE key = %s {self._expiry_filter()}",
+                [src],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                raise ValueError(f"Key {src!r} not found")
+
+            # Delete destination and its data
+            self._delete_all_key_data(cursor, dst)
+            cursor.execute(f"DELETE FROM {self._table} WHERE key = %s", [dst])
+
+            # Rename in auxiliary tables
+            for suffix in ("_hashes", "_lists", "_sets", "_zsets"):
+                cursor.execute(
+                    f"UPDATE {self._table}{suffix} SET key = %s WHERE key = %s",
+                    [dst, src],
+                )
+
+            # Rename in main table
+            cursor.execute(
+                f"UPDATE {self._table} SET key = %s WHERE key = %s",
+                [dst, src],
+            )
+        return True
+
+    def renamenx(self, src: KeyT, dst: KeyT) -> bool:
+        """Rename a key only if the destination does not exist."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT type FROM {self._table} WHERE key = %s {self._expiry_filter()}",
+                [src],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                raise ValueError(f"Key {src!r} not found")
+
+            # Check if dest exists
+            cursor.execute(
+                f"SELECT 1 FROM {self._table} WHERE key = %s {self._expiry_filter()}",
+                [dst],
+            )
+            if cursor.fetchone() is not None:
+                return False
+
+            # Rename in auxiliary tables
+            for suffix in ("_hashes", "_lists", "_sets", "_zsets"):
+                cursor.execute(
+                    f"UPDATE {self._table}{suffix} SET key = %s WHERE key = %s",
+                    [dst, src],
+                )
+
+            # Rename in main table
+            cursor.execute(
+                f"UPDATE {self._table} SET key = %s WHERE key = %s",
+                [dst, src],
+            )
+        return True
+
+    # =========================================================================
+    # Hash Operations
+    # =========================================================================
+
+    def hset(
+        self,
+        key: KeyT,
+        field: str | None = None,
+        value: Any = None,
+        mapping: Mapping[str, Any] | None = None,
+        items: list[Any] | None = None,
+    ) -> int:
+        """Set hash field(s)."""
+        pairs: list[tuple[str, Any]] = []
+
+        if field is not None:
+            pairs.append((field, value))
+        if mapping:
+            pairs.extend(mapping.items())
+        if items:
+            it = iter(items)
+            for f in it:
+                v = next(it)
+                pairs.append((f, v))
+
+        if not pairs:
+            return 0
+
+        count = 0
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, key, _TYPE_HASH)
+            for f, v in pairs:
+                encoded = self.encode(v)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"SELECT 1 FROM {self._table}_hashes WHERE key = %s AND field = %s",
+                    [key, f],
+                )
+                existed = cursor.fetchone() is not None
+                cursor.execute(
+                    f"""
+                    INSERT INTO {self._table}_hashes (key, field, value)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (key, field) DO UPDATE SET value = EXCLUDED.value
+                    """,
+                    [key, f, bytea],
+                )
+                if not existed:
+                    count += 1
+        return count
+
+    def hsetnx(self, key: KeyT, field: str, value: Any) -> bool:
+        """Set a hash field only if it doesn't exist."""
+        encoded = self.encode(value)
+        bytea = self._to_bytea(encoded)
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, key, _TYPE_HASH)
+            cursor.execute(
+                f"""
+                INSERT INTO {self._table}_hashes (key, field, value)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (key, field) DO NOTHING
+                """,
+                [key, field, bytea],
+            )
+            return cursor.rowcount > 0
+
+    def hget(self, key: KeyT, field: str) -> Any | None:
+        """Get a hash field."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT h.value FROM {self._table}_hashes h
+                INNER JOIN {self._table} m ON m.key = h.key
+                WHERE h.key = %s AND h.field = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, field, _TYPE_HASH],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return self.decode(row[0])
+
+    def hmget(self, key: KeyT, *fields: str) -> list[Any | None]:
+        """Get multiple hash fields."""
+        if not fields:
+            return []
+        with self._conn.cursor() as cursor:
+            placeholders = ", ".join(["%s"] * len(fields))
+            cursor.execute(
+                f"""
+                SELECT h.field, h.value FROM {self._table}_hashes h
+                INNER JOIN {self._table} m ON m.key = h.key
+                WHERE h.key = %s AND h.field IN ({placeholders}) AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, *fields, _TYPE_HASH],
+            )
+            found = {row[0]: row[1] for row in cursor.fetchall()}
+        return [self.decode(found[f]) if f in found else None for f in fields]
+
+    def hgetall(self, key: KeyT) -> dict[str, Any]:
+        """Get all hash fields."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT h.field, h.value FROM {self._table}_hashes h
+                INNER JOIN {self._table} m ON m.key = h.key
+                WHERE h.key = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, _TYPE_HASH],
+            )
+            return {row[0]: self.decode(row[1]) for row in cursor.fetchall()}
+
+    def hdel(self, key: KeyT, *fields: str) -> int:
+        """Delete hash fields."""
+        if not fields:
+            return 0
+        with self._conn.cursor() as cursor:
+            placeholders = ", ".join(["%s"] * len(fields))
+            cursor.execute(
+                f"DELETE FROM {self._table}_hashes WHERE key = %s AND field IN ({placeholders})",
+                [key, *fields],
+            )
+            return cursor.rowcount
+
+    def hexists(self, key: KeyT, field: str) -> bool:
+        """Check if a hash field exists."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT 1 FROM {self._table}_hashes h
+                INNER JOIN {self._table} m ON m.key = h.key
+                WHERE h.key = %s AND h.field = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, field, _TYPE_HASH],
+            )
+            return cursor.fetchone() is not None
+
+    def hlen(self, key: KeyT) -> int:
+        """Get the number of fields in a hash."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT COUNT(*) FROM {self._table}_hashes h
+                INNER JOIN {self._table} m ON m.key = h.key
+                WHERE h.key = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, _TYPE_HASH],
+            )
+            row = cursor.fetchone()
+            return row[0] if row else 0
+
+    def hkeys(self, key: KeyT) -> list[str]:
+        """Get all field names in a hash."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT h.field FROM {self._table}_hashes h
+                INNER JOIN {self._table} m ON m.key = h.key
+                WHERE h.key = %s AND m.type = %s {self._expiry_filter()}
+                ORDER BY h.field
+                """,
+                [key, _TYPE_HASH],
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    def hvals(self, key: KeyT) -> list[Any]:
+        """Get all values in a hash."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT h.value FROM {self._table}_hashes h
+                INNER JOIN {self._table} m ON m.key = h.key
+                WHERE h.key = %s AND m.type = %s {self._expiry_filter()}
+                ORDER BY h.field
+                """,
+                [key, _TYPE_HASH],
+            )
+            return [self.decode(row[0]) for row in cursor.fetchall()]
+
+    def hincrby(self, key: KeyT, field: str, amount: int = 1) -> int:
+        """Increment a hash field by an integer."""
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, key, _TYPE_HASH)
+            cursor.execute(
+                f"SELECT value FROM {self._table}_hashes WHERE key = %s AND field = %s FOR UPDATE",
+                [key, field],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                new_val = amount
+            else:
+                current = int(self.decode(row[0]))
+                new_val = current + amount
+            encoded = self._to_bytea(self.encode(new_val))
+            if row is None:
+                cursor.execute(
+                    f"INSERT INTO {self._table}_hashes (key, field, value) VALUES (%s, %s, %s)",
+                    [key, field, encoded],
+                )
+            else:
+                cursor.execute(
+                    f"UPDATE {self._table}_hashes SET value = %s WHERE key = %s AND field = %s",
+                    [encoded, key, field],
+                )
+            return new_val
+
+    def hincrbyfloat(self, key: KeyT, field: str, amount: float = 1.0) -> float:
+        """Increment a hash field by a float."""
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, key, _TYPE_HASH)
+            cursor.execute(
+                f"SELECT value FROM {self._table}_hashes WHERE key = %s AND field = %s FOR UPDATE",
+                [key, field],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                new_val = amount
+            else:
+                current = float(self.decode(row[0]))
+                new_val = current + amount
+            encoded = self._to_bytea(self.encode(new_val))
+            if row is None:
+                cursor.execute(
+                    f"INSERT INTO {self._table}_hashes (key, field, value) VALUES (%s, %s, %s)",
+                    [key, field, encoded],
+                )
+            else:
+                cursor.execute(
+                    f"UPDATE {self._table}_hashes SET value = %s WHERE key = %s AND field = %s",
+                    [encoded, key, field],
+                )
+            return new_val
+
+    # =========================================================================
+    # List Operations
+    # =========================================================================
+
+    def _list_bounds(self, cursor: Any, key: KeyT) -> tuple[int | None, int | None]:
+        """Get min and max positions for a list key."""
+        cursor.execute(
+            f"""
+            SELECT MIN(l.pos), MAX(l.pos) FROM {self._table}_lists l
+            INNER JOIN {self._table} m ON m.key = l.key
+            WHERE l.key = %s AND m.type = %s {self._expiry_filter()}
+            """,
+            [key, _TYPE_LIST],
+        )
+        row = cursor.fetchone()
+        if row is None or row[0] is None:
+            return None, None
+        return row[0], row[1]
+
+    def _list_positions(self, cursor: Any, key: KeyT) -> list[int]:
+        """Get all positions in order for a list key."""
+        cursor.execute(
+            f"""
+            SELECT l.pos FROM {self._table}_lists l
+            INNER JOIN {self._table} m ON m.key = l.key
+            WHERE l.key = %s AND m.type = %s {self._expiry_filter()}
+            ORDER BY l.pos
+            """,
+            [key, _TYPE_LIST],
+        )
+        return [row[0] for row in cursor.fetchall()]
+
+    def _resolve_list_index(self, positions: list[int], index: int) -> int | None:
+        """Resolve a Redis-style list index (supports negative) to a position value."""
+        if not positions:
+            return None
+        if index < 0:
+            index = len(positions) + index
+        if index < 0 or index >= len(positions):
+            return None
+        return positions[index]
+
+    def lpush(self, key: KeyT, *values: Any) -> int:
+        """Push values to the left of a list."""
+        if not values:
+            return 0
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, key, _TYPE_LIST)
+            min_pos, _ = self._list_bounds(cursor, key)
+            current_pos = (min_pos - 1) if min_pos is not None else 0
+            for v in values:
+                encoded = self.encode(v)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"INSERT INTO {self._table}_lists (key, pos, value) VALUES (%s, %s, %s)",
+                    [key, current_pos, bytea],
+                )
+                current_pos -= 1
+            cursor.execute(
+                f"SELECT COUNT(*) FROM {self._table}_lists WHERE key = %s",
+                [key],
+            )
+            return cursor.fetchone()[0]
+
+    def rpush(self, key: KeyT, *values: Any) -> int:
+        """Push values to the right of a list."""
+        if not values:
+            return 0
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, key, _TYPE_LIST)
+            _, max_pos = self._list_bounds(cursor, key)
+            current_pos = (max_pos + 1) if max_pos is not None else 0
+            for v in values:
+                encoded = self.encode(v)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"INSERT INTO {self._table}_lists (key, pos, value) VALUES (%s, %s, %s)",
+                    [key, current_pos, bytea],
+                )
+                current_pos += 1
+            cursor.execute(
+                f"SELECT COUNT(*) FROM {self._table}_lists WHERE key = %s",
+                [key],
+            )
+            return cursor.fetchone()[0]
+
+    def lpop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
+        """Pop value(s) from the left of a list."""
+        with self._conn.cursor() as cursor:
+            # Check key exists and is not expired
+            cursor.execute(
+                f"SELECT 1 FROM {self._table} WHERE key = %s AND type = %s {self._expiry_filter()}",
+                [key, _TYPE_LIST],
+            )
+            if cursor.fetchone() is None:
+                return [] if count is not None else None
+
+            if count is not None:
+                cursor.execute(
+                    f"SELECT pos, value FROM {self._table}_lists WHERE key = %s ORDER BY pos LIMIT %s",
+                    [key, count],
+                )
+                rows = cursor.fetchall()
+                if not rows:
+                    return []
+                positions = [row[0] for row in rows]
+                values = [self.decode(row[1]) for row in rows]
+                placeholders = ", ".join(["%s"] * len(positions))
+                cursor.execute(
+                    f"DELETE FROM {self._table}_lists WHERE key = %s AND pos IN ({placeholders})",
+                    [key, *positions],
+                )
+                return values
+            cursor.execute(
+                f"SELECT pos, value FROM {self._table}_lists WHERE key = %s ORDER BY pos LIMIT 1",
+                [key],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            cursor.execute(
+                f"DELETE FROM {self._table}_lists WHERE key = %s AND pos = %s",
+                [key, row[0]],
+            )
+            return self.decode(row[1])
+
+    def rpop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
+        """Pop value(s) from the right of a list."""
+        with self._conn.cursor() as cursor:
+            # Check key exists and is not expired
+            cursor.execute(
+                f"SELECT 1 FROM {self._table} WHERE key = %s AND type = %s {self._expiry_filter()}",
+                [key, _TYPE_LIST],
+            )
+            if cursor.fetchone() is None:
+                return [] if count is not None else None
+
+            if count is not None:
+                cursor.execute(
+                    f"SELECT pos, value FROM {self._table}_lists WHERE key = %s ORDER BY pos DESC LIMIT %s",
+                    [key, count],
+                )
+                rows = cursor.fetchall()
+                if not rows:
+                    return []
+                positions = [row[0] for row in rows]
+                # Reverse to get left-to-right order (rightmost popped first = reversed)
+                values = [self.decode(row[1]) for row in rows]
+                placeholders = ", ".join(["%s"] * len(positions))
+                cursor.execute(
+                    f"DELETE FROM {self._table}_lists WHERE key = %s AND pos IN ({placeholders})",
+                    [key, *positions],
+                )
+                return values
+            cursor.execute(
+                f"SELECT pos, value FROM {self._table}_lists WHERE key = %s ORDER BY pos DESC LIMIT 1",
+                [key],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            cursor.execute(
+                f"DELETE FROM {self._table}_lists WHERE key = %s AND pos = %s",
+                [key, row[0]],
+            )
+            return self.decode(row[1])
+
+    def lrange(self, key: KeyT, start: int, end: int) -> list[Any]:
+        """Get a range of elements from a list."""
+        with self._conn.cursor() as cursor:
+            positions = self._list_positions(cursor, key)
+            if not positions:
+                return []
+
+            length = len(positions)
+            # Resolve negative indices
+            if start < 0:
+                start = length + start
+            if end < 0:
+                end = length + end
+            start = max(0, start)
+            end = min(length - 1, end)
+
+            if start > end:
+                return []
+
+            selected_positions = positions[start : end + 1]
+            if not selected_positions:
+                return []
+
+            placeholders = ", ".join(["%s"] * len(selected_positions))
+            cursor.execute(
+                f"SELECT pos, value FROM {self._table}_lists WHERE key = %s AND pos IN ({placeholders}) ORDER BY pos",
+                [key, *selected_positions],
+            )
+            return [self.decode(row[1]) for row in cursor.fetchall()]
+
+    def lindex(self, key: KeyT, index: int) -> Any | None:
+        """Get an element from a list by index."""
+        with self._conn.cursor() as cursor:
+            positions = self._list_positions(cursor, key)
+            pos = self._resolve_list_index(positions, index)
+            if pos is None:
+                return None
+            cursor.execute(
+                f"SELECT value FROM {self._table}_lists WHERE key = %s AND pos = %s",
+                [key, pos],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return self.decode(row[0])
+
+    def llen(self, key: KeyT) -> int:
+        """Get the length of a list."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT COUNT(*) FROM {self._table}_lists l
+                INNER JOIN {self._table} m ON m.key = l.key
+                WHERE l.key = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, _TYPE_LIST],
+            )
+            return cursor.fetchone()[0]
+
+    def lpos(  # noqa: C901, PLR0911, PLR0912
+        self,
+        key: KeyT,
+        value: Any,
+        rank: int | None = None,
+        count: int | None = None,
+        maxlen: int | None = None,
+    ) -> int | list[int] | None:
+        """Find position(s) of element in list."""
+        encoded = self.encode(value)
+        bytea = self._to_bytea(encoded)
+
+        with self._conn.cursor() as cursor:
+            positions = self._list_positions(cursor, key)
+            if not positions:
+                if count is not None:
+                    return []
+                return None
+
+            # Fetch all values in order
+            if maxlen is not None:
+                scan_positions = positions[:maxlen]
+            else:
+                scan_positions = positions
+
+            if not scan_positions:
+                if count is not None:
+                    return []
+                return None
+
+            placeholders = ", ".join(["%s"] * len(scan_positions))
+            cursor.execute(
+                f"SELECT pos, value FROM {self._table}_lists WHERE key = %s AND pos IN ({placeholders}) ORDER BY pos",
+                [key, *scan_positions],
+            )
+            rows = cursor.fetchall()
+
+        # Build position->index mapping
+        pos_to_idx = {p: i for i, p in enumerate(positions)}
+
+        # Find matching indices
+        matching_indices: list[int] = []
+        for pos, val in rows:
+            if bytes(val) if isinstance(val, memoryview) else val == bytea:
+                matching_indices.append(pos_to_idx[pos])
+
+        if not matching_indices:
+            if count is not None:
+                return []
+            return None
+
+        # Apply rank
+        if rank is not None:
+            if rank > 0:
+                idx = rank - 1
+                if idx >= len(matching_indices):
+                    if count is not None:
+                        return []
+                    return None
+                matching_indices = matching_indices[idx:]
+            elif rank < 0:
+                idx = len(matching_indices) + rank
+                if idx < 0:
+                    if count is not None:
+                        return []
+                    return None
+                matching_indices = matching_indices[: idx + 1]
+                matching_indices.reverse()
+
+        if count is not None:
+            if count == 0:
+                return matching_indices
+            return matching_indices[:count]
+
+        return matching_indices[0] if matching_indices else None
+
+    def lmove(
+        self,
+        src: KeyT,
+        dst: KeyT,
+        wherefrom: str,
+        whereto: str,
+    ) -> Any | None:
+        """Atomically move an element from one list to another."""
+        with self._conn.cursor() as cursor:
+            # Pop from source
+            if wherefrom.upper() == "LEFT":
+                cursor.execute(
+                    f"SELECT pos, value FROM {self._table}_lists WHERE key = %s ORDER BY pos LIMIT 1",
+                    [src],
+                )
+            else:
+                cursor.execute(
+                    f"SELECT pos, value FROM {self._table}_lists WHERE key = %s ORDER BY pos DESC LIMIT 1",
+                    [src],
+                )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+
+            pos, val = row
+            cursor.execute(
+                f"DELETE FROM {self._table}_lists WHERE key = %s AND pos = %s",
+                [src, pos],
+            )
+
+            # Push to destination
+            self._ensure_key(cursor, dst, _TYPE_LIST)
+            if whereto.upper() == "LEFT":
+                min_pos, _ = self._list_bounds(cursor, dst)
+                new_pos = (min_pos - 1) if min_pos is not None else 0
+            else:
+                _, max_pos = self._list_bounds(cursor, dst)
+                new_pos = (max_pos + 1) if max_pos is not None else 0
+
+            bytea = bytes(val) if isinstance(val, memoryview) else val
+            cursor.execute(
+                f"INSERT INTO {self._table}_lists (key, pos, value) VALUES (%s, %s, %s)",
+                [dst, new_pos, bytea],
+            )
+            return self.decode(val)
+
+    def lrem(self, key: KeyT, count: int, value: Any) -> int:
+        """Remove elements from a list."""
+        encoded = self.encode(value)
+        bytea = self._to_bytea(encoded)
+
+        with self._conn.cursor() as cursor:
+            if count == 0:
+                # Remove all occurrences
+                cursor.execute(
+                    f"DELETE FROM {self._table}_lists WHERE key = %s AND value = %s",
+                    [key, bytea],
+                )
+                return cursor.rowcount
+            if count > 0:
+                # Remove first `count` occurrences (from head)
+                cursor.execute(
+                    f"""
+                    DELETE FROM {self._table}_lists
+                    WHERE (key, pos) IN (
+                        SELECT key, pos FROM {self._table}_lists
+                        WHERE key = %s AND value = %s
+                        ORDER BY pos LIMIT %s
+                    )
+                    """,
+                    [key, bytea, count],
+                )
+                return cursor.rowcount
+            # Remove last |count| occurrences (from tail)
+            cursor.execute(
+                f"""
+                    DELETE FROM {self._table}_lists
+                    WHERE (key, pos) IN (
+                        SELECT key, pos FROM {self._table}_lists
+                        WHERE key = %s AND value = %s
+                        ORDER BY pos DESC LIMIT %s
+                    )
+                    """,
+                [key, bytea, -count],
+            )
+            return cursor.rowcount
+
+    def ltrim(self, key: KeyT, start: int, end: int) -> bool:
+        """Trim a list to the specified range."""
+        with self._conn.cursor() as cursor:
+            positions = self._list_positions(cursor, key)
+            if not positions:
+                return True
+
+            length = len(positions)
+            if start < 0:
+                start = length + start
+            if end < 0:
+                end = length + end
+            start = max(0, start)
+            end = min(length - 1, end)
+
+            if start > end:
+                # Delete everything
+                cursor.execute(
+                    f"DELETE FROM {self._table}_lists WHERE key = %s",
+                    [key],
+                )
+                return True
+
+            keep_positions = set(positions[start : end + 1])
+            delete_positions = [p for p in positions if p not in keep_positions]
+
+            if delete_positions:
+                placeholders = ", ".join(["%s"] * len(delete_positions))
+                cursor.execute(
+                    f"DELETE FROM {self._table}_lists WHERE key = %s AND pos IN ({placeholders})",
+                    [key, *delete_positions],
+                )
+        return True
+
+    def lset(self, key: KeyT, index: int, value: Any) -> bool:
+        """Set an element in a list by index."""
+        encoded = self.encode(value)
+        bytea = self._to_bytea(encoded)
+
+        with self._conn.cursor() as cursor:
+            positions = self._list_positions(cursor, key)
+            pos = self._resolve_list_index(positions, index)
+            if pos is None:
+                raise IndexError("list index out of range")
+            cursor.execute(
+                f"UPDATE {self._table}_lists SET value = %s WHERE key = %s AND pos = %s",
+                [bytea, key, pos],
+            )
+        return True
+
+    def linsert(
+        self,
+        key: KeyT,
+        where: str,
+        pivot: Any,
+        value: Any,
+    ) -> int:
+        """Insert an element before or after another element."""
+        encoded_pivot = self.encode(pivot)
+        bytea_pivot = self._to_bytea(encoded_pivot)
+        encoded_value = self.encode(value)
+        bytea_value = self._to_bytea(encoded_value)
+
+        with self._conn.cursor() as cursor:
+            # Check key exists and is not expired
+            cursor.execute(
+                f"SELECT 1 FROM {self._table} WHERE key = %s AND type = %s {self._expiry_filter()}",
+                [key, _TYPE_LIST],
+            )
+            if cursor.fetchone() is None:
+                return 0
+
+            # Find the pivot position
+            cursor.execute(
+                f"SELECT pos FROM {self._table}_lists WHERE key = %s AND value = %s ORDER BY pos LIMIT 1",
+                [key, bytea_pivot],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return -1
+
+            pivot_pos = row[0]
+
+            if where.upper() == "BEFORE":
+                # Insert before: find a position between the previous element and pivot
+                cursor.execute(
+                    f"SELECT MAX(pos) FROM {self._table}_lists WHERE key = %s AND pos < %s",
+                    [key, pivot_pos],
+                )
+                prev_row = cursor.fetchone()
+                if prev_row[0] is None:
+                    new_pos = pivot_pos - 1
+                else:
+                    new_pos = prev_row[0] + 1
+                    if new_pos >= pivot_pos:
+                        # Need to make room: shift pivot and everything after up
+                        cursor.execute(
+                            f"UPDATE {self._table}_lists SET pos = pos + 1 WHERE key = %s AND pos >= %s",
+                            [key, pivot_pos],
+                        )
+                        new_pos = pivot_pos
+            else:
+                # Insert after: find a position between pivot and next element
+                cursor.execute(
+                    f"SELECT MIN(pos) FROM {self._table}_lists WHERE key = %s AND pos > %s",
+                    [key, pivot_pos],
+                )
+                next_row = cursor.fetchone()
+                if next_row[0] is None:
+                    new_pos = pivot_pos + 1
+                else:
+                    new_pos = pivot_pos + 1
+                    if new_pos >= next_row[0]:
+                        # Need to make room: shift everything after pivot up
+                        cursor.execute(
+                            f"UPDATE {self._table}_lists SET pos = pos + 1 WHERE key = %s AND pos > %s",
+                            [key, pivot_pos],
+                        )
+                        new_pos = pivot_pos + 1
+
+            cursor.execute(
+                f"INSERT INTO {self._table}_lists (key, pos, value) VALUES (%s, %s, %s)",
+                [key, new_pos, bytea_value],
+            )
+            cursor.execute(
+                f"SELECT COUNT(*) FROM {self._table}_lists WHERE key = %s",
+                [key],
+            )
+            return cursor.fetchone()[0]
+
+    # =========================================================================
+    # Set Operations
+    # =========================================================================
+
+    def sadd(self, key: KeyT, *members: Any) -> int:
+        """Add members to a set."""
+        if not members:
+            return 0
+        count = 0
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, key, _TYPE_SET)
+            for m in members:
+                encoded = self.encode(m)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"""
+                    INSERT INTO {self._table}_sets (key, member)
+                    VALUES (%s, %s)
+                    ON CONFLICT (key, member) DO NOTHING
+                    """,
+                    [key, bytea],
+                )
+                count += cursor.rowcount
+        return count
+
+    def scard(self, key: KeyT) -> int:
+        """Get the number of members in a set."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT COUNT(*) FROM {self._table}_sets s
+                INNER JOIN {self._table} m ON m.key = s.key
+                WHERE s.key = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, _TYPE_SET],
+            )
+            return cursor.fetchone()[0]
+
+    def sismember(self, key: KeyT, member: Any) -> bool:
+        """Check if a value is a member of a set."""
+        encoded = self.encode(member)
+        bytea = self._to_bytea(encoded)
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT 1 FROM {self._table}_sets s
+                INNER JOIN {self._table} m ON m.key = s.key
+                WHERE s.key = %s AND s.member = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, bytea, _TYPE_SET],
+            )
+            return cursor.fetchone() is not None
+
+    def smismember(self, key: KeyT, *members: Any) -> list[bool]:
+        """Check if multiple values are members of a set."""
+        if not members:
+            return []
+        results = []
+        with self._conn.cursor() as cursor:
+            for m in members:
+                encoded = self.encode(m)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"""
+                    SELECT 1 FROM {self._table}_sets s
+                    INNER JOIN {self._table} m ON m.key = s.key
+                    WHERE s.key = %s AND s.member = %s AND m.type = %s {self._expiry_filter()}
+                    """,
+                    [key, bytea, _TYPE_SET],
+                )
+                results.append(cursor.fetchone() is not None)
+        return results
+
+    def smembers(self, key: KeyT) -> builtins.set[Any]:
+        """Get all members of a set."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT s.member FROM {self._table}_sets s
+                INNER JOIN {self._table} m ON m.key = s.key
+                WHERE s.key = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, _TYPE_SET],
+            )
+            return {self.decode(row[0]) for row in cursor.fetchall()}
+
+    def srandmember(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
+        """Get random member(s) from a set."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT s.member FROM {self._table}_sets s
+                INNER JOIN {self._table} m ON m.key = s.key
+                WHERE s.key = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, _TYPE_SET],
+            )
+            rows = cursor.fetchall()
+
+        if not rows:
+            if count is not None:
+                return []
+            return None
+
+        members = [row[0] for row in rows]
+
+        if count is None:
+            return self.decode(random.choice(members))  # noqa: S311
+
+        if count >= 0:
+            sample = random.sample(members, min(count, len(members)))
+            return [self.decode(m) for m in sample]
+        # Negative count: allow duplicates
+        result = random.choices(members, k=-count)  # noqa: S311
+        return [self.decode(m) for m in result]
+
+    def spop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
+        """Remove and return random member(s) from a set."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT s.member FROM {self._table}_sets s
+                INNER JOIN {self._table} m ON m.key = s.key
+                WHERE s.key = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, _TYPE_SET],
+            )
+            rows = cursor.fetchall()
+
+        if not rows:
+            if count is not None:
+                return []
+            return None
+
+        members = [row[0] for row in rows]
+
+        if count is None:
+            chosen = random.choice(members)  # noqa: S311
+            with self._conn.cursor() as cursor:
+                cursor.execute(
+                    f"DELETE FROM {self._table}_sets WHERE key = %s AND member = %s",
+                    [key, chosen],
+                )
+            return self.decode(chosen)
+
+        selected = random.sample(members, min(count, len(members)))
+        if selected:
+            with self._conn.cursor() as cursor:
+                placeholders = ", ".join(["%s"] * len(selected))
+                cursor.execute(
+                    f"DELETE FROM {self._table}_sets WHERE key = %s AND member IN ({placeholders})",
+                    [key, *selected],
+                )
+        return [self.decode(m) for m in selected]
+
+    def srem(self, key: KeyT, *members: Any) -> int:
+        """Remove members from a set."""
+        if not members:
+            return 0
+        count = 0
+        with self._conn.cursor() as cursor:
+            for m in members:
+                encoded = self.encode(m)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"DELETE FROM {self._table}_sets WHERE key = %s AND member = %s",
+                    [key, bytea],
+                )
+                count += cursor.rowcount
+        return count
+
+    def smove(self, src: KeyT, dst: KeyT, member: Any) -> bool:
+        """Move a member from one set to another."""
+        encoded = self.encode(member)
+        bytea = self._to_bytea(encoded)
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"DELETE FROM {self._table}_sets WHERE key = %s AND member = %s",
+                [src, bytea],
+            )
+            if cursor.rowcount == 0:
+                return False
+            self._ensure_key(cursor, dst, _TYPE_SET)
+            cursor.execute(
+                f"""
+                INSERT INTO {self._table}_sets (key, member)
+                VALUES (%s, %s)
+                ON CONFLICT (key, member) DO NOTHING
+                """,
+                [dst, bytea],
+            )
+        return True
+
+    def _set_op_members(self, cursor: Any, keys: KeyT | Sequence[KeyT]) -> list[builtins.set[bytes]]:
+        """Fetch set members for multiple keys, returned as list of byte-sets."""
+        if isinstance(keys, (str, bytes, memoryview)):
+            keys = [keys]
+        result = []
+        for k in keys:
+            cursor.execute(
+                f"""
+                SELECT s.member FROM {self._table}_sets s
+                INNER JOIN {self._table} m ON m.key = s.key
+                WHERE s.key = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [k, _TYPE_SET],
+            )
+            members = set()
+            for row in cursor.fetchall():
+                val = row[0]
+                members.add(bytes(val) if isinstance(val, memoryview) else val)
+            result.append(members)
+        return result
+
+    def sdiff(self, keys: KeyT | Sequence[KeyT]) -> builtins.set[Any]:
+        """Return the difference of sets."""
+        with self._conn.cursor() as cursor:
+            sets = self._set_op_members(cursor, keys)
+        if not sets:
+            return set()
+        result = sets[0]
+        for s in sets[1:]:
+            result = result - s
+        return {self.decode(v) for v in result}
+
+    def sdiffstore(self, dest: KeyT, keys: KeyT | Sequence[KeyT]) -> int:
+        """Store the difference of sets."""
+        diff = self.sdiff(keys)
+        # Store result
+        self.delete(dest)
+        if not diff:
+            return 0
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, dest, _TYPE_SET)
+            for member in diff:
+                encoded = self.encode(member)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"INSERT INTO {self._table}_sets (key, member) VALUES (%s, %s) ON CONFLICT DO NOTHING",
+                    [dest, bytea],
+                )
+        return len(diff)
+
+    def sinter(self, keys: KeyT | Sequence[KeyT]) -> builtins.set[Any]:
+        """Return the intersection of sets."""
+        with self._conn.cursor() as cursor:
+            sets = self._set_op_members(cursor, keys)
+        if not sets:
+            return set()
+        result = sets[0]
+        for s in sets[1:]:
+            result = result & s
+        return {self.decode(v) for v in result}
+
+    def sinterstore(self, dest: KeyT, keys: KeyT | Sequence[KeyT]) -> int:
+        """Store the intersection of sets."""
+        inter = self.sinter(keys)
+        self.delete(dest)
+        if not inter:
+            return 0
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, dest, _TYPE_SET)
+            for member in inter:
+                encoded = self.encode(member)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"INSERT INTO {self._table}_sets (key, member) VALUES (%s, %s) ON CONFLICT DO NOTHING",
+                    [dest, bytea],
+                )
+        return len(inter)
+
+    def sunion(self, keys: KeyT | Sequence[KeyT]) -> builtins.set[Any]:
+        """Return the union of sets."""
+        with self._conn.cursor() as cursor:
+            sets = self._set_op_members(cursor, keys)
+        if not sets:
+            return set()
+        result: set[bytes] = set()
+        for s in sets:
+            result = result | s
+        return {self.decode(v) for v in result}
+
+    def sunionstore(self, dest: KeyT, keys: KeyT | Sequence[KeyT]) -> int:
+        """Store the union of sets."""
+        union = self.sunion(keys)
+        self.delete(dest)
+        if not union:
+            return 0
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, dest, _TYPE_SET)
+            for member in union:
+                encoded = self.encode(member)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"INSERT INTO {self._table}_sets (key, member) VALUES (%s, %s) ON CONFLICT DO NOTHING",
+                    [dest, bytea],
+                )
+        return len(union)
+
+    # =========================================================================
+    # Sorted Set Operations
+    # =========================================================================
+
+    def zadd(  # noqa: C901
+        self,
+        key: KeyT,
+        mapping: Mapping[Any, float],
+        *,
+        nx: bool = False,
+        xx: bool = False,
+        gt: bool = False,
+        lt: bool = False,
+        ch: bool = False,
+    ) -> int:
+        """Add members to a sorted set."""
+        if not mapping:
+            return 0
+
+        count = 0
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, key, _TYPE_ZSET)
+            for member, score in mapping.items():
+                encoded = self.encode(member)
+                bytea = self._to_bytea(encoded)
+
+                # Check if member exists
+                cursor.execute(
+                    f"SELECT score FROM {self._table}_zsets WHERE key = %s AND member = %s FOR UPDATE",
+                    [key, bytea],
+                )
+                row = cursor.fetchone()
+
+                if row is None:
+                    # Member doesn't exist
+                    if xx:
+                        continue
+                    cursor.execute(
+                        f"INSERT INTO {self._table}_zsets (key, member, score) VALUES (%s, %s, %s)",
+                        [key, bytea, score],
+                    )
+                    count += 1
+                else:
+                    # Member exists
+                    if nx:
+                        continue
+                    old_score = row[0]
+                    new_score = score
+                    should_update = True
+
+                    if gt and lt:
+                        should_update = False
+                    elif gt:
+                        should_update = new_score > old_score
+                    elif lt:
+                        should_update = new_score < old_score
+
+                    if should_update:
+                        cursor.execute(
+                            f"UPDATE {self._table}_zsets SET score = %s WHERE key = %s AND member = %s",
+                            [new_score, key, bytea],
+                        )
+                        if ch and old_score != new_score:
+                            count += 1
+                    # If ch and not updated, don't count
+        return count
+
+    def zcard(self, key: KeyT) -> int:
+        """Get the number of members in a sorted set."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT COUNT(*) FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, _TYPE_ZSET],
+            )
+            return cursor.fetchone()[0]
+
+    def zcount(self, key: KeyT, min_score: float | str, max_score: float | str) -> int:
+        """Count members in a score range."""
+        min_inclusive, min_val = _parse_score_bound(min_score)
+        max_inclusive, max_val = _parse_score_bound(max_score)
+
+        min_op = ">=" if min_inclusive else ">"
+        max_op = "<=" if max_inclusive else "<"
+
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT COUNT(*) FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+                AND z.score {min_op} %s AND z.score {max_op} %s
+                """,
+                [key, _TYPE_ZSET, min_val, max_val],
+            )
+            return cursor.fetchone()[0]
+
+    def zincrby(self, key: KeyT, amount: float, member: Any) -> float:
+        """Increment the score of a member."""
+        encoded = self.encode(member)
+        bytea = self._to_bytea(encoded)
+        with self._conn.cursor() as cursor:
+            self._ensure_key(cursor, key, _TYPE_ZSET)
+            cursor.execute(
+                f"SELECT score FROM {self._table}_zsets WHERE key = %s AND member = %s FOR UPDATE",
+                [key, bytea],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                cursor.execute(
+                    f"INSERT INTO {self._table}_zsets (key, member, score) VALUES (%s, %s, %s)",
+                    [key, bytea, amount],
+                )
+                return float(amount)
+            new_score = row[0] + amount
+            cursor.execute(
+                f"UPDATE {self._table}_zsets SET score = %s WHERE key = %s AND member = %s",
+                [new_score, key, bytea],
+            )
+            return float(new_score)
+
+    def zpopmin(self, key: KeyT, count: int = 1) -> list[tuple[Any, float]]:
+        """Remove and return members with lowest scores."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT z.member, z.score FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+                ORDER BY z.score, z.member LIMIT %s
+                """,
+                [key, _TYPE_ZSET, count],
+            )
+            rows = cursor.fetchall()
+            if not rows:
+                return []
+            for member, _score in rows:
+                cursor.execute(
+                    f"DELETE FROM {self._table}_zsets WHERE key = %s AND member = %s",
+                    [key, member],
+                )
+            return [(self.decode(m), float(s)) for m, s in rows]
+
+    def zpopmax(self, key: KeyT, count: int = 1) -> list[tuple[Any, float]]:
+        """Remove and return members with highest scores."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT z.member, z.score FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+                ORDER BY z.score DESC, z.member DESC LIMIT %s
+                """,
+                [key, _TYPE_ZSET, count],
+            )
+            rows = cursor.fetchall()
+            if not rows:
+                return []
+            for member, _score in rows:
+                cursor.execute(
+                    f"DELETE FROM {self._table}_zsets WHERE key = %s AND member = %s",
+                    [key, member],
+                )
+            return [(self.decode(m), float(s)) for m, s in rows]
+
+    def zrange(
+        self,
+        key: KeyT,
+        start: int,
+        end: int,
+        *,
+        withscores: bool = False,
+    ) -> list[Any] | list[tuple[Any, float]]:
+        """Get a range of members by index."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT member, score FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+                ORDER BY z.score, z.member
+                """,
+                [key, _TYPE_ZSET],
+            )
+            all_rows = cursor.fetchall()
+
+        if not all_rows:
+            return []
+
+        length = len(all_rows)
+        if start < 0:
+            start = length + start
+        if end < 0:
+            end = length + end
+        start = max(0, start)
+        end = min(length - 1, end)
+
+        if start > end:
+            return []
+
+        selected = all_rows[start : end + 1]
+        if withscores:
+            return [(self.decode(m), float(s)) for m, s in selected]
+        return [self.decode(m) for m, s in selected]
+
+    def zrevrange(
+        self,
+        key: KeyT,
+        start: int,
+        end: int,
+        *,
+        withscores: bool = False,
+    ) -> list[Any] | list[tuple[Any, float]]:
+        """Get a range of members by index, reversed."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT member, score FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+                ORDER BY z.score DESC, z.member DESC
+                """,
+                [key, _TYPE_ZSET],
+            )
+            all_rows = cursor.fetchall()
+
+        if not all_rows:
+            return []
+
+        length = len(all_rows)
+        if start < 0:
+            start = length + start
+        if end < 0:
+            end = length + end
+        start = max(0, start)
+        end = min(length - 1, end)
+
+        if start > end:
+            return []
+
+        selected = all_rows[start : end + 1]
+        if withscores:
+            return [(self.decode(m), float(s)) for m, s in selected]
+        return [self.decode(m) for m, s in selected]
+
+    def zrangebyscore(
+        self,
+        key: KeyT,
+        min_score: float | str,
+        max_score: float | str,
+        *,
+        start: int | None = None,
+        num: int | None = None,
+        withscores: bool = False,
+    ) -> list[Any] | list[tuple[Any, float]]:
+        """Get members by score range."""
+        min_inclusive, min_val = _parse_score_bound(min_score)
+        max_inclusive, max_val = _parse_score_bound(max_score)
+
+        min_op = ">=" if min_inclusive else ">"
+        max_op = "<=" if max_inclusive else "<"
+
+        sql = f"""
+            SELECT z.member, z.score FROM {self._table}_zsets z
+            INNER JOIN {self._table} m ON m.key = z.key
+            WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+            AND z.score {min_op} %s AND z.score {max_op} %s
+            ORDER BY z.score, z.member
+        """
+        params: list[Any] = [key, _TYPE_ZSET, min_val, max_val]
+
+        if start is not None and num is not None:
+            sql += " LIMIT %s OFFSET %s"
+            params.extend([num, start])
+
+        with self._conn.cursor() as cursor:
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+
+        if withscores:
+            return [(self.decode(m), float(s)) for m, s in rows]
+        return [self.decode(m) for m, s in rows]
+
+    def zrevrangebyscore(
+        self,
+        key: KeyT,
+        max_score: float | str,
+        min_score: float | str,
+        *,
+        start: int | None = None,
+        num: int | None = None,
+        withscores: bool = False,
+    ) -> list[Any] | list[tuple[Any, float]]:
+        """Get members by score range, reversed."""
+        min_inclusive, min_val = _parse_score_bound(min_score)
+        max_inclusive, max_val = _parse_score_bound(max_score)
+
+        min_op = ">=" if min_inclusive else ">"
+        max_op = "<=" if max_inclusive else "<"
+
+        sql = f"""
+            SELECT z.member, z.score FROM {self._table}_zsets z
+            INNER JOIN {self._table} m ON m.key = z.key
+            WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+            AND z.score {min_op} %s AND z.score {max_op} %s
+            ORDER BY z.score DESC, z.member DESC
+        """
+        params: list[Any] = [key, _TYPE_ZSET, min_val, max_val]
+
+        if start is not None and num is not None:
+            sql += " LIMIT %s OFFSET %s"
+            params.extend([num, start])
+
+        with self._conn.cursor() as cursor:
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+
+        if withscores:
+            return [(self.decode(m), float(s)) for m, s in rows]
+        return [self.decode(m) for m, s in rows]
+
+    def zrank(self, key: KeyT, member: Any) -> int | None:
+        """Get the rank of a member (0-based)."""
+        encoded = self.encode(member)
+        bytea = self._to_bytea(encoded)
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT member, score FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+                ORDER BY z.score, z.member
+                """,
+                [key, _TYPE_ZSET],
+            )
+            for i, row in enumerate(cursor.fetchall()):
+                raw_member = bytes(row[0]) if isinstance(row[0], memoryview) else row[0]
+                if raw_member == bytea:
+                    return i
+        return None
+
+    def zrevrank(self, key: KeyT, member: Any) -> int | None:
+        """Get the reverse rank of a member."""
+        encoded = self.encode(member)
+        bytea = self._to_bytea(encoded)
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT member, score FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+                ORDER BY z.score DESC, z.member DESC
+                """,
+                [key, _TYPE_ZSET],
+            )
+            for i, row in enumerate(cursor.fetchall()):
+                raw_member = bytes(row[0]) if isinstance(row[0], memoryview) else row[0]
+                if raw_member == bytea:
+                    return i
+        return None
+
+    def zrem(self, key: KeyT, *members: Any) -> int:
+        """Remove members from a sorted set."""
+        if not members:
+            return 0
+        count = 0
+        with self._conn.cursor() as cursor:
+            for m in members:
+                encoded = self.encode(m)
+                bytea = self._to_bytea(encoded)
+                cursor.execute(
+                    f"DELETE FROM {self._table}_zsets WHERE key = %s AND member = %s",
+                    [key, bytea],
+                )
+                count += cursor.rowcount
+        return count
+
+    def zremrangebyscore(self, key: KeyT, min_score: float | str, max_score: float | str) -> int:
+        """Remove members by score range."""
+        min_inclusive, min_val = _parse_score_bound(min_score)
+        max_inclusive, max_val = _parse_score_bound(max_score)
+
+        min_op = ">=" if min_inclusive else ">"
+        max_op = "<=" if max_inclusive else "<"
+
+        with self._conn.cursor() as cursor:
+            # Check key exists and is not expired
+            cursor.execute(
+                f"SELECT 1 FROM {self._table} WHERE key = %s AND type = %s {self._expiry_filter()}",
+                [key, _TYPE_ZSET],
+            )
+            if cursor.fetchone() is None:
+                return 0
+            cursor.execute(
+                f"""
+                DELETE FROM {self._table}_zsets
+                WHERE key = %s AND score {min_op} %s AND score {max_op} %s
+                """,
+                [key, min_val, max_val],
+            )
+            return cursor.rowcount
+
+    def zremrangebyrank(self, key: KeyT, start: int, end: int) -> int:
+        """Remove members by rank range."""
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT z.member, z.score FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND m.type = %s {self._expiry_filter()}
+                ORDER BY z.score, z.member
+                """,
+                [key, _TYPE_ZSET],
+            )
+            all_rows = cursor.fetchall()
+
+        if not all_rows:
+            return 0
+
+        length = len(all_rows)
+        if start < 0:
+            start = length + start
+        if end < 0:
+            end = length + end
+        start = max(0, start)
+        end = min(length - 1, end)
+
+        if start > end:
+            return 0
+
+        to_remove = all_rows[start : end + 1]
+        with self._conn.cursor() as cursor:
+            for member, _score in to_remove:
+                cursor.execute(
+                    f"DELETE FROM {self._table}_zsets WHERE key = %s AND member = %s",
+                    [key, member],
+                )
+        return len(to_remove)
+
+    def zscore(self, key: KeyT, member: Any) -> float | None:
+        """Get the score of a member."""
+        encoded = self.encode(member)
+        bytea = self._to_bytea(encoded)
+        with self._conn.cursor() as cursor:
+            cursor.execute(
+                f"""
+                SELECT z.score FROM {self._table}_zsets z
+                INNER JOIN {self._table} m ON m.key = z.key
+                WHERE z.key = %s AND z.member = %s AND m.type = %s {self._expiry_filter()}
+                """,
+                [key, bytea, _TYPE_ZSET],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return float(row[0])
+
+    def zmscore(self, key: KeyT, *members: Any) -> list[float | None]:
+        """Get scores for multiple members."""
+        return [self.zscore(key, m) for m in members]
+
+    # =========================================================================
+    # Not Supported Operations
+    # =========================================================================
+
+    # Stream operations
+    xadd = _not_supported("xadd")
+    xlen = _not_supported("xlen")
+    xrange = _not_supported("xrange")
+    xrevrange = _not_supported("xrevrange")
+    xread = _not_supported("xread")
+    xtrim = _not_supported("xtrim")
+    xdel = _not_supported("xdel")
+    xinfo_stream = _not_supported("xinfo_stream")
+    xinfo_groups = _not_supported("xinfo_groups")
+    xinfo_consumers = _not_supported("xinfo_consumers")
+    xgroup_create = _not_supported("xgroup_create")
+    xgroup_destroy = _not_supported("xgroup_destroy")
+    xgroup_setid = _not_supported("xgroup_setid")
+    xgroup_delconsumer = _not_supported("xgroup_delconsumer")
+    xreadgroup = _not_supported("xreadgroup")
+    xack = _not_supported("xack")
+    xpending = _not_supported("xpending")
+    xclaim = _not_supported("xclaim")
+    xautoclaim = _not_supported("xautoclaim")
+
+    # Lua scripts
+    eval = _not_supported("eval")
+
+    # Blocking operations
+    blpop = _not_supported("blpop")
+    brpop = _not_supported("brpop")
+    blmove = _not_supported("blmove")
+
+    # Set scan (use smembers instead)
+    sscan = _not_supported("sscan")
+    sscan_iter = _not_supported("sscan_iter")
+
+    # Pipeline
+    def pipeline(self, *, transaction: bool = True, version: int | None = None) -> Any:
+        """Not supported."""
+        raise NotSupportedError("pipeline", _BACKEND_NAME)
+
+    # Lock
+    def lock(self, key: str, **kwargs: Any) -> Any:
+        """Not supported."""
+        raise NotSupportedError("lock", _BACKEND_NAME)
+
+    def alock(self, key: str, **kwargs: Any) -> Any:
+        """Not supported."""
+        raise NotSupportedError("alock", _BACKEND_NAME)
+
+    # Client access
+    def get_client(self, key: KeyT | None = None, *, write: bool = False) -> Any:
+        """Return the Django database connection."""
+        return self._conn
+
+    def get_async_client(self, key: KeyT | None = None, *, write: bool = False) -> Any:
+        """Return the Django database connection."""
+        return self._conn
+
+    # Server info
+    def info(self, section: str | None = None) -> dict[str, Any]:
+        """Not supported."""
+        raise NotSupportedError("info", _BACKEND_NAME)
+
+    def slowlog_get(self, count: int = 10) -> list[Any]:
+        """Not supported."""
+        raise NotSupportedError("slowlog_get", _BACKEND_NAME)
+
+    def slowlog_len(self) -> int:
+        """Not supported."""
+        raise NotSupportedError("slowlog_len", _BACKEND_NAME)
+
+    # =========================================================================
+    # Async Wrappers
+    # =========================================================================
+
+    # Core
+    aget = _async("get")
+    aset = _async("set")
+    aadd = _async("add")
+    aset_with_flags = _async("set_with_flags")
+    adelete = _async("delete")
+    ahas_key = _async("has_key")
+    atouch = _async("touch")
+    aget_many = _async("get_many")
+    aset_many = _async("set_many")
+    adelete_many = _async("delete_many")
+    aincr = _async("incr")
+    aclear = _async("clear")
+    atype = _async("type")
+
+    # TTL
+    attl = _async("ttl")
+    apttl = _async("pttl")
+    aexpiretime = _async("expiretime")
+    aexpire = _async("expire")
+    apexpire = _async("pexpire")
+    aexpireat = _async("expireat")
+    apexpireat = _async("pexpireat")
+    apersist = _async("persist")
+
+    # Keys
+    akeys = _async("keys")
+    ascan = _async("scan")
+    adelete_pattern = _async("delete_pattern")
+    arename = _async("rename")
+    arenamenx = _async("renamenx")
+
+    # Hashes
+    ahset = _async("hset")
+    ahsetnx = _async("hsetnx")
+    ahget = _async("hget")
+    ahmget = _async("hmget")
+    ahgetall = _async("hgetall")
+    ahdel = _async("hdel")
+    ahexists = _async("hexists")
+    ahlen = _async("hlen")
+    ahkeys = _async("hkeys")
+    ahvals = _async("hvals")
+    ahincrby = _async("hincrby")
+    ahincrbyfloat = _async("hincrbyfloat")
+
+    # Lists
+    alpush = _async("lpush")
+    arpush = _async("rpush")
+    alpop = _async("lpop")
+    arpop = _async("rpop")
+    alrange = _async("lrange")
+    alindex = _async("lindex")
+    allen = _async("llen")
+    alpos = _async("lpos")
+    almove = _async("lmove")
+    alrem = _async("lrem")
+    altrim = _async("ltrim")
+    alset = _async("lset")
+    alinsert = _async("linsert")
+
+    # Sets
+    asadd = _async("sadd")
+    ascard = _async("scard")
+    asismember = _async("sismember")
+    asmismember = _async("smismember")
+    asmembers = _async("smembers")
+    asrandmember = _async("srandmember")
+    aspop = _async("spop")
+    asrem = _async("srem")
+    asmove = _async("smove")
+    asdiff = _async("sdiff")
+    asdiffstore = _async("sdiffstore")
+    asinter = _async("sinter")
+    asinterstore = _async("sinterstore")
+    asunion = _async("sunion")
+    asunionstore = _async("sunionstore")
+
+    # Sorted Sets
+    azadd = _async("zadd")
+    azcard = _async("zcard")
+    azcount = _async("zcount")
+    azincrby = _async("zincrby")
+    azpopmin = _async("zpopmin")
+    azpopmax = _async("zpopmax")
+    azrange = _async("zrange")
+    azrevrange = _async("zrevrange")
+    azrangebyscore = _async("zrangebyscore")
+    azrevrangebyscore = _async("zrevrangebyscore")
+    azrank = _async("zrank")
+    azrevrank = _async("zrevrank")
+    azrem = _async("zrem")
+    azremrangebyscore = _async("zremrangebyscore")
+    azremrangebyrank = _async("zremrangebyrank")
+    azscore = _async("zscore")
+    azmscore = _async("zmscore")
+
+    # Not supported async wrappers
+    axadd = _not_supported("axadd")
+    axlen = _not_supported("axlen")
+    axrange = _not_supported("axrange")
+    axrevrange = _not_supported("axrevrange")
+    axread = _not_supported("axread")
+    axtrim = _not_supported("axtrim")
+    axdel = _not_supported("axdel")
+    axinfo_stream = _not_supported("axinfo_stream")
+    axinfo_groups = _not_supported("axinfo_groups")
+    axinfo_consumers = _not_supported("axinfo_consumers")
+    axgroup_create = _not_supported("axgroup_create")
+    axgroup_destroy = _not_supported("axgroup_destroy")
+    axgroup_setid = _not_supported("axgroup_setid")
+    axgroup_delconsumer = _not_supported("axgroup_delconsumer")
+    axreadgroup = _not_supported("axreadgroup")
+    axack = _not_supported("axack")
+    axpending = _not_supported("axpending")
+    axclaim = _not_supported("axclaim")
+    axautoclaim = _not_supported("axautoclaim")
+    aeval = _not_supported("aeval")
+    ablpop = _not_supported("ablpop")
+    abrpop = _not_supported("abrpop")
+    ablmove = _not_supported("ablmove")
+    asscan = _not_supported("asscan")
+    asscan_iter = _not_supported("asscan_iter")
+
+    # iter_keys needs a proper async generator
+    async def aiter_keys(self, pattern: str, itersize: int | None = None) -> AsyncIterator[str]:
+        """Iterate keys matching pattern asynchronously."""
+        if itersize is None:
+            itersize = self._default_scan_itersize
+
+        cursor_val = 0
+        while True:
+            next_cursor, batch = await self.ascan(cursor=cursor_val, match=pattern, count=itersize)
+            for k in batch:
+                yield k
+            if next_cursor == 0:
+                break
+            cursor_val = next_cursor

--- a/django_cachex/postgres/__init__.py
+++ b/django_cachex/postgres/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "django_cachex.postgres.apps.PostgresCacheConfig"

--- a/django_cachex/postgres/apps.py
+++ b/django_cachex/postgres/apps.py
@@ -1,0 +1,12 @@
+"""Django app configuration for PostgreSQL cache tables."""
+
+from __future__ import annotations
+
+from django.apps import AppConfig
+
+
+class PostgresCacheConfig(AppConfig):
+    name = "django_cachex.postgres"
+    label = "cachex_postgres"
+    verbose_name = "Django Cachex PostgreSQL"
+    default_auto_field = "django.db.models.BigAutoField"

--- a/django_cachex/postgres/migrations/0001_initial.py
+++ b/django_cachex/postgres/migrations/0001_initial.py
@@ -1,0 +1,84 @@
+"""Initial migration — creates the five PostgreSQL cache tables as UNLOGGED."""
+
+import django.db.models
+from django.db import migrations, models
+
+from django_cachex.postgres.operations import CreateUnloggedModel
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        CreateUnloggedModel(
+            name="CacheEntry",
+            fields=[
+                ("key", models.TextField(primary_key=True, serialize=False)),
+                ("type", models.SmallIntegerField(default=0)),
+                ("value", models.BinaryField(blank=True, null=True)),
+                ("expires_at", models.DateTimeField(blank=True, null=True)),
+            ],
+            options={
+                "db_table": "cachex",
+                "indexes": [
+                    models.Index(
+                        fields=["expires_at"],
+                        condition=django.db.models.Q(expires_at__isnull=False),
+                        name="idx_cachex_expires",
+                    ),
+                ],
+            },
+        ),
+        CreateUnloggedModel(
+            name="CacheHash",
+            fields=[
+                ("pk", models.CompositePrimaryKey("key", "field")),
+                ("key", models.TextField()),
+                ("field", models.TextField()),
+                ("value", models.BinaryField()),
+            ],
+            options={
+                "db_table": "cachex_hashes",
+            },
+        ),
+        CreateUnloggedModel(
+            name="CacheList",
+            fields=[
+                ("pk", models.CompositePrimaryKey("key", "pos")),
+                ("key", models.TextField()),
+                ("pos", models.BigIntegerField()),
+                ("value", models.BinaryField()),
+            ],
+            options={
+                "db_table": "cachex_lists",
+            },
+        ),
+        CreateUnloggedModel(
+            name="CacheSet",
+            fields=[
+                ("pk", models.CompositePrimaryKey("key", "member")),
+                ("key", models.TextField()),
+                ("member", models.BinaryField()),
+            ],
+            options={
+                "db_table": "cachex_sets",
+            },
+        ),
+        CreateUnloggedModel(
+            name="CacheSortedSet",
+            fields=[
+                ("pk", models.CompositePrimaryKey("key", "member")),
+                ("key", models.TextField()),
+                ("member", models.BinaryField()),
+                ("score", models.FloatField()),
+            ],
+            options={
+                "db_table": "cachex_zsets",
+                "indexes": [
+                    models.Index(fields=["key", "score"], name="idx_cachex_zsets_score"),
+                ],
+            },
+        ),
+    ]

--- a/django_cachex/postgres/models.py
+++ b/django_cachex/postgres/models.py
@@ -1,0 +1,91 @@
+"""Django models for PostgreSQL cache tables.
+
+These models define the schema for the five tables used by the PostgreSQL cache
+backend. The tables are created as UNLOGGED by the initial migration, using
+:class:`~django_cachex.postgres.operations.CreateUnloggedModel`.
+
+Usage::
+
+    INSTALLED_APPS = [
+        ...,
+        "django_cachex.postgres",
+    ]
+
+Then run ``manage.py migrate`` to create the tables.
+
+The ``LOCATION`` in your ``CACHES`` setting must match the table prefix
+(default ``"cachex"``).
+"""
+
+from __future__ import annotations
+
+from django.db import models
+
+
+class CacheEntry(models.Model):
+    """Main key registry — stores string values and type/expiry metadata for all key types."""
+
+    key = models.TextField(primary_key=True)
+    type = models.SmallIntegerField(default=0)
+    value = models.BinaryField(null=True, blank=True)
+    expires_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = "cachex"
+        indexes = [
+            models.Index(
+                fields=["expires_at"],
+                condition=models.Q(expires_at__isnull=False),
+                name="idx_cachex_expires",
+            ),
+        ]
+
+
+class CacheHash(models.Model):
+    """Hash field storage — one row per (key, field) pair."""
+
+    pk = models.CompositePrimaryKey("key", "field")
+    key = models.TextField()
+    field = models.TextField()
+    value = models.BinaryField()
+
+    class Meta:
+        db_table = "cachex_hashes"
+
+
+class CacheList(models.Model):
+    """List item storage — sparse BIGINT positions for O(1) push/pop."""
+
+    pk = models.CompositePrimaryKey("key", "pos")
+    key = models.TextField()
+    pos = models.BigIntegerField()
+    value = models.BinaryField()
+
+    class Meta:
+        db_table = "cachex_lists"
+
+
+class CacheSet(models.Model):
+    """Set member storage — one row per (key, member) pair."""
+
+    pk = models.CompositePrimaryKey("key", "member")
+    key = models.TextField()
+    member = models.BinaryField()
+
+    class Meta:
+        db_table = "cachex_sets"
+
+
+class CacheSortedSet(models.Model):
+    """Sorted set storage — one row per (key, member) with a score for ordering."""
+
+    pk = models.CompositePrimaryKey("key", "member")
+    key = models.TextField()
+    member = models.BinaryField()
+    score = models.FloatField()
+
+    class Meta:
+        db_table = "cachex_zsets"
+        indexes = [
+            models.Index(fields=["key", "score"], name="idx_cachex_zsets_score"),
+        ]

--- a/django_cachex/postgres/operations.py
+++ b/django_cachex/postgres/operations.py
@@ -1,0 +1,34 @@
+"""Custom migration operations for PostgreSQL UNLOGGED tables."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import migrations
+
+
+class CreateUnloggedModel(migrations.CreateModel):
+    """Like CreateModel, but creates an UNLOGGED table on PostgreSQL.
+
+    UNLOGGED tables skip WAL writes (~2-3x faster), making them ideal for cache.
+    Data is truncated on crash, which is acceptable for ephemeral cache data.
+
+    On non-PostgreSQL backends this falls back to a regular CREATE TABLE.
+    """
+
+    def database_forwards(
+        self,
+        app_label: str,
+        schema_editor: Any,
+        from_state: Any,
+        to_state: Any,
+    ) -> None:
+        if schema_editor.connection.vendor == "postgresql":
+            original = schema_editor.sql_create_table
+            schema_editor.sql_create_table = "CREATE UNLOGGED TABLE %(table)s (%(definition)s)"
+            try:
+                super().database_forwards(app_label, schema_editor, from_state, to_state)
+            finally:
+                schema_editor.sql_create_table = original
+        else:
+            super().database_forwards(app_label, schema_editor, from_state, to_state)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ lz4 = ["lz4>=4.4.0"]
 zstd = ["backports-zstd>=1.3.0; python_version < '3.14'"]
 # Serializers
 msgpack = ["msgpack>=1.1.0"]
+# PostgreSQL backend
+postgres = ["psycopg[binary]>=3.1"]
 # Admin
 unfold = ["django-unfold>=0.70.0"]
 
@@ -60,6 +62,7 @@ dev = [
   "msgpack==1.1.2",
   "mypy==1.19.1",
   "pre-commit==4.5.1",
+  "psycopg==3.3.3",
   "pytest-asyncio==1.3.0",
   "pytest-cov==7.0.0",
   "pytest-django==4.12.0",
@@ -116,6 +119,17 @@ allow-star-arg-any = true      # Allow Any for *args and **kwargs
 suppress-none-returning = true # Don't require -> None on functions
 
 [tool.ruff.lint.per-file-ignores]
+"django_cachex/client/postgres.py" = [
+  "ARG001", # _not_supported factory has unused args by design
+  "S608",   # Table names from trusted Django CACHES config, not user input
+]
+"django_cachex/postgres/models.py" = [
+  "DJ008",  # Cache table models are internal, __str__ not useful
+  "RUF012", # Meta.indexes is standard Django pattern
+]
+"django_cachex/postgres/migrations/**" = [
+  "RUF012", # Mutable class defaults are standard Django migration pattern
+]
 "tests/**" = [
   "ANN",    # Type annotations not required in tests
   "ARG",    # Unused arguments common in fixtures

--- a/tests/cache/test_postgres.py
+++ b/tests/cache/test_postgres.py
@@ -1,0 +1,687 @@
+"""Tests for the PostgreSQL cache backend.
+
+Uses a PostgreSQL testcontainer, runs Django migrations to create the
+UNLOGGED tables, then exercises the full cache API through Django's
+cache framework.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from django.test import override_settings
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+from django_cachex.exceptions import NotSupportedError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from django_cachex.cache import KeyValueCache
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_PG_IMAGE = "postgres:17"
+_PG_DB = "cachex_test"
+_PG_USER = "cachex"
+_PG_PASS = "cachex"
+_DB_ALIAS = "pg_cache"
+
+
+@pytest.fixture(scope="session")
+def pg_container(django_db_blocker):
+    """Start a PostgreSQL 17 container and run migrations (session-scoped)."""
+    from django.core.management import call_command
+    from django.db import connections
+
+    container = DockerContainer(_PG_IMAGE)
+    container.with_env("POSTGRES_DB", _PG_DB)
+    container.with_env("POSTGRES_USER", _PG_USER)
+    container.with_env("POSTGRES_PASSWORD", _PG_PASS)
+    container.with_exposed_ports(5432)
+    container.start()
+    wait_for_logs(container, "database system is ready to accept connections", timeout=30)
+    time.sleep(1)
+    host = container.get_container_host_ip()
+    port = int(container.get_exposed_port(5432))
+
+    # Register the database alias so Django can connect
+    connections.settings[_DB_ALIAS] = {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": _PG_DB,
+        "USER": _PG_USER,
+        "PASSWORD": _PG_PASS,
+        "HOST": host,
+        "PORT": str(port),
+        "ATOMIC_REQUESTS": False,
+        "AUTOCOMMIT": True,
+        "CONN_MAX_AGE": 0,
+        "CONN_HEALTH_CHECKS": False,
+        "OPTIONS": {},
+        "TIME_ZONE": None,
+        "TEST": {
+            "CHARSET": None,
+            "COLLATION": None,
+            "MIGRATE": True,
+            "MIRROR": None,
+            "NAME": None,
+        },
+    }
+
+    # Unblock DB access for migration, then retry until PostgreSQL is ready
+    with django_db_blocker.unblock():
+        for attempt in range(10):
+            try:
+                call_command(
+                    "migrate",
+                    "cachex_postgres",
+                    database=_DB_ALIAS,
+                    verbosity=0,
+                )
+                break
+            except Exception:
+                if attempt == 9:
+                    raise
+                time.sleep(0.5)
+
+    yield {"host": host, "port": port}
+
+    with django_db_blocker.unblock():
+        try:
+            connections[_DB_ALIAS].close()
+            delattr(connections._connections, _DB_ALIAS)
+        except AttributeError:
+            pass
+    connections.settings.pop(_DB_ALIAS, None)
+    container.stop()
+
+
+@pytest.fixture
+def cache(pg_container, django_db_blocker) -> Iterator[KeyValueCache]:
+    """Provide a fresh PostgreSQLCache instance, cleared before and after each test."""
+    cache_settings = {
+        "default": {
+            "BACKEND": "django_cachex.cache.PostgreSQLCache",
+            "LOCATION": "cachex",
+            "OPTIONS": {
+                "DATABASE": _DB_ALIAS,
+            },
+        },
+    }
+
+    # Use django_db_blocker to allow database access without @pytest.mark.django_db.
+    # The mark doesn't work because it resolves databases="__all__" before our
+    # pg_cache alias is registered, then blocks access to it.
+    with django_db_blocker.unblock(), override_settings(CACHES=cache_settings):
+        from django.core.cache import cache as default_cache
+
+        pg_cache = cast("KeyValueCache", default_cache)
+        pg_cache.clear()
+        yield pg_cache
+        pg_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Core Cache Operations
+# ---------------------------------------------------------------------------
+
+
+class TestCoreOperations:
+    def test_set_and_get(self, cache: KeyValueCache):
+        cache.set("key1", "value1")
+        assert cache.get("key1") == "value1"
+
+    def test_get_missing(self, cache: KeyValueCache):
+        assert cache.get("nonexistent") is None
+
+    def test_set_overwrite(self, cache: KeyValueCache):
+        cache.set("k", "v1")
+        cache.set("k", "v2")
+        assert cache.get("k") == "v2"
+
+    def test_add_only_if_missing(self, cache: KeyValueCache):
+        assert cache.add("add_key", "first") is True
+        assert cache.add("add_key", "second") is False
+        assert cache.get("add_key") == "first"
+
+    def test_delete(self, cache: KeyValueCache):
+        cache.set("del_me", 1)
+        assert cache.delete("del_me") is True
+        assert cache.get("del_me") is None
+        assert cache.delete("del_me") is False
+
+    def test_has_key(self, cache: KeyValueCache):
+        cache.set("exists", "yes")
+        assert cache.has_key("exists") is True
+        assert cache.has_key("nope") is False
+
+    def test_get_many(self, cache: KeyValueCache):
+        cache.set("a", 1)
+        cache.set("b", 2)
+        result = cache.get_many(["a", "b", "c"])
+        assert result == {"a": 1, "b": 2}
+
+    def test_set_many(self, cache: KeyValueCache):
+        cache.set_many({"x": 10, "y": 20})
+        assert cache.get("x") == 10
+        assert cache.get("y") == 20
+
+    def test_delete_many(self, cache: KeyValueCache):
+        cache.set_many({"p": 1, "q": 2, "r": 3})
+        deleted = cache.delete_many(["p", "q"])
+        assert deleted == 2
+        assert cache.get("p") is None
+        assert cache.get("r") == 3
+
+    def test_incr_decr(self, cache: KeyValueCache):
+        cache.set("counter", 10)
+        assert cache.incr("counter") == 11
+        assert cache.incr("counter", 5) == 16
+        assert cache.decr("counter", 3) == 13
+
+    def test_incr_nonexistent_raises(self, cache: KeyValueCache):
+        with pytest.raises(ValueError):
+            cache.incr("missing_counter")
+
+    def test_clear(self, cache: KeyValueCache):
+        cache.set("a", 1)
+        cache.set("b", 2)
+        assert cache.clear() is True
+        assert cache.get("a") is None
+
+
+class TestDataTypes:
+    def test_integer(self, cache: KeyValueCache):
+        cache.set("int_val", 42)
+        assert cache.get("int_val") == 42
+
+    def test_float(self, cache: KeyValueCache):
+        cache.set("float_val", 3.14)
+        assert cache.get("float_val") == 3.14
+
+    def test_string(self, cache: KeyValueCache):
+        cache.set("str_val", "hello world")
+        assert cache.get("str_val") == "hello world"
+
+    def test_dict(self, cache: KeyValueCache):
+        cache.set("dict_val", {"a": 1, "b": [2, 3]})
+        assert cache.get("dict_val") == {"a": 1, "b": [2, 3]}
+
+    def test_list(self, cache: KeyValueCache):
+        cache.set("list_val", [1, "two", 3.0])
+        assert cache.get("list_val") == [1, "two", 3.0]
+
+    def test_bool(self, cache: KeyValueCache):
+        cache.set("bool_val", True)
+        assert cache.get("bool_val") is True
+
+    def test_none(self, cache: KeyValueCache):
+        cache.set("none_val", None)
+        # None as value should round-trip (pickle handles it)
+        assert cache.get("none_val") is None
+
+    def test_unicode(self, cache: KeyValueCache):
+        cache.set("unicode", "你好世界 🌍")
+        assert cache.get("unicode") == "你好世界 🌍"
+
+
+class TestSetFlags:
+    def test_set_nx(self, cache: KeyValueCache):
+        assert cache.set("nx_key", "first", nx=True) is True
+        assert cache.set("nx_key", "second", nx=True) is False
+        assert cache.get("nx_key") == "first"
+
+    def test_set_xx(self, cache: KeyValueCache):
+        assert cache.set("xx_key", "val", xx=True) is False
+        cache.set("xx_key", "exists")
+        assert cache.set("xx_key", "updated", xx=True) is True
+        assert cache.get("xx_key") == "updated"
+
+    def test_set_get(self, cache: KeyValueCache):
+        cache.set("get_key", "old")
+        old = cache.set("get_key", "new", get=True)
+        assert old == "old"
+        assert cache.get("get_key") == "new"
+
+    def test_set_get_missing(self, cache: KeyValueCache):
+        result = cache.set("get_missing", "val", get=True)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TTL Operations
+# ---------------------------------------------------------------------------
+
+
+class TestTTL:
+    def test_set_with_timeout(self, cache: KeyValueCache):
+        cache.set("ttl_key", "value", timeout=60)
+        ttl = cache.ttl("ttl_key")
+        assert ttl is not None
+        assert 0 < ttl <= 60
+
+    def test_ttl_no_expiry(self, cache: KeyValueCache):
+        cache.set("no_ttl", "value", timeout=None)
+        assert cache.ttl("no_ttl") is None
+
+    def test_ttl_missing_key(self, cache: KeyValueCache):
+        assert cache.ttl("gone") == -2
+
+    def test_pttl(self, cache: KeyValueCache):
+        cache.set("pttl_key", "value", timeout=60)
+        pttl = cache.pttl("pttl_key")
+        assert pttl is not None
+        assert 0 < pttl <= 60000
+
+    def test_persist(self, cache: KeyValueCache):
+        cache.set("persist_key", "value", timeout=60)
+        assert cache.persist("persist_key") is True
+        assert cache.ttl("persist_key") is None
+
+    def test_expire(self, cache: KeyValueCache):
+        cache.set("exp_key", "value", timeout=None)
+        assert cache.expire("exp_key", 30) is True
+        ttl = cache.ttl("exp_key")
+        assert ttl is not None
+        assert 0 < ttl <= 30
+
+    def test_touch(self, cache: KeyValueCache):
+        cache.set("touch_key", "value", timeout=10)
+        assert cache.touch("touch_key", timeout=60) is True
+        ttl = cache.ttl("touch_key")
+        assert ttl is not None
+        assert ttl > 10
+
+    def test_expiretime(self, cache: KeyValueCache):
+        cache.set("etime", "val", timeout=600)
+        etime = cache.expiretime("etime")
+        assert etime is not None
+        assert etime > 0
+
+
+# ---------------------------------------------------------------------------
+# Key Operations
+# ---------------------------------------------------------------------------
+
+
+class TestKeyOps:
+    def test_keys_pattern(self, cache: KeyValueCache):
+        cache.set("user:1", "a")
+        cache.set("user:2", "b")
+        cache.set("order:1", "c")
+        result = cache.keys("*user*")
+        assert sorted(result) == sorted([k for k in result if "user" in k])
+
+    def test_type_string(self, cache: KeyValueCache):
+        cache.set("str_type", "hello")
+        assert cache.type("str_type") is not None
+
+    def test_type_missing(self, cache: KeyValueCache):
+        assert cache.type("missing_type") is None
+
+    def test_delete_pattern(self, cache: KeyValueCache):
+        cache.set("dp:1", "a")
+        cache.set("dp:2", "b")
+        cache.set("other", "c")
+        deleted = cache.delete_pattern("dp:*")
+        assert deleted == 2
+        assert cache.get("other") == "c"
+
+    def test_rename(self, cache: KeyValueCache):
+        cache.set("src", "val")
+        cache.rename("src", "dst")
+        assert cache.get("src") is None
+        assert cache.get("dst") == "val"
+
+    def test_rename_missing_raises(self, cache: KeyValueCache):
+        with pytest.raises(ValueError):
+            cache.rename("no_such_key", "dst")
+
+    def test_scan(self, cache: KeyValueCache):
+        cache.set("scan:a", 1)
+        cache.set("scan:b", 2)
+        _, keys = cache.scan(pattern="scan:*")
+        assert set(keys) == {"scan:a", "scan:b"}
+
+
+# ---------------------------------------------------------------------------
+# Hash Operations
+# ---------------------------------------------------------------------------
+
+
+class TestHashes:
+    def test_hset_and_hget(self, cache: KeyValueCache):
+        cache.hset("h1", "field1", "value1")
+        assert cache.hget("h1", "field1") == "value1"
+        assert cache.hget("h1", "missing") is None
+
+    def test_hset_mapping(self, cache: KeyValueCache):
+        cache.hset("h2", mapping={"a": 1, "b": 2, "c": 3})
+        assert cache.hlen("h2") == 3
+        assert cache.hget("h2", "b") == 2
+
+    def test_hgetall(self, cache: KeyValueCache):
+        cache.hset("h3", mapping={"x": "hello", "y": 42})
+        result = cache.hgetall("h3")
+        assert result == {"x": "hello", "y": 42}
+
+    def test_hmget(self, cache: KeyValueCache):
+        cache.hset("h4", mapping={"a": 1, "b": 2})
+        assert cache.hmget("h4", "a", "b", "c") == [1, 2, None]
+
+    def test_hdel(self, cache: KeyValueCache):
+        cache.hset("h5", mapping={"a": 1, "b": 2, "c": 3})
+        assert cache.hdel("h5", "b") == 1
+        assert cache.hlen("h5") == 2
+
+    def test_hexists(self, cache: KeyValueCache):
+        cache.hset("h6", "field", "val")
+        assert cache.hexists("h6", "field") is True
+        assert cache.hexists("h6", "nope") is False
+
+    def test_hkeys_hvals(self, cache: KeyValueCache):
+        cache.hset("h7", mapping={"a": 1, "b": 2})
+        assert sorted(cache.hkeys("h7")) == ["a", "b"]
+        assert sorted(cache.hvals("h7")) == [1, 2]
+
+    def test_hsetnx(self, cache: KeyValueCache):
+        assert cache.hsetnx("h8", "f", "first") is True
+        assert cache.hsetnx("h8", "f", "second") is False
+        assert cache.hget("h8", "f") == "first"
+
+    def test_hincrby(self, cache: KeyValueCache):
+        cache.hset("h9", "count", 10)
+        assert cache.hincrby("h9", "count", 5) == 15
+
+    def test_hincrbyfloat(self, cache: KeyValueCache):
+        cache.hset("h10", "score", 1.5)
+        result = cache.hincrbyfloat("h10", "score", 0.5)
+        assert abs(result - 2.0) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# List Operations
+# ---------------------------------------------------------------------------
+
+
+class TestLists:
+    def test_lpush_rpush_lrange(self, cache: KeyValueCache):
+        cache.rpush("L1", "a", "b", "c")
+        assert cache.lrange("L1", 0, -1) == ["a", "b", "c"]
+        cache.lpush("L1", "z")
+        assert cache.lrange("L1", 0, -1) == ["z", "a", "b", "c"]
+
+    def test_lpop_rpop(self, cache: KeyValueCache):
+        cache.rpush("L2", 1, 2, 3)
+        assert cache.lpop("L2") == 1
+        assert cache.rpop("L2") == 3
+        assert cache.lrange("L2", 0, -1) == [2]
+
+    def test_lpop_count(self, cache: KeyValueCache):
+        cache.rpush("L3", "a", "b", "c", "d")
+        result = cache.lpop("L3", count=2)
+        assert result == ["a", "b"]
+        assert cache.llen("L3") == 2
+
+    def test_rpop_count(self, cache: KeyValueCache):
+        cache.rpush("L4", "a", "b", "c", "d")
+        result = cache.rpop("L4", count=2)
+        assert result == ["d", "c"]
+
+    def test_llen(self, cache: KeyValueCache):
+        assert cache.llen("empty_list") == 0
+        cache.rpush("L5", "a", "b")
+        assert cache.llen("L5") == 2
+
+    def test_lindex(self, cache: KeyValueCache):
+        cache.rpush("L6", "a", "b", "c")
+        assert cache.lindex("L6", 0) == "a"
+        assert cache.lindex("L6", -1) == "c"
+        assert cache.lindex("L6", 99) is None
+
+    def test_lset(self, cache: KeyValueCache):
+        cache.rpush("L7", "a", "b", "c")
+        cache.lset("L7", 1, "B")
+        assert cache.lrange("L7", 0, -1) == ["a", "B", "c"]
+
+    def test_lrem(self, cache: KeyValueCache):
+        cache.rpush("L8", "a", "b", "a", "c", "a")
+        removed = cache.lrem("L8", 2, "a")
+        assert removed == 2
+        assert cache.llen("L8") == 3
+
+    def test_ltrim(self, cache: KeyValueCache):
+        cache.rpush("L9", "a", "b", "c", "d", "e")
+        cache.ltrim("L9", 1, 3)
+        assert cache.lrange("L9", 0, -1) == ["b", "c", "d"]
+
+    def test_lmove(self, cache: KeyValueCache):
+        cache.rpush("src_list", "a", "b", "c")
+        result = cache.lmove("src_list", "dst_list", "LEFT", "RIGHT")
+        assert result == "a"
+        assert cache.lrange("dst_list", 0, -1) == ["a"]
+        assert cache.lrange("src_list", 0, -1) == ["b", "c"]
+
+    def test_linsert(self, cache: KeyValueCache):
+        cache.rpush("L10", "a", "c")
+        length = cache.linsert("L10", "BEFORE", "c", "b")
+        assert length == 3
+        assert cache.lrange("L10", 0, -1) == ["a", "b", "c"]
+
+    def test_lpop_empty(self, cache: KeyValueCache):
+        assert cache.lpop("empty") is None
+        assert cache.lpop("empty", count=3) == []
+
+    def test_lpos(self, cache: KeyValueCache):
+        cache.rpush("L11", "a", "b", "c", "b", "d")
+        assert cache.lpos("L11", "b") == 1
+        assert cache.lpos("L11", "z") is None
+
+
+# ---------------------------------------------------------------------------
+# Set Operations
+# ---------------------------------------------------------------------------
+
+
+class TestSets:
+    def test_sadd_smembers(self, cache: KeyValueCache):
+        cache.sadd("S1", "a", "b", "c")
+        assert cache.smembers("S1") == {"a", "b", "c"}
+
+    def test_scard(self, cache: KeyValueCache):
+        cache.sadd("S2", "x", "y")
+        assert cache.scard("S2") == 2
+
+    def test_sismember(self, cache: KeyValueCache):
+        cache.sadd("S3", "a", "b")
+        assert cache.sismember("S3", "a") is True
+        assert cache.sismember("S3", "z") is False
+
+    def test_smismember(self, cache: KeyValueCache):
+        cache.sadd("S4", "a", "b")
+        assert cache.smismember("S4", "a", "c") == [True, False]
+
+    def test_srem(self, cache: KeyValueCache):
+        cache.sadd("S5", "a", "b", "c")
+        assert cache.srem("S5", "b") == 1
+        assert cache.smembers("S5") == {"a", "c"}
+
+    def test_spop(self, cache: KeyValueCache):
+        cache.sadd("S6", "only")
+        result = cache.spop("S6")
+        assert result == "only"
+        assert cache.scard("S6") == 0
+
+    def test_srandmember(self, cache: KeyValueCache):
+        cache.sadd("S7", "a", "b", "c")
+        result = cache.srandmember("S7")
+        assert result in {"a", "b", "c"}
+
+    def test_sdiff(self, cache: KeyValueCache):
+        cache.sadd("SA", "a", "b", "c")
+        cache.sadd("SB", "b", "c", "d")
+        assert cache.sdiff(["SA", "SB"]) == {"a"}
+
+    def test_sinter(self, cache: KeyValueCache):
+        cache.sadd("SC", "a", "b", "c")
+        cache.sadd("SD", "b", "c", "d")
+        assert cache.sinter(["SC", "SD"]) == {"b", "c"}
+
+    def test_sunion(self, cache: KeyValueCache):
+        cache.sadd("SE", "a", "b")
+        cache.sadd("SF", "b", "c")
+        assert cache.sunion(["SE", "SF"]) == {"a", "b", "c"}
+
+    def test_smove(self, cache: KeyValueCache):
+        cache.sadd("SG", "a", "b")
+        cache.sadd("SH", "c")
+        assert cache.smove("SG", "SH", "a") is True
+        assert cache.smembers("SG") == {"b"}
+        assert cache.smembers("SH") == {"a", "c"}
+
+    def test_sdiffstore(self, cache: KeyValueCache):
+        cache.sadd("SI", "a", "b", "c")
+        cache.sadd("SJ", "b")
+        count = cache.sdiffstore("SRESULT", ["SI", "SJ"])
+        assert count == 2
+        assert cache.smembers("SRESULT") == {"a", "c"}
+
+
+# ---------------------------------------------------------------------------
+# Sorted Set Operations
+# ---------------------------------------------------------------------------
+
+
+class TestSortedSets:
+    def test_zadd_zrange(self, cache: KeyValueCache):
+        cache.zadd("Z1", {"a": 1.0, "b": 2.0, "c": 3.0})
+        assert cache.zrange("Z1", 0, -1) == ["a", "b", "c"]
+
+    def test_zadd_withscores(self, cache: KeyValueCache):
+        cache.zadd("Z2", {"x": 10.0, "y": 20.0})
+        result = cache.zrange("Z2", 0, -1, withscores=True)
+        assert result == [("x", 10.0), ("y", 20.0)]
+
+    def test_zcard(self, cache: KeyValueCache):
+        cache.zadd("Z3", {"a": 1.0, "b": 2.0})
+        assert cache.zcard("Z3") == 2
+
+    def test_zscore(self, cache: KeyValueCache):
+        cache.zadd("Z4", {"member": 42.5})
+        assert cache.zscore("Z4", "member") == 42.5
+        assert cache.zscore("Z4", "missing") is None
+
+    def test_zrank_zrevrank(self, cache: KeyValueCache):
+        cache.zadd("Z5", {"a": 1.0, "b": 2.0, "c": 3.0})
+        assert cache.zrank("Z5", "b") == 1
+        assert cache.zrevrank("Z5", "b") == 1
+
+    def test_zincrby(self, cache: KeyValueCache):
+        cache.zadd("Z6", {"m": 5.0})
+        assert cache.zincrby("Z6", 3.0, "m") == 8.0
+
+    def test_zrem(self, cache: KeyValueCache):
+        cache.zadd("Z7", {"a": 1.0, "b": 2.0, "c": 3.0})
+        assert cache.zrem("Z7", "b") == 1
+        assert cache.zcard("Z7") == 2
+
+    def test_zpopmin(self, cache: KeyValueCache):
+        cache.zadd("Z8", {"a": 1.0, "b": 2.0, "c": 3.0})
+        result = cache.zpopmin("Z8")
+        assert result == [("a", 1.0)]
+        assert cache.zcard("Z8") == 2
+
+    def test_zpopmax(self, cache: KeyValueCache):
+        cache.zadd("Z9", {"a": 1.0, "b": 2.0, "c": 3.0})
+        result = cache.zpopmax("Z9")
+        assert result == [("c", 3.0)]
+
+    def test_zcount(self, cache: KeyValueCache):
+        cache.zadd("Z10", {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0})
+        assert cache.zcount("Z10", 2, 3) == 2
+
+    def test_zrangebyscore(self, cache: KeyValueCache):
+        cache.zadd("Z11", {"a": 1.0, "b": 2.0, "c": 3.0})
+        result = cache.zrangebyscore("Z11", 1, 2)
+        assert result == ["a", "b"]
+
+    def test_zrevrange(self, cache: KeyValueCache):
+        cache.zadd("Z12", {"a": 1.0, "b": 2.0, "c": 3.0})
+        assert cache.zrevrange("Z12", 0, 1) == ["c", "b"]
+
+    def test_zremrangebyscore(self, cache: KeyValueCache):
+        cache.zadd("Z13", {"a": 1.0, "b": 2.0, "c": 3.0})
+        removed = cache.zremrangebyscore("Z13", 1, 2)
+        assert removed == 2
+        assert cache.zrange("Z13", 0, -1) == ["c"]
+
+    def test_zremrangebyrank(self, cache: KeyValueCache):
+        cache.zadd("Z14", {"a": 1.0, "b": 2.0, "c": 3.0})
+        removed = cache.zremrangebyrank("Z14", 0, 1)
+        assert removed == 2
+        assert cache.zrange("Z14", 0, -1) == ["c"]
+
+    def test_zadd_nx(self, cache: KeyValueCache):
+        cache.zadd("Z15", {"a": 1.0})
+        cache.zadd("Z15", {"a": 5.0}, nx=True)
+        assert cache.zscore("Z15", "a") == 1.0
+
+    def test_zadd_xx(self, cache: KeyValueCache):
+        cache.zadd("Z16", {"a": 1.0})
+        count = cache.zadd("Z16", {"a": 5.0, "b": 2.0}, xx=True)
+        assert cache.zscore("Z16", "a") == 5.0
+        assert cache.zscore("Z16", "b") is None
+
+    def test_zmscore(self, cache: KeyValueCache):
+        cache.zadd("Z17", {"a": 1.0, "b": 2.0})
+        assert cache.zmscore("Z17", "a", "b", "c") == [1.0, 2.0, None]
+
+
+# ---------------------------------------------------------------------------
+# Not Supported Operations
+# ---------------------------------------------------------------------------
+
+
+class TestNotSupported:
+    def test_eval_script_raises(self, cache: KeyValueCache):
+        with pytest.raises(NotSupportedError):
+            cache.eval_script("return 1", keys=["k"])
+
+    def test_streams_raise(self, cache: KeyValueCache):
+        with pytest.raises(NotSupportedError):
+            cache.xadd("stream", {"field": "value"})
+
+    def test_blocking_ops_raise(self, cache: KeyValueCache):
+        with pytest.raises(NotSupportedError):
+            cache.blpop("key", timeout=1)
+
+
+# ---------------------------------------------------------------------------
+# Type Transitions
+# ---------------------------------------------------------------------------
+
+
+class TestTypeTransitions:
+    def test_string_to_hash(self, cache: KeyValueCache):
+        """SET a key as string, then HSET — should work (type transitions)."""
+        cache.set("tkey", "string_value")
+        cache.hset("tkey", "field", "hash_value")
+        assert cache.hget("tkey", "field") == "hash_value"
+        assert cache.get("tkey") is None
+
+    def test_hash_to_string(self, cache: KeyValueCache):
+        cache.hset("tkey2", "f", "v")
+        cache.set("tkey2", "now_a_string")
+        assert cache.get("tkey2") == "now_a_string"
+        assert cache.hget("tkey2", "f") is None
+
+    def test_list_to_set(self, cache: KeyValueCache):
+        cache.rpush("tkey3", "a", "b")
+        cache.sadd("tkey3", "x", "y")
+        assert cache.smembers("tkey3") == {"x", "y"}
+        assert cache.llen("tkey3") == 0

--- a/tests/settings/base.py
+++ b/tests/settings/base.py
@@ -11,6 +11,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.sessions",
     "django_cachex.admin",
+    "django_cachex.postgres",
 ]
 
 # Database configuration for tests

--- a/uv.lock
+++ b/uv.lock
@@ -447,6 +447,9 @@ lz4 = [
 msgpack = [
     { name = "msgpack" },
 ]
+postgres = [
+    { name = "psycopg", extra = ["binary"] },
+]
 redis = [
     { name = "redis" },
 ]
@@ -470,6 +473,7 @@ dev = [
     { name = "msgpack" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "psycopg" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -497,12 +501,13 @@ requires-dist = [
     { name = "django-unfold", marker = "extra == 'unfold'", specifier = ">=0.70.0" },
     { name = "lz4", marker = "extra == 'lz4'", specifier = ">=4.4.0" },
     { name = "msgpack", marker = "extra == 'msgpack'", specifier = ">=1.1.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=6,<8" },
     { name = "redis", extras = ["hiredis"], marker = "extra == 'hiredis'", specifier = ">=6,<8" },
     { name = "valkey", marker = "extra == 'valkey'", specifier = ">=6.1.0,<7" },
     { name = "valkey", extras = ["libvalkey"], marker = "extra == 'libvalkey'", specifier = ">=6.1.0,<7" },
 ]
-provides-extras = ["valkey", "libvalkey", "redis", "hiredis", "lz4", "zstd", "msgpack", "unfold"]
+provides-extras = ["valkey", "libvalkey", "redis", "hiredis", "lz4", "zstd", "msgpack", "postgres", "unfold"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -514,6 +519,7 @@ dev = [
     { name = "msgpack", specifier = "==1.1.2" },
     { name = "mypy", specifier = "==1.19.1" },
     { name = "pre-commit", specifier = "==4.5.1" },
+    { name = "psycopg", specifier = "==3.3.3" },
     { name = "pytest", specifier = "==9.0.2" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-cov", specifier = "==7.0.0" },
@@ -1250,6 +1256,64 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/15/021be5c0cbc5b7c1ab46e91cc3434eb42569f79a0592e67b8d25e66d844d/psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d", size = 4591170, upload-time = "2026-02-18T16:48:55.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/54/a60211c346c9a2f8c6b272b5f2bbe21f6e11800ce7f61e99ba75cf8b63e1/psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8", size = 4670009, upload-time = "2026-02-18T16:49:03.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/53/ac7c18671347c553362aadbf65f92786eef9540676ca24114cc02f5be405/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df", size = 5469735, upload-time = "2026-02-18T16:49:10.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c3/4f4e040902b82a344eff1c736cde2f2720f127fe939c7e7565706f96dd44/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351", size = 5152919, upload-time = "2026-02-18T16:49:16.335Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/d929679c6a5c212bcf738806c7c89f5b3d0919f2e1685a0e08d6ff877945/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d", size = 6738785, upload-time = "2026-02-18T16:49:22.687Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b0/09703aeb69a9443d232d7b5318d58742e8ca51ff79f90ffe6b88f1db45e7/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2", size = 4979008, upload-time = "2026-02-18T16:49:27.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a6/e662558b793c6e13a7473b970fee327d635270e41eded3090ef14045a6a5/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e", size = 4508255, upload-time = "2026-02-18T16:49:31.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/0f8b2e1d5e0093921b6f324a948a5c740c1447fbb45e97acaf50241d0f39/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc", size = 4189166, upload-time = "2026-02-18T16:49:35.801Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ec/ce2e91c33bc8d10b00c87e2f6b0fb570641a6a60042d6a9ae35658a3a797/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0", size = 3924544, upload-time = "2026-02-18T16:49:41.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2f/7718141485f73a924205af60041c392938852aa447a94c8cbd222ff389a1/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830", size = 4235297, upload-time = "2026-02-18T16:49:46.726Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f9/1add717e2643a003bbde31b1b220172e64fbc0cb09f06429820c9173f7fc/psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14", size = 3547659, upload-time = "2026-02-18T16:49:52.999Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
More a proof of concept.

Adds a PostgreSQL-based cache backend that implements the full cachex API (strings, hashes, lists, sets, sorted sets, TTL, key patterns) using UNLOGGED tables for performance. This eliminates the Redis dependency for smaller deployments while keeping the same API surface.