### PR TITLE
feat: rust async bridge — tokio runtime + RustAwaitable (#64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,29 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
+  test-rust:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.14"
+          - "3.14t"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run rust async-bridge tests
+        run: uv run pytest tests/rust/ -v
+
   test-admin:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "django-cachex"
 version = "0.3.0"
 dependencies = [
  "pyo3",
+ "tokio",
 ]
 
 [[package]]
@@ -26,6 +27,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -125,6 +132,15 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "pin-project-lite",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.28", features = ["extension-module"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.28", features = ["extension-module"] }
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
 
 [profile.release]
 lto = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
   "django-stubs==6.0.3",
   "djlint==1.36.4",
   "lz4==4.4.5",
+  "maturin==1.13.1",
   "msgpack==1.1.2",
   "mypy==1.20.2",
   "pre-commit==4.6.0",

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -1,0 +1,485 @@
+// Async bridge: tokio runtime + RustAwaitable Python class.
+//
+// Verbatim port of django-vcache's `src/async_bridge.rs` (MIT,
+// David Burke / GlitchTip). Upstream:
+// https://gitlab.com/glitchtip/django-vcache/-/blob/main/src/async_bridge.rs
+//
+// Keep this file in lockstep with upstream. If you want to diverge,
+// open a discussion first — the design (5-poll busy-yield, OnceLock
+// runtime with PID fork detection, oneshot channel + watcher task) is
+// the load-bearing part and must not drift accidentally.
+
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyList, PyString, PyTuple};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::runtime::Runtime;
+use tokio::sync::oneshot;
+
+/// Fork-safe tokio runtime with zero-cost fast path.
+///
+/// Fast path (99.99% of calls): atomic PID check + OnceLock::get() → &'static.
+/// Slow path (first call or after fork): OnceLock init or Mutex-protected
+/// runtime creation. After fork(), the parent's dead runtime is leaked via
+/// Box::leak to avoid joining dead threads.
+static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+static RUNTIME_PID: AtomicU32 = AtomicU32::new(0);
+static FORK_RUNTIME: Mutex<Option<(u32, &'static Runtime)>> = Mutex::new(None);
+
+#[inline]
+pub fn get_runtime() -> &'static Runtime {
+    let pid = std::process::id();
+    if RUNTIME_PID.load(Ordering::Relaxed) == pid {
+        // Fast path: same process, no fork. Zero-cost OnceLock get.
+        return RUNTIME.get().unwrap();
+    }
+    init_or_fork_runtime(pid)
+}
+
+#[cold]
+fn init_or_fork_runtime(pid: u32) -> &'static Runtime {
+    let stored = RUNTIME_PID.load(Ordering::Relaxed);
+
+    if stored == 0 {
+        // First call: initialize via OnceLock (handles concurrent init safely)
+        let rt = RUNTIME.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to create tokio runtime")
+        });
+        RUNTIME_PID.store(pid, Ordering::Relaxed);
+        return rt;
+    }
+
+    // Fork detected: parent's tokio threads are dead in this child.
+    // Create a fresh runtime and leak it (can't drop a dead runtime safely).
+    let mut guard = FORK_RUNTIME.lock().unwrap();
+    if let Some((stored_pid, rt)) = *guard {
+        if stored_pid == pid {
+            return rt;
+        }
+    }
+    let rt: &'static Runtime = Box::leak(Box::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime"),
+    ));
+    *guard = Some((pid, rt));
+    rt
+}
+
+// =========================================================================
+// Result types — Rust-native, no GIL needed to construct
+// =========================================================================
+
+pub enum RawResult {
+    OptBytes(Option<Vec<u8>>),
+    Bool(bool),
+    Int(i64),
+    OptBytesList(Vec<Option<Vec<u8>>>),
+    BytesList(Vec<Vec<u8>>),
+    StringList(Vec<String>),
+    OptKeyAndBytesList(Option<(String, Vec<Vec<u8>>)>),
+    /// Connection/IO error → PyConnectionError (swallowed by IGNORE_EXCEPTIONS)
+    Error(String),
+    /// Data/server error → PyRuntimeError (NOT swallowed, indicates real problems)
+    ServerError(String),
+}
+
+impl RawResult {
+    pub fn into_py(self, py: Python<'_>) -> Result<Py<PyAny>, PyErr> {
+        match self {
+            RawResult::OptBytes(Some(b)) => Ok(PyBytes::new(py, &b).into_any().unbind()),
+            RawResult::OptBytes(None) => Ok(py.None()),
+            RawResult::Bool(b) => {
+                Ok(b.into_pyobject(py).unwrap().to_owned().into_any().unbind())
+            }
+            RawResult::Int(n) => Ok(n.into_pyobject(py).unwrap().into_any().unbind()),
+            RawResult::OptBytesList(items) => {
+                let py_items: Vec<Py<PyAny>> = items
+                    .into_iter()
+                    .map(|r| match r {
+                        Some(bytes) => PyBytes::new(py, &bytes).into_any().unbind(),
+                        None => py.None(),
+                    })
+                    .collect();
+                Ok(PyList::new(py, py_items)?.into_any().unbind())
+            }
+            RawResult::BytesList(items) => {
+                let py_items: Vec<Py<PyAny>> = items
+                    .iter()
+                    .map(|b| PyBytes::new(py, b).into_any().unbind())
+                    .collect();
+                Ok(PyList::new(py, py_items)?.into_any().unbind())
+            }
+            RawResult::StringList(items) => {
+                let py_items: Vec<Py<PyAny>> = items
+                    .iter()
+                    .map(|s| PyString::new(py, s).into_any().unbind())
+                    .collect();
+                Ok(PyList::new(py, py_items)?.into_any().unbind())
+            }
+            RawResult::OptKeyAndBytesList(Some((key, values))) => {
+                let py_values: Vec<Py<PyAny>> = values
+                    .iter()
+                    .map(|b| PyBytes::new(py, b).into_any().unbind())
+                    .collect();
+                let py_key = PyString::new(py, &key).into_any().unbind();
+                let py_list = PyList::new(py, py_values)?.into_any().unbind();
+                Ok(PyTuple::new(py, [py_key, py_list])?.into_any().unbind())
+            }
+            RawResult::OptKeyAndBytesList(None) => Ok(py.None()),
+            RawResult::Error(e) => Err(pyo3::exceptions::PyConnectionError::new_err(e)),
+            RawResult::ServerError(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e)),
+        }
+    }
+}
+
+// =========================================================================
+// RustAwaitable — deferred-callback async bridge
+//
+// The tokio task sends its result via a oneshot channel — no GIL needed.
+//
+// __next__ polls try_recv(). For fast local operations, the result is
+// usually ready on the first call → zero overhead, identical to the old
+// busy-yield approach.
+//
+// If the result isn't ready after 5 polls, we switch to callback mode:
+// get the event loop, spawn a lightweight watcher task, and yield self
+// with _asyncio_future_blocking=True. The watcher awaits the oneshot
+// and calls call_soon_threadsafe(_wake).
+//
+// This gives us the best of both worlds:
+// - Fast path: zero GIL from tokio threads, minimal per-op overhead
+// - Slow path: proper callback-based suspend (no CPU burn)
+// - Idle: zero CPU (no busy-yield loops)
+// =========================================================================
+
+/// A done-callback with its associated context, matching asyncio's
+/// `add_done_callback(fn, *, context=ctx)` protocol. Storing the context
+/// ensures callbacks run in the correct `contextvars.Context`, which is
+/// critical for middleware that uses `ContextVar.reset(token)`.
+struct DoneCallback {
+    callback: Py<PyAny>,
+    context: Option<Py<PyAny>>,
+}
+
+/// Callback-mode state — only allocated when an operation doesn't resolve
+/// within the busy-yield window (5 polls). Most fast ops never need this,
+/// so keeping it boxed avoids bloating every RustAwaitable allocation.
+struct CallbackState {
+    event_loop: Py<PyAny>,
+    callbacks: Vec<DoneCallback>,
+    result_slot: Arc<Mutex<Option<Result<RawResult, ()>>>>,
+}
+
+#[pyclass]
+pub struct RustAwaitable {
+    rx: Option<oneshot::Receiver<RawResult>>,
+    /// Successful result value — stored for result() after StopIteration delivery.
+    value: Option<Py<PyAny>>,
+    /// Error exception object — raised by result() for the Task to propagate.
+    error: Option<Py<PyAny>>,
+    /// Whether we have a stored result (value or error).
+    resolved: bool,
+    /// Whether cancel() was called.
+    cancelled: bool,
+    #[pyo3(get, set)]
+    _asyncio_future_blocking: bool,
+    /// Number of times __next__ has been called without a result.
+    polls: u8,
+    /// Callback mode state — allocated lazily on 6th poll miss.
+    cb: Option<Box<CallbackState>>,
+}
+
+/// Helper: raise asyncio.CancelledError.
+fn cancelled_error(py: Python<'_>) -> PyErr {
+    if let Ok(asyncio) = py.import("asyncio") {
+        if let Ok(cls) = asyncio.getattr("CancelledError") {
+            if let Ok(exc) = cls.call0() {
+                return PyErr::from_value(exc.into_any());
+            }
+        }
+    }
+    pyo3::exceptions::PyRuntimeError::new_err("cancelled")
+}
+
+/// Helper: deliver a successful result via StopIteration and store in self.value.
+fn deliver_value(
+    this: &mut RustAwaitable,
+    py: Python<'_>,
+    val: Py<PyAny>,
+) -> PyResult<Py<PyAny>> {
+    this.resolved = true;
+    this.value = Some(val.clone_ref(py));
+    let stop = py
+        .get_type::<pyo3::exceptions::PyStopIteration>()
+        .call1((val,))?;
+    Err(PyErr::from_value(stop.into_any()))
+}
+
+/// Helper: store an error and raise it.
+fn deliver_error(this: &mut RustAwaitable, py: Python<'_>, err: PyErr) -> PyResult<Py<PyAny>> {
+    this.resolved = true;
+    this.error = Some(err.value(py).clone().into_any().unbind());
+    Err(err)
+}
+
+#[pymethods]
+impl RustAwaitable {
+    fn __await__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    fn __iter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    #[getter]
+    fn _loop(&self) -> Option<&Py<PyAny>> {
+        self.cb.as_ref().map(|cb| &cb.event_loop)
+    }
+
+    fn __next__(slf: Py<Self>, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let mut this = slf.borrow_mut(py);
+
+        // Cancelled — raise CancelledError.
+        if this.cancelled {
+            return Err(cancelled_error(py));
+        }
+
+        // Already resolved — re-deliver stored result.
+        if this.resolved {
+            if let Some(ref exc) = this.error {
+                return Err(PyErr::from_value(exc.bind(py).clone()));
+            }
+            if let Some(ref value) = this.value {
+                let stop = py
+                    .get_type::<pyo3::exceptions::PyStopIteration>()
+                    .call1((value,))?;
+                return Err(PyErr::from_value(stop.into_any()));
+            }
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "awaitable already consumed",
+            ));
+        }
+
+        // Check result_slot (set by watcher task via Rust mutex, no GIL needed).
+        if let Some(ref cb) = this.cb {
+            let maybe = cb.result_slot.lock().unwrap().take();
+            if let Some(raw_result) = maybe {
+                this.cb = None;
+                return match raw_result {
+                    Ok(raw) => match raw.into_py(py) {
+                        Ok(val) => deliver_value(&mut this, py, val),
+                        Err(e) => deliver_error(&mut this, py, e),
+                    },
+                    Err(()) => deliver_error(
+                        &mut this,
+                        py,
+                        pyo3::exceptions::PyRuntimeError::new_err("operation was dropped"),
+                    ),
+                };
+            }
+        }
+
+        // Try to read result directly from the oneshot channel.
+        if let Some(rx) = this.rx.as_mut() {
+            match rx.try_recv() {
+                Ok(raw) => {
+                    this.rx = None;
+                    return match raw.into_py(py) {
+                        Ok(val) => deliver_value(&mut this, py, val),
+                        Err(e) => deliver_error(&mut this, py, e),
+                    };
+                }
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    this.rx = None;
+                    return deliver_error(
+                        &mut this,
+                        py,
+                        pyo3::exceptions::PyRuntimeError::new_err("operation was dropped"),
+                    );
+                }
+                Err(oneshot::error::TryRecvError::Empty) => {
+                    // Not ready yet
+                }
+            }
+        } else if this.resolved {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "awaitable already consumed",
+            ));
+        }
+
+        this.polls += 1;
+
+        if this.polls <= 5 {
+            // Busy-yield for up to 5 iterations — covers nearly all fast ops
+            // (sub-ms driver operations resolve within 1-3 event loop ticks).
+            // Callback mode has high fixed cost (get_running_loop + watcher
+            // spawn + spawn_blocking + GIL acquisition), so busy-yield is
+            // cheaper even when all 5 polls miss.
+            drop(this);
+            return Ok(py.None());
+        }
+
+        // Sixth poll miss: switch to callback mode (for genuinely slow ops).
+        let rx = this.rx.take().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("awaitable already consumed")
+        })?;
+
+        let asyncio = py.import("asyncio")?;
+        let event_loop = asyncio.call_method0("get_running_loop")?;
+        this._asyncio_future_blocking = true;
+
+        // Spawn a lightweight watcher that awaits the result and wakes us.
+        let event_loop_ref = event_loop.clone().into_any().unbind();
+        let awaitable_ref = slf.clone_ref(py).into_any();
+        let result_slot = Arc::new(Mutex::new(None));
+        this.cb = Some(Box::new(CallbackState {
+            event_loop: event_loop.into_any().unbind(),
+            callbacks: Vec::new(),
+            result_slot: result_slot.clone(),
+        }));
+        get_runtime().spawn(async move {
+            let raw = rx.await;
+            let raw_result = match raw {
+                Ok(r) => Ok(r),
+                Err(_) => Err(()),
+            };
+            *result_slot.lock().unwrap() = Some(raw_result);
+            tokio::task::spawn_blocking(move || {
+                Python::try_attach(|py| {
+                    if let Ok(wake) = awaitable_ref.getattr(py, "_wake") {
+                        let _ =
+                            event_loop_ref.call_method1(py, "call_soon_threadsafe", (wake,));
+                    }
+                });
+            });
+        });
+
+        drop(this);
+        Ok(slf.into_any())
+    }
+
+    /// Called on the event loop thread via call_soon_threadsafe.
+    /// Fires done-callbacks so the Task can resume.
+    ///
+    /// Each callback is invoked via `context.run(callback, self)` when a
+    /// context was provided by `add_done_callback`, matching asyncio.Future's
+    /// contract.  This ensures the callback (typically `Task.__step`) runs
+    /// in the correct `contextvars.Context`.
+    fn _wake(slf: Py<Self>, py: Python<'_>) {
+        let callbacks = {
+            let mut this = slf.borrow_mut(py);
+            this.cb
+                .as_mut()
+                .map(|cb| std::mem::take(&mut cb.callbacks))
+                .unwrap_or_default()
+        };
+        for done_cb in callbacks {
+            if let Some(ref ctx) = done_cb.context {
+                let _ = ctx.call_method1(py, "run", (&done_cb.callback, &slf));
+            } else {
+                let _ = done_cb.callback.call1(py, (&slf,));
+            }
+        }
+    }
+
+    #[pyo3(signature = (fn_cb, *, context=None))]
+    fn add_done_callback(&mut self, fn_cb: Py<PyAny>, context: Option<Py<PyAny>>) {
+        if let Some(ref mut cb) = self.cb {
+            cb.callbacks.push(DoneCallback {
+                callback: fn_cb,
+                context,
+            });
+        }
+        // If no callback state yet (still in busy-yield), the callback
+        // will be added when we enter callback mode. In practice, asyncio
+        // only calls add_done_callback after we yield with future_blocking=True.
+    }
+
+    fn result(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        if self.cancelled {
+            return Err(cancelled_error(py));
+        }
+        if let Some(ref exc) = self.error {
+            return Err(PyErr::from_value(exc.bind(py).clone()));
+        }
+        match &self.value {
+            Some(v) => Ok(v.clone_ref(py)),
+            None => Ok(py.None()),
+        }
+    }
+
+    fn exception(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        if self.cancelled {
+            let asyncio = py.import("asyncio")?;
+            let exc = asyncio.getattr("CancelledError")?.call0()?;
+            return Ok(exc.into_any().unbind());
+        }
+        match &self.error {
+            Some(exc) => Ok(exc.clone_ref(py)),
+            None => Ok(py.None()),
+        }
+    }
+
+    /// Cancel the awaitable. Drops the oneshot receiver so the tokio task
+    /// result is discarded. Returns True if successfully cancelled.
+    ///
+    /// In callback mode, fires done-callbacks via loop.call_soon() so the
+    /// Task can resume and throw CancelledError. Without this, a BLMOVE
+    /// with infinite timeout would hang on SIGTERM.
+    #[pyo3(signature = (msg=None))]
+    fn cancel(slf: Py<Self>, py: Python<'_>, msg: Option<Py<PyAny>>) -> bool {
+        let mut this = slf.borrow_mut(py);
+        let _ = msg;
+        if this.resolved || this.cancelled {
+            return false;
+        }
+        this.cancelled = true;
+        this.rx = None;
+        let cb_state = this.cb.take();
+        drop(this);
+        if let Some(cb) = cb_state {
+            for done_cb in cb.callbacks {
+                let kwargs = pyo3::types::PyDict::new(py);
+                if let Some(ref ctx) = done_cb.context {
+                    let _ = kwargs.set_item("context", ctx);
+                }
+                let _ = cb.event_loop.call_method(
+                    py,
+                    "call_soon",
+                    (&done_cb.callback, slf.bind(py)),
+                    Some(&kwargs),
+                );
+            }
+        }
+        true
+    }
+
+    fn cancelled(&self) -> bool {
+        self.cancelled
+    }
+
+    fn done(&self) -> bool {
+        self.resolved || self.cancelled
+    }
+}
+
+impl RustAwaitable {
+    pub fn new(rx: oneshot::Receiver<RawResult>) -> Self {
+        RustAwaitable {
+            rx: Some(rx),
+            value: None,
+            error: None,
+            resolved: false,
+            cancelled: false,
+            _asyncio_future_blocking: false,
+            polls: 0,
+            cb: None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,14 @@
 // Rust I/O driver for django-cachex.
 //
-// This file is intentionally a stub. The async bridge, connection layer,
-// and command bindings land in follow-up PRs (issues #64, #65, #66).
-// What ships here is just the build pipeline and an importable extension
-// module so subsequent PRs have something to attach code to.
-//
 // Heavily inspired by django-vcache (MIT, by David Burke / GlitchTip):
 // https://gitlab.com/glitchtip/django-vcache
+
+mod async_bridge;
 
 use pyo3::prelude::*;
 
 #[pymodule]
-fn _driver(_m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _driver(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<async_bridge::RustAwaitable>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,20 @@
 // https://gitlab.com/glitchtip/django-vcache
 
 mod async_bridge;
+mod test_helpers;
 
 use pyo3::prelude::*;
 
 #[pymodule]
 fn _driver(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<async_bridge::RustAwaitable>()?;
+    m.add_function(wrap_pyfunction!(test_helpers::_test_resolved_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(test_helpers::_test_resolved_none, m)?)?;
+    m.add_function(wrap_pyfunction!(test_helpers::_test_resolved_int, m)?)?;
+    m.add_function(wrap_pyfunction!(test_helpers::_test_delayed_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(test_helpers::_test_pending, m)?)?;
+    m.add_function(wrap_pyfunction!(test_helpers::_test_dropped, m)?)?;
+    m.add_function(wrap_pyfunction!(test_helpers::_test_error, m)?)?;
+    m.add_function(wrap_pyfunction!(test_helpers::_test_server_error, m)?)?;
     Ok(())
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,76 @@
+// Test-only PyO3 functions for driving RustAwaitable from Python tests.
+// Always compiled in (PyO3 doesn't expose Rust #[cfg(test)] to Python).
+// All exported names start with `_test_` to mark them as internal.
+
+use crate::async_bridge::{RawResult, RustAwaitable, get_runtime};
+use pyo3::prelude::*;
+use std::time::Duration;
+use tokio::sync::oneshot;
+
+/// Resolved-bytes awaitable: sender fires synchronously before returning.
+#[pyfunction]
+pub fn _test_resolved_bytes(b: Vec<u8>) -> RustAwaitable {
+    let (tx, rx) = oneshot::channel();
+    let _ = tx.send(RawResult::OptBytes(Some(b)));
+    RustAwaitable::new(rx)
+}
+
+/// Resolved-None awaitable.
+#[pyfunction]
+pub fn _test_resolved_none() -> RustAwaitable {
+    let (tx, rx) = oneshot::channel();
+    let _ = tx.send(RawResult::OptBytes(None));
+    RustAwaitable::new(rx)
+}
+
+/// Resolved-int awaitable.
+#[pyfunction]
+pub fn _test_resolved_int(n: i64) -> RustAwaitable {
+    let (tx, rx) = oneshot::channel();
+    let _ = tx.send(RawResult::Int(n));
+    RustAwaitable::new(rx)
+}
+
+/// Delayed-bytes awaitable: tokio task sleeps `delay_ms` then sends.
+/// Used to force callback mode (delay > 5 polls' worth of event-loop ticks).
+#[pyfunction]
+pub fn _test_delayed_bytes(b: Vec<u8>, delay_ms: u64) -> RustAwaitable {
+    let (tx, rx) = oneshot::channel();
+    get_runtime().spawn(async move {
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        let _ = tx.send(RawResult::OptBytes(Some(b)));
+    });
+    RustAwaitable::new(rx)
+}
+
+/// Pending-forever awaitable: sender is leaked, never resolves. For cancel tests.
+#[pyfunction]
+pub fn _test_pending() -> RustAwaitable {
+    let (tx, rx) = oneshot::channel::<RawResult>();
+    Box::leak(Box::new(tx));
+    RustAwaitable::new(rx)
+}
+
+/// Dropped-sender awaitable: oneshot closes immediately → "operation was dropped".
+#[pyfunction]
+pub fn _test_dropped() -> RustAwaitable {
+    let (tx, rx) = oneshot::channel::<RawResult>();
+    drop(tx);
+    RustAwaitable::new(rx)
+}
+
+/// Connection-error awaitable: resolves with PyConnectionError.
+#[pyfunction]
+pub fn _test_error(msg: String) -> RustAwaitable {
+    let (tx, rx) = oneshot::channel();
+    let _ = tx.send(RawResult::Error(msg));
+    RustAwaitable::new(rx)
+}
+
+/// Server-error awaitable: resolves with PyRuntimeError.
+#[pyfunction]
+pub fn _test_server_error(msg: String) -> RustAwaitable {
+    let (tx, rx) = oneshot::channel();
+    let _ = tx.send(RawResult::ServerError(msg));
+    RustAwaitable::new(rx)
+}

--- a/tests/rust/test_async_bridge_cancel.py
+++ b/tests/rust/test_async_bridge_cancel.py
@@ -1,0 +1,34 @@
+import asyncio
+
+import pytest
+from django_cachex._driver import _test_delayed_bytes, _test_pending, _test_resolved_bytes
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_in_busy_yield():
+    awaitable = _test_pending()
+    assert awaitable.cancel() is True
+    assert awaitable.cancelled() is True
+    with pytest.raises(asyncio.CancelledError):
+        await awaitable
+
+
+@pytest.mark.asyncio
+async def test_cancel_returns_false_when_already_resolved():
+    awaitable = _test_resolved_bytes(b"x")
+    await awaitable
+    assert awaitable.cancel() is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_in_callback_mode_wakes_task():
+    async def runner():
+        awaitable = _test_delayed_bytes(b"never", 5_000)
+        await awaitable
+
+    task = asyncio.create_task(runner())
+    for _ in range(10):
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/rust/test_async_bridge_cancel.py
+++ b/tests/rust/test_async_bridge_cancel.py
@@ -32,3 +32,22 @@ async def test_cancel_in_callback_mode_wakes_task():
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+async def test_cancel_fires_done_callbacks_via_call_soon():
+    awaitable = _test_pending()
+    it = iter(awaitable)
+    for _ in range(6):
+        next(it)
+    assert awaitable._asyncio_future_blocking is True
+
+    fired = []
+    awaitable.add_done_callback(fired.append)
+
+    assert awaitable.cancel() is True
+
+    await asyncio.sleep(0)
+
+    assert len(fired) == 1
+    assert fired[0] is awaitable

--- a/tests/rust/test_async_bridge_fast.py
+++ b/tests/rust/test_async_bridge_fast.py
@@ -1,0 +1,32 @@
+import pytest
+from django_cachex._driver import (
+    _test_resolved_bytes,
+    _test_resolved_int,
+    _test_resolved_none,
+)
+
+
+@pytest.mark.asyncio
+async def test_fast_path_bytes():
+    awaitable = _test_resolved_bytes(b"hello")
+    result = await awaitable
+    assert result == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_fast_path_none():
+    awaitable = _test_resolved_none()
+    assert await awaitable is None
+
+
+@pytest.mark.asyncio
+async def test_fast_path_int():
+    awaitable = _test_resolved_int(42)
+    assert await awaitable == 42
+
+
+@pytest.mark.asyncio
+async def test_fast_path_does_not_enter_callback_mode():
+    awaitable = _test_resolved_bytes(b"x")
+    await awaitable
+    assert awaitable._loop is None

--- a/tests/rust/test_async_bridge_fork.py
+++ b/tests/rust/test_async_bridge_fork.py
@@ -1,0 +1,43 @@
+import asyncio
+import multiprocessing as mp
+import sys
+
+import pytest
+
+fork_ctx = mp.get_context("fork")
+
+
+def _child_body(q) -> None:
+    try:
+        from django_cachex._driver import _test_delayed_bytes
+
+        async def go() -> bytes:
+            return await _test_delayed_bytes(b"child", 25)
+
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(go())
+        finally:
+            loop.close()
+        q.put(("ok", result))
+    except Exception as exc:  # noqa: BLE001 — proxy any failure back to parent
+        q.put(("err", repr(exc)))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fork not supported on Windows")
+def test_fork_creates_fresh_runtime():
+    from django_cachex._driver import _test_resolved_bytes
+
+    async def warm() -> None:
+        await _test_resolved_bytes(b"warm")
+
+    asyncio.run(warm())
+
+    q = fork_ctx.Queue()
+    p = fork_ctx.Process(target=_child_body, args=(q,))
+    p.start()
+    p.join(timeout=10)
+    assert p.exitcode == 0, f"child exited with {p.exitcode}"
+    status, payload = q.get(timeout=1)
+    assert status == "ok", f"child failed: {payload}"
+    assert payload == b"child"

--- a/tests/rust/test_async_bridge_loops.py
+++ b/tests/rust/test_async_bridge_loops.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from django_cachex._driver import _test_delayed_bytes, _test_resolved_bytes
+
+
+def test_runtime_survives_loop_close():
+    async def go(n: int) -> bytes:
+        awaitable = _test_delayed_bytes(f"v{n}".encode(), 25)
+        return await awaitable
+
+    loop1 = asyncio.new_event_loop()
+    try:
+        assert loop1.run_until_complete(go(1)) == b"v1"
+    finally:
+        loop1.close()
+
+    loop2 = asyncio.new_event_loop()
+    try:
+        assert loop2.run_until_complete(go(2)) == b"v2"
+    finally:
+        loop2.close()
+
+
+def test_runtime_serves_fast_and_slow_in_same_loop():
+    async def go() -> tuple[bytes, bytes]:
+        a = await _test_resolved_bytes(b"fast")
+        b = await _test_delayed_bytes(b"slow", 30)
+        return a, b
+
+    loop = asyncio.new_event_loop()
+    try:
+        assert loop.run_until_complete(go()) == (b"fast", b"slow")
+    finally:
+        loop.close()

--- a/tests/rust/test_async_bridge_slow.py
+++ b/tests/rust/test_async_bridge_slow.py
@@ -1,0 +1,29 @@
+import pytest
+from django_cachex._driver import _test_delayed_bytes, _test_dropped
+
+
+@pytest.mark.asyncio
+async def test_slow_path_resolves():
+    awaitable = _test_delayed_bytes(b"slow", 50)
+    result = await awaitable
+    assert result == b"slow"
+
+
+@pytest.mark.asyncio
+async def test_slow_path_marks_future_blocking():
+    awaitable = _test_delayed_bytes(b"x", 200)
+    it = iter(awaitable)
+    for _ in range(6):
+        try:
+            next(it)
+        except StopIteration:
+            return
+    assert awaitable._asyncio_future_blocking is True
+    assert awaitable._loop is not None
+
+
+@pytest.mark.asyncio
+async def test_slow_path_dropped_sender_raises():
+    awaitable = _test_dropped()
+    with pytest.raises(RuntimeError, match="dropped"):
+        await awaitable

--- a/tests/rust/test_async_bridge_smoke.py
+++ b/tests/rust/test_async_bridge_smoke.py
@@ -1,0 +1,4 @@
+def test_rustawaitable_class_is_exported():
+    from django_cachex._driver import RustAwaitable
+
+    assert RustAwaitable.__name__ == "RustAwaitable"

--- a/uv.lock
+++ b/uv.lock
@@ -314,6 +314,7 @@ dev = [
     { name = "django-stubs" },
     { name = "djlint" },
     { name = "lz4" },
+    { name = "maturin" },
     { name = "msgpack" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -356,6 +357,7 @@ dev = [
     { name = "django-stubs", specifier = "==6.0.3" },
     { name = "djlint", specifier = "==1.36.4" },
     { name = "lz4", specifier = "==4.4.5" },
+    { name = "maturin", specifier = "==1.13.1" },
     { name = "msgpack", specifier = "==1.1.2" },
     { name = "mypy", specifier = "==1.20.2" },
     { name = "pre-commit", specifier = "==4.6.0" },
@@ -680,6 +682,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "maturin"
+version = "1.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/16/b284a7bc4af3dd87717c784278c1b8cb18606ad1f6f7a671c47bfd9c3df0/maturin-1.13.1.tar.gz", hash = "sha256:9a87ff3b8e4d1c6eac33ebfe8e261e8236516d98d45c0323550621819b5a1a2f", size = 340369, upload-time = "2026-04-09T15:14:07.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/4d/a23fc95be881aa8c7a6ea353410417872e4d7065df03d7f3db8f0dbed4a7/maturin-1.13.1-py3-none-linux_armv6l.whl", hash = "sha256:416e4e01cb88b798e606ee43929df897e42c1647b722ef68283816cca99a8742", size = 10102444, upload-time = "2026-04-09T15:13:48.393Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/1e/65c385d65bae95cf04895d52f39dbed8b1453ae55da2903d252ade40a774/maturin-1.13.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:72888e87819ce546d0d2df900e4b385e4ef299077d92ee37b48923a5602dae94", size = 19576043, upload-time = "2026-04-09T15:14:08.685Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/13/f6bc868d0bfecd9314870b97f530a167e31f7878ac4945c78245c6eef69c/maturin-1.13.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:98b5fcf1a186c217830a8295ecc2989c6b1cf50945417adfc15252107b9475b7", size = 10117339, upload-time = "2026-04-09T15:13:40.559Z" },
+    { url = "https://files.pythonhosted.org/packages/51/58/279e081305c11c1c1c4fccacf77df8959646c5d4de7a57ec7e787653e270/maturin-1.13.1-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:3da18cccf2f683c0977bff9146a0908d6ffce836d600665736ac01679f588cb9", size = 10139689, upload-time = "2026-04-09T15:13:38.291Z" },
+    { url = "https://files.pythonhosted.org/packages/00/94/69391af5396c6aab723932240803f49e5f3de3dd7c57d32f02d237a0ce32/maturin-1.13.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:6b1e5916a253243e8f5f9e847b62bbc98420eec48c9ce2e2e8724c6da89d359b", size = 10551141, upload-time = "2026-04-09T15:13:42.887Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/bf/4edac2667b49e3733438062ae416413b8fc8d42e1bd499ba15e1fb02fc55/maturin-1.13.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:dc91031e0619c1e28730279ef9ee5f106c9b9ec806b013f888676b242f892eb7", size = 9983094, upload-time = "2026-04-09T15:13:56.868Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/a6d651cfe8fc6bf2e892c90e3cdbb25c06d81c9115140d03ea1a68a97575/maturin-1.13.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:001741c6cff56aa8ea59a0d78ae990c0550d0e3e82b00b683eedb4158a8ef7e6", size = 9949980, upload-time = "2026-04-09T15:13:59.185Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/82c067464f848e38af9910bce55eb54302b1c1284a279d515dbfcf5994f5/maturin-1.13.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:01c845825c917c07c1d0b2c9032c59c16a7d383d1e649a46481d3e5693c2750f", size = 13186276, upload-time = "2026-04-09T15:13:45.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f4/25367baf1025580f047f9b37598bb3fadc416e24536afd4f28e190335c73/maturin-1.13.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f69093ed4a0e6464e52a7fc26d714f859ce15630ec8070743398c6bf41f38a9e", size = 10891837, upload-time = "2026-04-09T15:13:35.68Z" },
+    { url = "https://files.pythonhosted.org/packages/af/be/caafad8ce74974b7deafdf144d12f758993dfea4c66c9905b138f51a7792/maturin-1.13.1-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:c1490584f3c70af45466ee99065b49e6657ebdccac6b10571bb44681309c9396", size = 10351032, upload-time = "2026-04-09T15:14:01.632Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0e/970a721d27cfa410e8bfa0a1e32e6ef52cb8169692110a5fdabe1af3f570/maturin-1.13.1-py3-none-win32.whl", hash = "sha256:c6a720b252c99de072922dbe4432ab19662b6f80045b0355fec23bdfccb450da", size = 8855465, upload-time = "2026-04-09T15:13:51.122Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/7c1e0d65fa147d5479055a171541c82b8cdfc1c825d85a82240470f14176/maturin-1.13.1-py3-none-win_amd64.whl", hash = "sha256:a2017d2281203d0c6570240e7d746564d766d756105823b7de68bda6ae722711", size = 10230471, upload-time = "2026-04-09T15:13:53.89Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2a/afe0193b673a79ffd2e01ad999511b7e9e6b49af02bb3759d82a78c3043d/maturin-1.13.1-py3-none-win_arm64.whl", hash = "sha256:2839024dcd65776abb4759e5bca29941971e095574162a4d335191da4be9ff24", size = 8905575, upload-time = "2026-04-09T15:14:03.891Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Verbatim port of django-vcache's `src/async_bridge.rs` (MIT, David Burke / GlitchTip).

## What's in

- `src/async_bridge.rs`: tokio runtime singleton with PID-tracking fork detection, `RustAwaitable` PyO3 class, `RawResult` enum (Error → PyConnectionError, ServerError → PyRuntimeError).
- `src/test_helpers.rs`: PyO3 functions to drive `RustAwaitable` from Python tests (`_test_resolved_*`, `_test_delayed_bytes`, `_test_pending`, `_test_dropped`, `_test_error`, `_test_server_error`).
- `tests/rust/`: fast path, slow/callback path, cancellation, cross-event-loop reuse, fork-safety. 14 tests.
- CI: `test-rust` job on 3.14 and 3.14t (free-threaded).

## Tokio features

`rt-multi-thread, sync, time` — the `sync` feature is required for `oneshot` (vcache gets it transitively via `redis`'s `tokio-comp`); `time` is for the `_test_delayed_bytes` helper. We'll get the rest via `redis-rs` in #65.

## What's deferred

- Connection layer (#65) and command surface (#66) build on this. Nothing else changes here.
- Debug introspection (`get_runtime_info`, etc.) — not added.

## Verification

- `pytest tests/cache/ -n auto` — 3886 passed, 62 skipped (no regression).
- `pytest tests/rust/ -v` — 14 passed.

Closes #64.