### PR TITLE
feat: rust connection layer — standard / cluster / sentinel (#65)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,323 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "django-cachex"
 version = "0.3.0"
 dependencies = [
  "pyo3",
+ "redis",
+ "rustls",
  "tokio",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -17,16 +329,218 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -39,6 +553,24 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -117,6 +649,258 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redis"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44e94c96d8870a387d88ce3de3fdd608cbfc0705f03cb343cdde91509d3e49a"
+dependencies = [
+ "arc-swap",
+ "arcstr",
+ "async-lock",
+ "backon",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "crc16",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "log",
+ "lru",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "rustls",
+ "rustls-native-certs",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "url",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,10 +912,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tokio"
@@ -139,7 +944,34 @@ version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -147,3 +979,251 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,16 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.28", features = ["extension-module"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
+redis = { version = "1", features = [
+  "tokio-comp",
+  "connection-manager",
+  "cluster",
+  "cluster-async",
+  "tokio-rustls-comp",
+  "tls-rustls-insecure",
+  "cache-aio",
+] }
+rustls = { version = "0.23", features = ["ring"] }
 
 [profile.release]
 lto = true

--- a/django_cachex/_rust_clients.py
+++ b/django_cachex/_rust_clients.py
@@ -1,0 +1,124 @@
+"""Process-wide registry of Rust driver instances.
+
+One driver per (URL, options) tuple, shared across cache instances. PID-checked
+so post-fork children rebuild their own connection pools instead of inheriting
+the parent's tokio runtime / sockets.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import TYPE_CHECKING
+
+from django_cachex._driver import RustValkeyDriver  # ty: ignore[unresolved-import]
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable
+
+_CLIENTS: dict[Hashable, RustValkeyDriver] = {}
+_PID = os.getpid()
+_LOCK = threading.Lock()
+
+
+def _check_pid() -> None:
+    global _PID  # noqa: PLW0603
+    pid = os.getpid()
+    if pid != _PID:
+        _CLIENTS.clear()
+        _PID = pid
+
+
+def _get_or_create(key: Hashable, factory) -> RustValkeyDriver:  # noqa: ANN001
+    _check_pid()
+    with _LOCK:
+        driver = _CLIENTS.get(key)
+        if driver is None:
+            driver = factory()
+            _CLIENTS[key] = driver
+        return driver
+
+
+def get_driver_standard(
+    url: str,
+    *,
+    cache_max_size: int | None = None,
+    cache_ttl_secs: int | None = None,
+    ssl_ca_certs: str | None = None,
+    ssl_certfile: str | None = None,
+    ssl_keyfile: str | None = None,
+) -> RustValkeyDriver:
+    key = ("standard", url, cache_max_size, cache_ttl_secs, ssl_ca_certs, ssl_certfile, ssl_keyfile)
+    return _get_or_create(
+        key,
+        lambda: RustValkeyDriver.connect_standard(
+            url,
+            cache_max_size=cache_max_size,
+            cache_ttl_secs=cache_ttl_secs,
+            ssl_ca_certs=ssl_ca_certs,
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile=ssl_keyfile,
+        ),
+    )
+
+
+def get_driver_cluster(
+    urls: list[str],
+    *,
+    ssl_ca_certs: str | None = None,
+    ssl_certfile: str | None = None,
+    ssl_keyfile: str | None = None,
+) -> RustValkeyDriver:
+    key = ("cluster", tuple(urls), ssl_ca_certs, ssl_certfile, ssl_keyfile)
+    return _get_or_create(
+        key,
+        lambda: RustValkeyDriver.connect_cluster(
+            list(urls),
+            ssl_ca_certs=ssl_ca_certs,
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile=ssl_keyfile,
+        ),
+    )
+
+
+def get_driver_sentinel(
+    sentinel_urls: list[str],
+    service_name: str,
+    db: int,
+    *,
+    cache_max_size: int | None = None,
+    cache_ttl_secs: int | None = None,
+    ssl_ca_certs: str | None = None,
+    ssl_certfile: str | None = None,
+    ssl_keyfile: str | None = None,
+) -> RustValkeyDriver:
+    key = (
+        "sentinel",
+        tuple(sentinel_urls),
+        service_name,
+        db,
+        cache_max_size,
+        cache_ttl_secs,
+        ssl_ca_certs,
+        ssl_certfile,
+        ssl_keyfile,
+    )
+    return _get_or_create(
+        key,
+        lambda: RustValkeyDriver.connect_sentinel(
+            list(sentinel_urls),
+            service_name,
+            db,
+            cache_max_size=cache_max_size,
+            cache_ttl_secs=cache_ttl_secs,
+            ssl_ca_certs=ssl_ca_certs,
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile=ssl_keyfile,
+        ),
+    )
+
+
+def _reset_for_tests() -> None:
+    """Clear the registry. Test-only — production code must not call this."""
+    with _LOCK:
+        _CLIENTS.clear()

--- a/django_cachex/_rust_clients.py
+++ b/django_cachex/_rust_clients.py
@@ -14,24 +14,24 @@ from typing import TYPE_CHECKING
 from django_cachex._driver import RustValkeyDriver  # ty: ignore[unresolved-import]
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable
+    from collections.abc import Callable, Hashable
 
 _CLIENTS: dict[Hashable, RustValkeyDriver] = {}
 _PID = os.getpid()
 _LOCK = threading.Lock()
 
 
-def _check_pid() -> None:
+def _get_or_create(key: Hashable, factory: Callable[[], RustValkeyDriver]) -> RustValkeyDriver:
+    # Lock wraps both the PID check and the dict ops so a concurrent fork-detect
+    # under free-threaded 3.14t can't race two clears or skip an in-flight insert.
+    # `factory()` is a blocking connect() — we serialize it here intentionally;
+    # a double-checked pattern would let two callers race the same connect.
     global _PID  # noqa: PLW0603
-    pid = os.getpid()
-    if pid != _PID:
-        _CLIENTS.clear()
-        _PID = pid
-
-
-def _get_or_create(key: Hashable, factory) -> RustValkeyDriver:  # noqa: ANN001
-    _check_pid()
     with _LOCK:
+        pid = os.getpid()
+        if pid != _PID:
+            _CLIENTS.clear()
+            _PID = pid
         driver = _CLIENTS.get(key)
         if driver is None:
             driver = factory()
@@ -92,9 +92,11 @@ def get_driver_sentinel(
     ssl_certfile: str | None = None,
     ssl_keyfile: str | None = None,
 ) -> RustValkeyDriver:
+    # Sentinel nodes are equivalent — sort so reordered lists hit the same driver.
+    # (Cluster URLs are NOT sorted: node order can affect initial topology probe.)
     key = (
         "sentinel",
-        tuple(sentinel_urls),
+        tuple(sorted(sentinel_urls)),
         service_name,
         db,
         cache_max_size,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,11 @@ warn_unreachable = false
 django_settings_module = "tests.settings.base"
 
 [[tool.mypy.overrides]]
+# _driver is the maturin-built Rust extension; no stub file yet (planned with #66).
+module = "django_cachex._driver"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "lz4.*"
 ignore_missing_imports = true
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,206 @@
+// PyO3 driver wrapper for the Rust I/O driver.
+//
+// Adapted from django-vcache (MIT, by David Burke / GlitchTip):
+// https://gitlab.com/glitchtip/django-vcache/-/blob/main/src/client.rs
+//
+// Issue #65 lands only the connection layer + a slim sync surface
+// (`set_sync`, `get_sync`, `flushdb_sync`) needed to verify connectivity.
+// The full sync + async command surface is added in issue #66.
+
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+use crate::async_bridge::get_runtime;
+use crate::connection::{
+    ClientCacheOpts, TlsOpts, ValkeyConn, connect_cluster, connect_sentinel, connect_standard,
+};
+
+#[pyclass]
+pub struct RustValkeyDriver {
+    connection: ValkeyConn,
+}
+
+// Sync: release GIL, block on tokio runtime.
+macro_rules! sync_op {
+    ($py:expr, $self:expr, $conn:ident, $body:expr) => {{
+        let mut $conn = $self.connection.clone();
+        $py.detach(|| get_runtime().block_on(async { $body }))
+    }};
+}
+
+/// Classify a Redis error: connection/transient → PyConnectionError
+/// (swallowable by IGNORE_EXCEPTIONS), everything else → PyRuntimeError.
+fn to_py_err(e: redis::RedisError) -> PyErr {
+    if is_connection_error(&e) {
+        pyo3::exceptions::PyConnectionError::new_err(e.to_string())
+    } else {
+        pyo3::exceptions::PyRuntimeError::new_err(e.to_string())
+    }
+}
+
+fn is_connection_error(e: &redis::RedisError) -> bool {
+    matches!(
+        e.kind(),
+        redis::ErrorKind::Io
+            | redis::ErrorKind::Server(redis::ServerErrorKind::BusyLoading)
+            | redis::ErrorKind::Server(redis::ServerErrorKind::TryAgain)
+            | redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly)
+    ) || e.is_connection_dropped()
+        || e.is_connection_refusal()
+        || e.is_timeout()
+}
+
+fn make_cache_opts(max_size: Option<usize>, ttl_secs: Option<u64>) -> Option<ClientCacheOpts> {
+    if max_size.is_some() || ttl_secs.is_some() {
+        Some(ClientCacheOpts {
+            max_size: max_size.unwrap_or(10_000),
+            ttl_secs: ttl_secs.unwrap_or(300),
+        })
+    } else {
+        None
+    }
+}
+
+fn read_pem_file(param: &str, path: &str) -> PyResult<Vec<u8>> {
+    std::fs::read(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            pyo3::exceptions::PyFileNotFoundError::new_err(format!("{param} {path}: {e}"))
+        } else {
+            pyo3::exceptions::PyOSError::new_err(format!("{param} {path}: {e}"))
+        }
+    })
+}
+
+fn make_tls_opts(
+    ssl_ca_certs: Option<String>,
+    ssl_certfile: Option<String>,
+    ssl_keyfile: Option<String>,
+) -> PyResult<Option<TlsOpts>> {
+    if ssl_ca_certs.is_none() && ssl_certfile.is_none() && ssl_keyfile.is_none() {
+        return Ok(None);
+    }
+    if ssl_certfile.is_some() != ssl_keyfile.is_some() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "ssl_certfile and ssl_keyfile must both be provided for mTLS",
+        ));
+    }
+    let root_cert = ssl_ca_certs
+        .map(|p| read_pem_file("ssl_ca_certs", &p))
+        .transpose()?;
+    let client_cert = ssl_certfile
+        .map(|p| read_pem_file("ssl_certfile", &p))
+        .transpose()?;
+    let client_key = ssl_keyfile
+        .map(|p| read_pem_file("ssl_keyfile", &p))
+        .transpose()?;
+    Ok(Some(TlsOpts {
+        root_cert,
+        client_cert,
+        client_key,
+    }))
+}
+
+#[pymethods]
+impl RustValkeyDriver {
+    #[staticmethod]
+    #[pyo3(signature = (url, cache_max_size=None, cache_ttl_secs=None, ssl_ca_certs=None, ssl_certfile=None, ssl_keyfile=None))]
+    fn connect_standard(
+        py: Python<'_>,
+        url: &str,
+        cache_max_size: Option<usize>,
+        cache_ttl_secs: Option<u64>,
+        ssl_ca_certs: Option<String>,
+        ssl_certfile: Option<String>,
+        ssl_keyfile: Option<String>,
+    ) -> PyResult<Self> {
+        let url = url.to_string();
+        let cache_opts = make_cache_opts(cache_max_size, cache_ttl_secs);
+        let tls_opts = make_tls_opts(ssl_ca_certs, ssl_certfile, ssl_keyfile)?;
+        let conn = py
+            .detach(|| get_runtime().block_on(connect_standard(&url, cache_opts, tls_opts)))
+            .map_err(pyo3::exceptions::PyConnectionError::new_err)?;
+        Ok(Self { connection: conn })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (urls, ssl_ca_certs=None, ssl_certfile=None, ssl_keyfile=None))]
+    fn connect_cluster(
+        py: Python<'_>,
+        urls: Vec<String>,
+        ssl_ca_certs: Option<String>,
+        ssl_certfile: Option<String>,
+        ssl_keyfile: Option<String>,
+    ) -> PyResult<Self> {
+        let tls_opts = make_tls_opts(ssl_ca_certs, ssl_certfile, ssl_keyfile)?;
+        let conn = py
+            .detach(|| get_runtime().block_on(connect_cluster(urls, tls_opts)))
+            .map_err(pyo3::exceptions::PyConnectionError::new_err)?;
+        Ok(Self { connection: conn })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (sentinel_urls, service_name, db, cache_max_size=None, cache_ttl_secs=None, ssl_ca_certs=None, ssl_certfile=None, ssl_keyfile=None))]
+    fn connect_sentinel(
+        py: Python<'_>,
+        sentinel_urls: Vec<String>,
+        service_name: &str,
+        db: i64,
+        cache_max_size: Option<usize>,
+        cache_ttl_secs: Option<u64>,
+        ssl_ca_certs: Option<String>,
+        ssl_certfile: Option<String>,
+        ssl_keyfile: Option<String>,
+    ) -> PyResult<Self> {
+        let service_name = service_name.to_string();
+        let cache_opts = make_cache_opts(cache_max_size, cache_ttl_secs);
+        let tls_opts = make_tls_opts(ssl_ca_certs, ssl_certfile, ssl_keyfile)?;
+        let conn = py
+            .detach(|| {
+                get_runtime().block_on(connect_sentinel(
+                    sentinel_urls,
+                    &service_name,
+                    db,
+                    cache_opts,
+                    tls_opts,
+                ))
+            })
+            .map_err(pyo3::exceptions::PyConnectionError::new_err)?;
+        Ok(Self { connection: conn })
+    }
+
+    /// Returns (hits, misses, invalidations) or None if client-side caching disabled.
+    fn cache_statistics(&self) -> Option<(usize, usize, usize)> {
+        self.connection
+            .cache_statistics()
+            .map(|s| (s.hit, s.miss, s.invalidate))
+    }
+
+    // =========================================================================
+    // Slim test surface — full command surface comes in issue #66.
+    // =========================================================================
+
+    #[pyo3(signature = (key))]
+    fn get_sync(&self, py: Python<'_>, key: &str) -> PyResult<Option<Py<PyAny>>> {
+        let result: Result<Option<Vec<u8>>, _> = sync_op!(py, self, conn, conn.get_bytes(key).await);
+        match result.map_err(to_py_err)? {
+            Some(bytes) => Ok(Some(PyBytes::new(py, &bytes).into_any().unbind())),
+            None => Ok(None),
+        }
+    }
+
+    #[pyo3(signature = (key, value, ttl=None))]
+    fn set_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        value: &[u8],
+        ttl: Option<u64>,
+    ) -> PyResult<()> {
+        let value = value.to_vec();
+        sync_op!(py, self, conn, conn.set_bytes(key, value, ttl).await).map_err(to_py_err)
+    }
+
+    fn flushdb_sync(&self, py: Python<'_>) -> PyResult<()> {
+        sync_op!(py, self, conn, conn.flushdb().await).map_err(to_py_err)
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,1143 @@
+// Connection layer for the Rust I/O driver.
+//
+// Verbatim port from django-vcache (MIT, by David Burke / GlitchTip):
+// https://gitlab.com/glitchtip/django-vcache/-/blob/main/src/connection.rs
+// Keep in lockstep with upstream — do not diverge without discussion.
+
+use redis::aio::{ConnectionManager, ConnectionManagerConfig};
+use redis::caching::{CacheConfig, CacheStatistics};
+use redis::cluster::ClusterClient;
+use redis::cluster_async::ClusterConnection;
+use redis::{AsyncCommands, Client, RedisResult, TlsCertificates};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+/// Optional client-side caching parameters (passed from Python).
+#[derive(Clone, Debug)]
+pub struct ClientCacheOpts {
+    pub max_size: usize,
+    pub ttl_secs: u64,
+}
+
+/// TLS certificate options (PEM bytes, read from files by caller).
+#[derive(Clone)]
+pub struct TlsOpts {
+    pub root_cert: Option<Vec<u8>>,
+    pub client_cert: Option<Vec<u8>>,
+    pub client_key: Option<Vec<u8>>,
+}
+
+impl TlsOpts {
+    fn to_tls_certs(&self) -> TlsCertificates {
+        let client_tls = match (&self.client_cert, &self.client_key) {
+            (Some(cert), Some(key)) => Some(redis::ClientTlsConfig {
+                client_cert: cert.clone(),
+                client_key: key.clone(),
+            }),
+            _ => None,
+        };
+        TlsCertificates {
+            client_tls,
+            root_cert: self.root_cert.clone(),
+        }
+    }
+}
+
+/// Create a redis::Client, using `build_with_tls` when TLS opts are provided.
+fn create_client(url: &str, tls_opts: Option<&TlsOpts>) -> redis::RedisResult<Client> {
+    match tls_opts {
+        Some(opts) => Client::build_with_tls(url, opts.to_tls_certs()),
+        None => Client::open(url),
+    }
+}
+
+fn conn_manager_config(cache: Option<&ClientCacheOpts>) -> ConnectionManagerConfig {
+    let mut cfg = ConnectionManagerConfig::new()
+        .set_pipeline_buffer_size(1000)
+        .set_response_timeout(Some(Duration::from_secs(30)));
+    if let Some(opts) = cache {
+        let cc = CacheConfig::new()
+            .set_size(NonZeroUsize::new(opts.max_size).unwrap_or(NonZeroUsize::MIN))
+            .set_default_client_ttl(Duration::from_secs(opts.ttl_secs));
+        cfg = cfg.set_cache_config(cc);
+    }
+    cfg
+}
+
+/// Ensure the URL uses RESP3 protocol.
+fn url_with_resp3(url: &str) -> String {
+    if url.contains("protocol=") {
+        return url.to_string();
+    }
+    // Handle fragment (#...) — query params must come before it.
+    let (base, fragment) = match url.split_once('#') {
+        Some((b, f)) => (b, Some(f)),
+        None => (url, None),
+    };
+    let sep = if base.contains('?') { '&' } else { '?' };
+    match fragment {
+        Some(f) => format!("{base}{sep}protocol=resp3#{f}"),
+        None => format!("{base}{sep}protocol=resp3"),
+    }
+}
+
+/// Config for blocking operations — no response timeout since BLMOVE/BLMPOP
+/// intentionally wait for data (possibly minutes). Never has caching.
+fn blocking_conn_manager_config() -> ConnectionManagerConfig {
+    ConnectionManagerConfig::new()
+        .set_pipeline_buffer_size(1000)
+        .set_response_timeout(None)
+}
+
+/// Sentinel-aware connection that re-discovers master on failover.
+#[derive(Clone)]
+pub struct SentinelConn {
+    inner: Arc<RwLock<ConnectionManager>>,
+    sentinel_urls: Arc<[String]>,
+    service_name: Arc<str>,
+    db: i64,
+    is_blocking: bool,
+    cache_opts: Option<ClientCacheOpts>,
+    tls_opts: Option<TlsOpts>,
+}
+
+impl SentinelConn {
+    fn conn_config(&self) -> ConnectionManagerConfig {
+        if self.is_blocking {
+            blocking_conn_manager_config()
+        } else {
+            conn_manager_config(self.cache_opts.as_ref())
+        }
+    }
+
+    pub async fn get_conn(&self) -> ConnectionManager {
+        self.inner.read().await.clone()
+    }
+
+    fn is_failover_error(e: &redis::RedisError) -> bool {
+        matches!(
+            e.kind(),
+            redis::ErrorKind::Io
+                | redis::ErrorKind::Server(redis::ServerErrorKind::BusyLoading)
+                | redis::ErrorKind::Server(redis::ServerErrorKind::TryAgain)
+                | redis::ErrorKind::Server(redis::ServerErrorKind::ReadOnly)
+        ) || e.is_connection_dropped()
+    }
+
+    pub async fn rediscover(&self) -> RedisResult<()> {
+        for sentinel_url in self.sentinel_urls.iter() {
+            let client = match create_client(sentinel_url.as_str(), self.tls_opts.as_ref()) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let mut conn =
+                match ConnectionManager::new_with_config(client, conn_manager_config(None)).await {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+            let result: RedisResult<Vec<String>> = redis::cmd("SENTINEL")
+                .arg("get-master-addr-by-name")
+                .arg(&*self.service_name)
+                .query_async(&mut conn)
+                .await;
+
+            if let Ok(addr) = result {
+                if addr.len() == 2 {
+                    let scheme = if self.tls_opts.is_some() {
+                        "rediss"
+                    } else {
+                        "redis"
+                    };
+                    let base_url =
+                        format!("{scheme}://{}:{}/{}", addr[0], addr[1], self.db);
+                    let master_url = url_with_resp3(&base_url);
+                    let client =
+                        create_client(master_url.as_str(), self.tls_opts.as_ref())?;
+                    let new_mgr =
+                        ConnectionManager::new_with_config(client, self.conn_config()).await?;
+                    let mut guard = self.inner.write().await;
+                    *guard = new_mgr;
+                    return Ok(());
+                }
+            }
+        }
+        Err(redis::RedisError::from((
+            redis::ErrorKind::Io,
+            "Failed to rediscover master from any sentinel",
+        )))
+    }
+}
+
+/// Inner connection enum — one per connection type.
+/// All methods for individual Redis commands live here.
+#[derive(Clone)]
+enum ValkeyConnInner {
+    Standard(ConnectionManager),
+    Cluster(ClusterConnection),
+    Sentinel(SentinelConn),
+}
+
+// Macro to dispatch a redis command to the correct connection variant.
+// For sentinel, retries once on failover error after re-discovering master.
+macro_rules! dispatch_cmd {
+    ($self:expr, $cmd:expr) => {
+        match $self {
+            ValkeyConnInner::Standard(c) => $cmd.query_async(c).await,
+            ValkeyConnInner::Cluster(c) => $cmd.query_async(c).await,
+            ValkeyConnInner::Sentinel(s) => {
+                let cmd_retry = $cmd.clone();
+                let mut c = s.get_conn().await;
+                match $cmd.query_async(&mut c).await {
+                    Ok(v) => Ok(v),
+                    Err(e) if SentinelConn::is_failover_error(&e) => {
+                        s.rediscover().await?;
+                        let mut c = s.get_conn().await;
+                        cmd_retry.query_async(&mut c).await
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+        }
+    };
+}
+
+// Macro for sentinel retry on AsyncCommands methods.
+macro_rules! sentinel_retry {
+    ($s:expr, $c:ident, $op:expr) => {{
+        let mut $c = $s.get_conn().await;
+        match $op {
+            Ok(v) => Ok(v),
+            Err(e) if SentinelConn::is_failover_error(&e) => {
+                $s.rediscover().await?;
+                let mut $c = $s.get_conn().await;
+                $op
+            }
+            Err(e) => Err(e),
+        }
+    }};
+}
+
+// Macro for methods where all three variants use the same AsyncCommands call.
+macro_rules! conn_method {
+    ($self:expr, $c:ident, $op:expr) => {
+        match $self {
+            ValkeyConnInner::Standard($c) => $op,
+            ValkeyConnInner::Cluster($c) => $op,
+            ValkeyConnInner::Sentinel(s) => sentinel_retry!(s, $c, $op),
+        }
+    };
+}
+
+impl ValkeyConnInner {
+    pub async fn get_bytes(&mut self, key: &str) -> RedisResult<Option<Vec<u8>>> {
+        conn_method!(self, c, c.get(key).await)
+    }
+
+    pub async fn set_bytes(
+        &mut self,
+        key: &str,
+        value: Vec<u8>,
+        ttl: Option<u64>,
+    ) -> RedisResult<()> {
+        match ttl {
+            Some(t) => conn_method!(self, c, c.set_ex(key, value.as_slice(), t).await),
+            None => conn_method!(self, c, c.set(key, value.as_slice()).await),
+        }
+    }
+
+    pub async fn set_nx(
+        &mut self,
+        key: &str,
+        value: Vec<u8>,
+        ttl: Option<u64>,
+    ) -> RedisResult<bool> {
+        let mut cmd = redis::cmd("SET");
+        cmd.arg(key).arg(value).arg("NX");
+        if let Some(t) = ttl {
+            cmd.arg("EX").arg(t);
+        }
+        let result: Option<String> = dispatch_cmd!(self, cmd)?;
+        Ok(result.is_some())
+    }
+
+    pub async fn del(&mut self, key: &str) -> RedisResult<i64> {
+        conn_method!(self, c, c.del(key).await)
+    }
+
+    pub async fn del_many(&mut self, keys: &[String]) -> RedisResult<i64> {
+        match self {
+            Self::Cluster(c) => {
+                let mut total: i64 = 0;
+                for key in keys {
+                    let n: i64 = c.del(key.as_str()).await?;
+                    total += n;
+                }
+                Ok(total)
+            }
+            _ => {
+                let mut cmd = redis::cmd("DEL");
+                for key in keys {
+                    cmd.arg(key.as_str());
+                }
+                dispatch_cmd!(self, cmd)
+            }
+        }
+    }
+
+    pub async fn exists(&mut self, key: &str) -> RedisResult<bool> {
+        conn_method!(self, c, c.exists(key).await)
+    }
+
+    pub async fn expire(&mut self, key: &str, seconds: u64) -> RedisResult<bool> {
+        conn_method!(self, c, c.expire(key, seconds as i64).await)
+    }
+
+    pub async fn persist(&mut self, key: &str) -> RedisResult<bool> {
+        conn_method!(self, c, c.persist(key).await)
+    }
+
+    pub async fn mget_bytes(&mut self, keys: &[String]) -> RedisResult<Vec<Option<Vec<u8>>>> {
+        match self {
+            Self::Cluster(c) => {
+                let mut results = Vec::with_capacity(keys.len());
+                for key in keys {
+                    let r: Option<Vec<u8>> = c.get(key.as_str()).await?;
+                    results.push(r);
+                }
+                Ok(results)
+            }
+            _ => {
+                let mut cmd = redis::cmd("MGET");
+                cmd.arg(keys);
+                dispatch_cmd!(self, cmd)
+            }
+        }
+    }
+
+    pub async fn pipeline_set(
+        &mut self,
+        entries: &[(String, Vec<u8>)],
+        ttl: Option<u64>,
+    ) -> RedisResult<()> {
+        match self {
+            Self::Standard(c) => {
+                let mut pipe = redis::pipe();
+                for (key, value) in entries {
+                    match ttl {
+                        Some(t) => {
+                            pipe.set_ex(key.as_str(), value.as_slice(), t);
+                        }
+                        None => {
+                            pipe.set(key.as_str(), value.as_slice());
+                        }
+                    }
+                }
+                pipe.query_async::<()>(c).await
+            }
+            Self::Cluster(c) => {
+                for (key, value) in entries {
+                    match ttl {
+                        Some(t) => {
+                            c.set_ex::<_, _, ()>(key.as_str(), value.as_slice(), t)
+                                .await?;
+                        }
+                        None => {
+                            c.set::<_, _, ()>(key.as_str(), value.as_slice()).await?;
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Self::Sentinel(s) => {
+                let build_pipe = || {
+                    let mut pipe = redis::pipe();
+                    for (key, value) in entries {
+                        match ttl {
+                            Some(t) => {
+                                pipe.set_ex(key.as_str(), value.as_slice(), t);
+                            }
+                            None => {
+                                pipe.set(key.as_str(), value.as_slice());
+                            }
+                        }
+                    }
+                    pipe
+                };
+                let mut c = s.get_conn().await;
+                match build_pipe().query_async::<()>(&mut c).await {
+                    Ok(()) => Ok(()),
+                    Err(e) if SentinelConn::is_failover_error(&e) => {
+                        s.rediscover().await?;
+                        let mut c = s.get_conn().await;
+                        build_pipe().query_async::<()>(&mut c).await
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+        }
+    }
+
+    pub async fn flushdb(&mut self) -> RedisResult<()> {
+        dispatch_cmd!(self, redis::cmd("FLUSHDB"))
+    }
+
+    pub async fn incr_by(&mut self, key: &str, delta: i64) -> RedisResult<i64> {
+        conn_method!(self, c, c.incr(key, delta).await)
+    }
+
+    // Lock operations
+
+    pub async fn lock_acquire(
+        &mut self,
+        key: &str,
+        token: &str,
+        timeout_ms: Option<u64>,
+    ) -> RedisResult<bool> {
+        let mut cmd = redis::cmd("SET");
+        cmd.arg(key).arg(token).arg("NX");
+        if let Some(ms) = timeout_ms {
+            cmd.arg("PX").arg(ms);
+        }
+        let result: Option<String> = dispatch_cmd!(self, cmd)?;
+        Ok(result.is_some())
+    }
+
+    pub async fn lock_release(&mut self, key: &str, token: &str) -> RedisResult<i64> {
+        let script = r#"
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+            else
+                return 0
+            end
+        "#;
+        let mut cmd = redis::cmd("EVAL");
+        cmd.arg(script).arg(1).arg(key).arg(token);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn lock_extend(
+        &mut self,
+        key: &str,
+        token: &str,
+        additional_ms: u64,
+    ) -> RedisResult<i64> {
+        let script = r#"
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("pexpire", KEYS[1], ARGV[2])
+            else
+                return 0
+            end
+        "#;
+        let mut cmd = redis::cmd("EVAL");
+        cmd.arg(script)
+            .arg(1)
+            .arg(key)
+            .arg(token)
+            .arg(additional_ms);
+        dispatch_cmd!(self, cmd)
+    }
+
+    // Eval
+
+    pub async fn eval(
+        &mut self,
+        script: &str,
+        keys: &[String],
+        args: &[Vec<u8>],
+    ) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("EVAL");
+        cmd.arg(script).arg(keys.len());
+        for k in keys {
+            cmd.arg(k.as_str());
+        }
+        for a in args {
+            cmd.arg(a.as_slice());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn evalsha(
+        &mut self,
+        sha: &str,
+        keys: &[String],
+        args: &[Vec<u8>],
+    ) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("EVALSHA");
+        cmd.arg(sha).arg(keys.len());
+        for k in keys {
+            cmd.arg(k.as_str());
+        }
+        for a in args {
+            cmd.arg(a.as_slice());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn script_load(&mut self, script: &str) -> RedisResult<String> {
+        let mut cmd = redis::cmd("SCRIPT");
+        cmd.arg("LOAD").arg(script);
+        dispatch_cmd!(self, cmd)
+    }
+
+    /// Execute a pipeline of arbitrary commands.
+    pub async fn pipeline_exec(
+        &mut self,
+        commands: Vec<(String, Vec<Vec<u8>>)>,
+    ) -> RedisResult<Vec<redis::Value>> {
+        match self {
+            Self::Standard(c) => {
+                let mut pipe = redis::pipe();
+                for (cmd_name, args) in &commands {
+                    let mut cmd = redis::cmd(cmd_name);
+                    for a in args {
+                        cmd.arg(a.as_slice());
+                    }
+                    pipe.add_command(cmd);
+                }
+                pipe.query_async(c).await
+            }
+            Self::Cluster(_) => {
+                let mut results = Vec::with_capacity(commands.len());
+                for (cmd_name, args) in &commands {
+                    let mut cmd = redis::cmd(cmd_name);
+                    for a in args {
+                        cmd.arg(a.as_slice());
+                    }
+                    let val: redis::Value = dispatch_cmd!(self, cmd)?;
+                    results.push(val);
+                }
+                Ok(results)
+            }
+            Self::Sentinel(s) => {
+                let build_pipe = || {
+                    let mut pipe = redis::pipe();
+                    for (cmd_name, args) in &commands {
+                        let mut cmd = redis::cmd(cmd_name);
+                        for a in args {
+                            cmd.arg(a.as_slice());
+                        }
+                        pipe.add_command(cmd);
+                    }
+                    pipe
+                };
+                let mut c = s.get_conn().await;
+                match build_pipe().query_async(&mut c).await {
+                    Ok(v) => Ok(v),
+                    Err(e) if SentinelConn::is_failover_error(&e) => {
+                        s.rediscover().await?;
+                        let mut c = s.get_conn().await;
+                        build_pipe().query_async(&mut c).await
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+        }
+    }
+
+    // List operations
+
+    pub async fn lpush(&mut self, key: &str, values: Vec<Vec<u8>>) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("LPUSH");
+        cmd.arg(key);
+        for v in &values {
+            cmd.arg(v.as_slice());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn rpush(&mut self, key: &str, values: Vec<Vec<u8>>) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("RPUSH");
+        cmd.arg(key);
+        for v in &values {
+            cmd.arg(v.as_slice());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn rpop(&mut self, key: &str) -> RedisResult<Option<Vec<u8>>> {
+        conn_method!(self, c, c.rpop(key, None).await)
+    }
+
+    pub async fn lrange(
+        &mut self,
+        key: &str,
+        start: i64,
+        stop: i64,
+    ) -> RedisResult<Vec<Vec<u8>>> {
+        let mut cmd = redis::cmd("LRANGE");
+        cmd.arg(key).arg(start).arg(stop);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn lrem(&mut self, key: &str, count: i64, value: &[u8]) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("LREM");
+        cmd.arg(key).arg(count).arg(value);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn ltrim(&mut self, key: &str, start: i64, stop: i64) -> RedisResult<()> {
+        let mut cmd = redis::cmd("LTRIM");
+        cmd.arg(key).arg(start).arg(stop);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn llen(&mut self, key: &str) -> RedisResult<i64> {
+        conn_method!(self, c, c.llen(key).await)
+    }
+
+    pub async fn blmove(
+        &mut self,
+        source: &str,
+        destination: &str,
+        wherefrom: &str,
+        whereto: &str,
+        timeout: f64,
+    ) -> RedisResult<Option<Vec<u8>>> {
+        let mut cmd = redis::cmd("BLMOVE");
+        cmd.arg(source)
+            .arg(destination)
+            .arg(wherefrom)
+            .arg(whereto)
+            .arg(timeout);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn blmpop(
+        &mut self,
+        timeout: f64,
+        keys: &[String],
+        direction: &str,
+        count: i64,
+    ) -> RedisResult<Option<(String, Vec<Vec<u8>>)>> {
+        let mut cmd = redis::cmd("BLMPOP");
+        cmd.arg(timeout).arg(keys.len());
+        for k in keys {
+            cmd.arg(k.as_str());
+        }
+        cmd.arg(direction);
+        cmd.arg("COUNT").arg(count);
+        let val: redis::Value = dispatch_cmd!(self, cmd)?;
+        match val {
+            redis::Value::Nil => Ok(None),
+            redis::Value::Array(mut items) if items.len() == 2 => {
+                let elems_val = items.pop().unwrap();
+                let key_val = items.pop().unwrap();
+                let key: String = redis::from_redis_value(key_val)?;
+                let elements: Vec<Vec<u8>> = redis::from_redis_value(elems_val)?;
+                Ok(Some((key, elements)))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    // Scan
+
+    pub async fn scan_all(&mut self, pattern: &str, count: i64) -> RedisResult<Vec<String>> {
+        match self {
+            Self::Cluster(_) => {
+                let mut cmd = redis::cmd("KEYS");
+                cmd.arg(pattern);
+                dispatch_cmd!(self, cmd)
+            }
+            Self::Standard(c) => {
+                let mut all_keys = Vec::new();
+                let mut cursor: u64 = 0;
+                loop {
+                    let (new_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                        .arg(cursor)
+                        .arg("MATCH")
+                        .arg(pattern)
+                        .arg("COUNT")
+                        .arg(count)
+                        .query_async(c)
+                        .await?;
+                    all_keys.extend(keys);
+                    if new_cursor == 0 {
+                        break;
+                    }
+                    cursor = new_cursor;
+                }
+                Ok(all_keys)
+            }
+            Self::Sentinel(s) => {
+                let mut all_keys = Vec::new();
+                let mut cursor: u64 = 0;
+                let mut c = s.get_conn().await;
+                loop {
+                    let result: RedisResult<(u64, Vec<String>)> = redis::cmd("SCAN")
+                        .arg(cursor)
+                        .arg("MATCH")
+                        .arg(pattern)
+                        .arg("COUNT")
+                        .arg(count)
+                        .query_async(&mut c)
+                        .await;
+                    match result {
+                        Ok((new_cursor, keys)) => {
+                            all_keys.extend(keys);
+                            if new_cursor == 0 {
+                                break;
+                            }
+                            cursor = new_cursor;
+                        }
+                        Err(e) if cursor == 0 && SentinelConn::is_failover_error(&e) => {
+                            s.rediscover().await?;
+                            c = s.get_conn().await;
+                            all_keys.clear();
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+                Ok(all_keys)
+            }
+        }
+    }
+}
+
+// =========================================================================
+// Connection config — stored for lazy blocking connection creation
+// =========================================================================
+
+#[derive(Clone)]
+enum ConnConfig {
+    Standard {
+        url: Arc<str>,
+        tls_opts: Option<TlsOpts>,
+    },
+    Cluster {
+        urls: Arc<[String]>,
+        tls_opts: Option<TlsOpts>,
+    },
+    Sentinel {
+        sentinel_urls: Arc<[String]>,
+        service_name: Arc<str>,
+        db: i64,
+        tls_opts: Option<TlsOpts>,
+    },
+}
+
+impl ValkeyConnInner {
+    fn cache_statistics(&self) -> Option<CacheStatistics> {
+        match self {
+            Self::Standard(c) => c.get_cache_statistics(),
+            Self::Cluster(_) => None, // cluster connection doesn't expose this yet
+            Self::Sentinel(s) => {
+                // Can't block here — return None if lock is contested.
+                s.inner.try_read().ok().and_then(|c| c.get_cache_statistics())
+            }
+        }
+    }
+}
+
+// =========================================================================
+// ValkeyConn — public wrapper with separate regular + blocking connections
+// =========================================================================
+
+/// Public connection handle. Uses one connection for regular (fast) ops and
+/// a lazily-created second connection for blocking ops (BLMOVE, BLMPOP).
+///
+/// Redis processes commands sequentially per connection — a BLMOVE with a
+/// 1-second timeout blocks ALL other commands multiplexed on that connection.
+/// The separate blocking connection prevents this head-of-line blocking.
+#[derive(Clone)]
+pub struct ValkeyConn {
+    regular: ValkeyConnInner,
+    blocking: Arc<tokio::sync::OnceCell<ValkeyConnInner>>,
+    config: ConnConfig,
+}
+
+impl ValkeyConn {
+    /// Get or lazily create the blocking connection.
+    async fn get_blocking(&self) -> RedisResult<ValkeyConnInner> {
+        self.blocking
+            .get_or_try_init(|| async {
+                match &self.config {
+                    ConnConfig::Standard { url, tls_opts } => {
+                        let blocking_url = url_with_resp3(url);
+                        let client =
+                            create_client(blocking_url.as_str(), tls_opts.as_ref())?;
+                        let mgr = ConnectionManager::new_with_config(
+                            client,
+                            blocking_conn_manager_config(),
+                        )
+                        .await?;
+                        Ok(ValkeyConnInner::Standard(mgr))
+                    }
+                    ConnConfig::Cluster { urls, tls_opts } => {
+                        let url_refs: Vec<&str> =
+                            urls.iter().map(|s| s.as_str()).collect();
+                        let client = match tls_opts {
+                            Some(opts) => ClusterClient::builder(url_refs)
+                                .certs(opts.to_tls_certs())
+                                .build()?,
+                            None => ClusterClient::new(url_refs)?,
+                        };
+                        let conn = client.get_async_connection().await?;
+                        Ok(ValkeyConnInner::Cluster(conn))
+                    }
+                    ConnConfig::Sentinel {
+                        sentinel_urls,
+                        service_name,
+                        db,
+                        tls_opts,
+                    } => {
+                        create_sentinel_inner(
+                            sentinel_urls,
+                            service_name,
+                            *db,
+                            true,
+                            None,
+                            tls_opts.clone(),
+                        )
+                        .await
+                    }
+                }
+            })
+            .await
+            .cloned()
+    }
+
+    // === Regular ops — delegate to self.regular ===
+
+    pub async fn get_bytes(&mut self, key: &str) -> RedisResult<Option<Vec<u8>>> {
+        self.regular.get_bytes(key).await
+    }
+
+    pub async fn set_bytes(
+        &mut self,
+        key: &str,
+        value: Vec<u8>,
+        ttl: Option<u64>,
+    ) -> RedisResult<()> {
+        self.regular.set_bytes(key, value, ttl).await
+    }
+
+    pub async fn set_nx(
+        &mut self,
+        key: &str,
+        value: Vec<u8>,
+        ttl: Option<u64>,
+    ) -> RedisResult<bool> {
+        self.regular.set_nx(key, value, ttl).await
+    }
+
+    pub async fn del(&mut self, key: &str) -> RedisResult<i64> {
+        self.regular.del(key).await
+    }
+
+    pub async fn del_many(&mut self, keys: &[String]) -> RedisResult<i64> {
+        self.regular.del_many(keys).await
+    }
+
+    pub async fn exists(&mut self, key: &str) -> RedisResult<bool> {
+        self.regular.exists(key).await
+    }
+
+    pub async fn expire(&mut self, key: &str, seconds: u64) -> RedisResult<bool> {
+        self.regular.expire(key, seconds).await
+    }
+
+    pub async fn persist(&mut self, key: &str) -> RedisResult<bool> {
+        self.regular.persist(key).await
+    }
+
+    pub async fn mget_bytes(&mut self, keys: &[String]) -> RedisResult<Vec<Option<Vec<u8>>>> {
+        self.regular.mget_bytes(keys).await
+    }
+
+    pub async fn pipeline_set(
+        &mut self,
+        entries: &[(String, Vec<u8>)],
+        ttl: Option<u64>,
+    ) -> RedisResult<()> {
+        self.regular.pipeline_set(entries, ttl).await
+    }
+
+    pub async fn flushdb(&mut self) -> RedisResult<()> {
+        self.regular.flushdb().await
+    }
+
+    pub async fn incr_by(&mut self, key: &str, delta: i64) -> RedisResult<i64> {
+        self.regular.incr_by(key, delta).await
+    }
+
+    pub async fn lock_acquire(
+        &mut self,
+        key: &str,
+        token: &str,
+        timeout_ms: Option<u64>,
+    ) -> RedisResult<bool> {
+        self.regular.lock_acquire(key, token, timeout_ms).await
+    }
+
+    pub async fn lock_release(&mut self, key: &str, token: &str) -> RedisResult<i64> {
+        self.regular.lock_release(key, token).await
+    }
+
+    pub async fn lock_extend(
+        &mut self,
+        key: &str,
+        token: &str,
+        additional_ms: u64,
+    ) -> RedisResult<i64> {
+        self.regular.lock_extend(key, token, additional_ms).await
+    }
+
+    pub async fn eval(
+        &mut self,
+        script: &str,
+        keys: &[String],
+        args: &[Vec<u8>],
+    ) -> RedisResult<redis::Value> {
+        self.regular.eval(script, keys, args).await
+    }
+
+    pub async fn evalsha(
+        &mut self,
+        sha: &str,
+        keys: &[String],
+        args: &[Vec<u8>],
+    ) -> RedisResult<redis::Value> {
+        self.regular.evalsha(sha, keys, args).await
+    }
+
+    pub async fn script_load(&mut self, script: &str) -> RedisResult<String> {
+        self.regular.script_load(script).await
+    }
+
+    pub async fn pipeline_exec(
+        &mut self,
+        commands: Vec<(String, Vec<Vec<u8>>)>,
+    ) -> RedisResult<Vec<redis::Value>> {
+        self.regular.pipeline_exec(commands).await
+    }
+
+    pub async fn lpush(&mut self, key: &str, values: Vec<Vec<u8>>) -> RedisResult<i64> {
+        self.regular.lpush(key, values).await
+    }
+
+    pub async fn rpush(&mut self, key: &str, values: Vec<Vec<u8>>) -> RedisResult<i64> {
+        self.regular.rpush(key, values).await
+    }
+
+    pub async fn rpop(&mut self, key: &str) -> RedisResult<Option<Vec<u8>>> {
+        self.regular.rpop(key).await
+    }
+
+    pub async fn lrange(
+        &mut self,
+        key: &str,
+        start: i64,
+        stop: i64,
+    ) -> RedisResult<Vec<Vec<u8>>> {
+        self.regular.lrange(key, start, stop).await
+    }
+
+    pub async fn lrem(&mut self, key: &str, count: i64, value: &[u8]) -> RedisResult<i64> {
+        self.regular.lrem(key, count, value).await
+    }
+
+    pub async fn ltrim(&mut self, key: &str, start: i64, stop: i64) -> RedisResult<()> {
+        self.regular.ltrim(key, start, stop).await
+    }
+
+    pub async fn llen(&mut self, key: &str) -> RedisResult<i64> {
+        self.regular.llen(key).await
+    }
+
+    pub async fn scan_all(&mut self, pattern: &str, count: i64) -> RedisResult<Vec<String>> {
+        self.regular.scan_all(pattern, count).await
+    }
+
+    pub fn cache_statistics(&self) -> Option<CacheStatistics> {
+        self.regular.cache_statistics()
+    }
+
+    // === Blocking ops — use separate connection ===
+
+    pub async fn blmove(
+        &mut self,
+        source: &str,
+        destination: &str,
+        wherefrom: &str,
+        whereto: &str,
+        timeout: f64,
+    ) -> RedisResult<Option<Vec<u8>>> {
+        let mut conn = self.get_blocking().await?;
+        conn.blmove(source, destination, wherefrom, whereto, timeout)
+            .await
+    }
+
+    pub async fn blmpop(
+        &mut self,
+        timeout: f64,
+        keys: &[String],
+        direction: &str,
+        count: i64,
+    ) -> RedisResult<Option<(String, Vec<Vec<u8>>)>> {
+        let mut conn = self.get_blocking().await?;
+        conn.blmpop(timeout, keys, direction, count).await
+    }
+}
+
+// =========================================================================
+// Connection constructors
+// =========================================================================
+
+/// Helper: create a SentinelConn inner (used by both regular and lazy blocking).
+async fn create_sentinel_inner(
+    sentinel_urls: &[String],
+    service_name: &str,
+    db: i64,
+    is_blocking: bool,
+    cache_opts: Option<ClientCacheOpts>,
+    tls_opts: Option<TlsOpts>,
+) -> RedisResult<ValkeyConnInner> {
+    let config = if is_blocking {
+        blocking_conn_manager_config()
+    } else {
+        conn_manager_config(cache_opts.as_ref())
+    };
+    let mut last_err = String::from("No sentinels provided");
+
+    for sentinel_url in sentinel_urls {
+        let client = match create_client(sentinel_url.as_str(), tls_opts.as_ref()) {
+            Ok(c) => c,
+            Err(e) => {
+                last_err = format!("Sentinel {sentinel_url}: {e}");
+                continue;
+            }
+        };
+
+        let mut conn =
+            match ConnectionManager::new_with_config(client, conn_manager_config(None)).await {
+                Ok(c) => c,
+                Err(e) => {
+                    last_err = format!("Sentinel {sentinel_url}: {e}");
+                    continue;
+                }
+            };
+
+        let result: RedisResult<Vec<String>> = redis::cmd("SENTINEL")
+            .arg("get-master-addr-by-name")
+            .arg(service_name)
+            .query_async(&mut conn)
+            .await;
+
+        match result {
+            Ok(addr) if addr.len() == 2 => {
+                let scheme = if tls_opts.is_some() { "rediss" } else { "redis" };
+                let base_url =
+                    format!("{scheme}://{}:{}/{}", addr[0], addr[1], db);
+                let master_url = url_with_resp3(&base_url);
+                let master_client =
+                    create_client(master_url.as_str(), tls_opts.as_ref())?;
+                let mgr = ConnectionManager::new_with_config(master_client, config).await?;
+                return Ok(ValkeyConnInner::Sentinel(SentinelConn {
+                    inner: Arc::new(RwLock::new(mgr)),
+                    sentinel_urls: Arc::from(sentinel_urls),
+                    service_name: Arc::from(service_name),
+                    db,
+                    is_blocking,
+                    cache_opts,
+                    tls_opts,
+                }));
+            }
+            Ok(_) => {
+                last_err = format!("Sentinel {sentinel_url}: unexpected response format");
+            }
+            Err(e) => {
+                last_err = format!("Sentinel {sentinel_url}: {e}");
+            }
+        }
+    }
+
+    Err(redis::RedisError::from((
+        redis::ErrorKind::Io,
+        "Failed to discover master from any sentinel",
+        last_err,
+    )))
+}
+
+/// Connect to a single Valkey/Redis node.
+pub async fn connect_standard(
+    url: &str,
+    cache_opts: Option<ClientCacheOpts>,
+    tls_opts: Option<TlsOpts>,
+) -> Result<ValkeyConn, String> {
+    let conn_url = url_with_resp3(url);
+    let client = create_client(conn_url.as_str(), tls_opts.as_ref())
+        .map_err(|e| format!("Invalid URL: {e}"))?;
+    let mgr =
+        ConnectionManager::new_with_config(client, conn_manager_config(cache_opts.as_ref()))
+            .await
+            .map_err(|e| format!("Connection failed: {e}"))?;
+    Ok(ValkeyConn {
+        regular: ValkeyConnInner::Standard(mgr),
+        blocking: Arc::new(tokio::sync::OnceCell::new()),
+        config: ConnConfig::Standard {
+            url: Arc::from(url),
+            tls_opts,
+        },
+    })
+}
+
+/// Connect to a Valkey/Redis cluster.
+pub async fn connect_cluster(
+    urls: Vec<String>,
+    tls_opts: Option<TlsOpts>,
+) -> Result<ValkeyConn, String> {
+    // Client-side caching not yet supported for cluster mode in redis-rs.
+    let url_refs: Vec<&str> = urls.iter().map(|s| s.as_str()).collect();
+    let client = match &tls_opts {
+        Some(opts) => ClusterClient::builder(url_refs)
+            .certs(opts.to_tls_certs())
+            .build(),
+        None => ClusterClient::new(url_refs),
+    }
+    .map_err(|e| format!("Invalid cluster URLs: {e}"))?;
+    let conn = client
+        .get_async_connection()
+        .await
+        .map_err(|e| format!("Cluster connection failed: {e}"))?;
+    Ok(ValkeyConn {
+        regular: ValkeyConnInner::Cluster(conn),
+        blocking: Arc::new(tokio::sync::OnceCell::new()),
+        config: ConnConfig::Cluster {
+            urls: Arc::from(urls),
+            tls_opts,
+        },
+    })
+}
+
+/// Connect via Sentinel with automatic failover support.
+pub async fn connect_sentinel(
+    sentinel_urls: Vec<String>,
+    service_name: &str,
+    db: i64,
+    cache_opts: Option<ClientCacheOpts>,
+    tls_opts: Option<TlsOpts>,
+) -> Result<ValkeyConn, String> {
+    let inner = create_sentinel_inner(
+        &sentinel_urls,
+        service_name,
+        db,
+        false,
+        cache_opts,
+        tls_opts.clone(),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(ValkeyConn {
+        regular: inner,
+        blocking: Arc::new(tokio::sync::OnceCell::new()),
+        config: ConnConfig::Sentinel {
+            sentinel_urls: Arc::from(sentinel_urls),
+            service_name: Arc::from(service_name),
+            db,
+            tls_opts,
+        },
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,11 @@
 // https://gitlab.com/glitchtip/django-vcache
 
 mod async_bridge;
+mod client;
+// Full ValkeyConn surface comes online in issue #66; suppress dead-code warnings
+// for methods/fields wired up there (lock_*, eval, list/stream ops, blocking conn).
+#[allow(dead_code)]
+mod connection;
 mod test_helpers;
 
 use pyo3::prelude::*;
@@ -11,6 +16,7 @@ use pyo3::prelude::*;
 #[pymodule]
 fn _driver(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<async_bridge::RustAwaitable>()?;
+    m.add_class::<client::RustValkeyDriver>()?;
     m.add_function(wrap_pyfunction!(test_helpers::_test_resolved_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(test_helpers::_test_resolved_none, m)?)?;
     m.add_function(wrap_pyfunction!(test_helpers::_test_resolved_int, m)?)?;

--- a/tests/rust/test_clients_registry.py
+++ b/tests/rust/test_clients_registry.py
@@ -47,6 +47,15 @@ def test_sentinel_key_includes_service_name_and_db(sentinel_container):
     assert a is b
 
 
+def test_sentinel_url_order_does_not_create_duplicate(sentinel_container):
+    # Sentinel nodes are equivalent — reordered URL lists must reuse the same driver.
+    base = f"redis://{sentinel_container.host}:{sentinel_container.port}"
+    urls = [base, "redis://unreachable.example:26379", "redis://other.example:26379"]
+    a = get_driver_sentinel(urls, "mymaster", 0)
+    b = get_driver_sentinel(list(reversed(urls)), "mymaster", 0)
+    assert a is b
+
+
 def test_pid_change_clears_registry(redis_container):
     url = f"redis://{redis_container.host}:{redis_container.port}/0"
     first = get_driver_standard(url)

--- a/tests/rust/test_clients_registry.py
+++ b/tests/rust/test_clients_registry.py
@@ -1,0 +1,59 @@
+import os
+from unittest.mock import patch
+
+from django_cachex import _rust_clients
+from django_cachex._rust_clients import (
+    _CLIENTS,
+    _reset_for_tests,
+    get_driver_cluster,
+    get_driver_sentinel,
+    get_driver_standard,
+)
+
+
+def setup_function():
+    _reset_for_tests()
+
+
+def test_same_url_returns_same_driver(redis_container):
+    url = f"redis://{redis_container.host}:{redis_container.port}/0"
+    a = get_driver_standard(url)
+    b = get_driver_standard(url)
+    assert a is b
+
+
+def test_different_options_get_different_drivers(redis_container):
+    url = f"redis://{redis_container.host}:{redis_container.port}/0"
+    a = get_driver_standard(url)
+    b = get_driver_standard(url, cache_max_size=128)
+    assert a is not b
+
+
+def test_cluster_key_uses_url_tuple(cluster_container):
+    host, port = cluster_container
+    urls = [f"redis://{host}:{port + i}" for i in range(6)]
+    a = get_driver_cluster(urls)
+    b = get_driver_cluster(urls)
+    assert a is b
+    # Same set in different order is treated as a different key (intentional).
+    c = get_driver_cluster(list(reversed(urls)))
+    assert c is not a
+
+
+def test_sentinel_key_includes_service_name_and_db(sentinel_container):
+    urls = [f"redis://{sentinel_container.host}:{sentinel_container.port}"]
+    a = get_driver_sentinel(urls, "mymaster", 0)
+    b = get_driver_sentinel(urls, "mymaster", 0)
+    assert a is b
+
+
+def test_pid_change_clears_registry(redis_container):
+    url = f"redis://{redis_container.host}:{redis_container.port}/0"
+    first = get_driver_standard(url)
+    assert _CLIENTS  # populated
+
+    with patch.object(_rust_clients, "_PID", os.getpid() + 1):
+        second = get_driver_standard(url)
+
+    assert second is not first
+    assert len(_CLIENTS) == 1  # registry was cleared, then repopulated with `second`

--- a/tests/rust/test_driver_client_cache.py
+++ b/tests/rust/test_driver_client_cache.py
@@ -44,9 +44,11 @@ def test_client_side_cache_invalidates_on_write(redis_container):
     other.set_sync("k", b"v2")
 
     # Read until we observe the new value (gives the invalidation push time to land).
+    # 5s deadline tolerates slow CI runners; on a healthy box the push lands in <100ms.
     import time
 
-    for _ in range(50):
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
         if driver.get_sync("k") == b"v2":
             break
         time.sleep(0.02)

--- a/tests/rust/test_driver_client_cache.py
+++ b/tests/rust/test_driver_client_cache.py
@@ -1,0 +1,58 @@
+from django_cachex._driver import RustValkeyDriver
+
+
+def test_cache_statistics_disabled_by_default(redis_container):
+    driver = RustValkeyDriver.connect_standard(f"redis://{redis_container.host}:{redis_container.port}/0")
+    assert driver.cache_statistics() is None
+
+
+def test_client_side_cache_records_hits(redis_container):
+    driver = RustValkeyDriver.connect_standard(
+        f"redis://{redis_container.host}:{redis_container.port}/0",
+        cache_max_size=128,
+        cache_ttl_secs=60,
+    )
+    driver.flushdb_sync()
+    driver.set_sync("k", b"v")
+
+    # First read populates the client cache (miss).
+    assert driver.get_sync("k") == b"v"
+    # Subsequent reads hit the local cache.
+    for _ in range(5):
+        assert driver.get_sync("k") == b"v"
+
+    stats = driver.cache_statistics()
+    assert stats is not None
+    hits, _misses, _invalidates = stats
+    assert hits >= 1
+
+
+def test_client_side_cache_invalidates_on_write(redis_container):
+    driver = RustValkeyDriver.connect_standard(
+        f"redis://{redis_container.host}:{redis_container.port}/0",
+        cache_max_size=128,
+        cache_ttl_secs=60,
+    )
+    driver.flushdb_sync()
+
+    driver.set_sync("k", b"v1")
+    assert driver.get_sync("k") == b"v1"  # populates cache
+    assert driver.get_sync("k") == b"v1"  # hit
+
+    # Write the same key from a separate connection (server pushes invalidation).
+    other = RustValkeyDriver.connect_standard(f"redis://{redis_container.host}:{redis_container.port}/0")
+    other.set_sync("k", b"v2")
+
+    # Read until we observe the new value (gives the invalidation push time to land).
+    import time
+
+    for _ in range(50):
+        if driver.get_sync("k") == b"v2":
+            break
+        time.sleep(0.02)
+    assert driver.get_sync("k") == b"v2"
+
+    stats = driver.cache_statistics()
+    assert stats is not None
+    _hits, _misses, invalidates = stats
+    assert invalidates >= 1

--- a/tests/rust/test_driver_cluster.py
+++ b/tests/rust/test_driver_cluster.py
@@ -1,0 +1,29 @@
+from django_cachex._driver import RustValkeyDriver
+
+from tests.fixtures.containers import CLUSTER_NODE_COUNT
+
+
+def _cluster_urls(host: str, port: int) -> list[str]:
+    return [f"redis://{host}:{port + i}" for i in range(CLUSTER_NODE_COUNT)]
+
+
+def test_connect_cluster_and_round_trip(cluster_container):
+    host, port = cluster_container
+    driver = RustValkeyDriver.connect_cluster(_cluster_urls(host, port))
+    driver.flushdb_sync()
+
+    driver.set_sync("a", b"1")
+    driver.set_sync("b", b"2")
+    driver.set_sync("c", b"3")
+
+    assert driver.get_sync("a") == b"1"
+    assert driver.get_sync("b") == b"2"
+    assert driver.get_sync("c") == b"3"
+
+
+def test_cluster_get_missing_returns_none(cluster_container):
+    host, port = cluster_container
+    driver = RustValkeyDriver.connect_cluster(_cluster_urls(host, port))
+    driver.flushdb_sync()
+
+    assert driver.get_sync("nope") is None

--- a/tests/rust/test_driver_sentinel.py
+++ b/tests/rust/test_driver_sentinel.py
@@ -1,0 +1,24 @@
+from django_cachex._driver import RustValkeyDriver
+
+
+def test_connect_sentinel_and_round_trip(sentinel_container):
+    driver = RustValkeyDriver.connect_sentinel(
+        [f"redis://{sentinel_container.host}:{sentinel_container.port}"],
+        "mymaster",
+        0,
+    )
+    driver.flushdb_sync()
+
+    driver.set_sync("k", b"v")
+    assert driver.get_sync("k") == b"v"
+
+
+def test_sentinel_with_no_quorum_fails(sentinel_container):
+    import pytest
+
+    with pytest.raises(ConnectionError):
+        RustValkeyDriver.connect_sentinel(
+            [f"redis://{sentinel_container.host}:{sentinel_container.port}"],
+            "no-such-service",
+            0,
+        )

--- a/tests/rust/test_driver_sentinel_failover.py
+++ b/tests/rust/test_driver_sentinel_failover.py
@@ -1,0 +1,93 @@
+import time
+from contextlib import suppress
+from typing import TYPE_CHECKING, NamedTuple
+
+import pytest
+from django_cachex._driver import RustValkeyDriver
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+from tests.fixtures.containers import (
+    BITNAMI_REDIS_IMAGE,
+    _get_container_internal_ip,
+    _start_bitnami_master,
+    _start_bitnami_replica,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+class FailoverSetup(NamedTuple):
+    sentinel_host: str
+    sentinel_port: int
+    master: DockerContainer
+    replica: DockerContainer
+    sentinel: DockerContainer
+
+
+@pytest.fixture
+def failover_setup() -> Generator[FailoverSetup]:
+    """Spin up master + replica + sentinel pointed at master with quorum=1.
+
+    Function-scoped because the test kills the master.
+    """
+    master = _start_bitnami_master()
+    master_ip = _get_container_internal_ip(master.container)
+    replica = _start_bitnami_replica(master_ip)
+
+    sentinel_conf = (
+        f"sentinel monitor mymaster {master_ip} 6379 1\n"
+        "sentinel down-after-milliseconds mymaster 2000\n"
+        "sentinel failover-timeout mymaster 10000\n"
+        "sentinel parallel-syncs mymaster 1\n"
+    )
+    sentinel = DockerContainer(BITNAMI_REDIS_IMAGE)
+    sentinel.with_exposed_ports(26379)
+    sentinel.with_env("ALLOW_EMPTY_PASSWORD", "yes")
+    sentinel.with_command(
+        f"sh -c 'echo \"{sentinel_conf}\" > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf --port 26379'",
+    )
+    sentinel.start()
+    wait_for_logs(sentinel, r"\+monitor master")
+
+    yield FailoverSetup(
+        sentinel_host=sentinel.get_container_host_ip(),
+        sentinel_port=int(sentinel.get_exposed_port(26379)),
+        master=master.container,
+        replica=replica.container,
+        sentinel=sentinel,
+    )
+
+    for c in (sentinel, replica.container, master.container):
+        with suppress(Exception):
+            c.stop()
+
+
+def test_sentinel_rediscovers_master_after_failover(failover_setup):
+    driver = RustValkeyDriver.connect_sentinel(
+        [f"redis://{failover_setup.sentinel_host}:{failover_setup.sentinel_port}"],
+        "mymaster",
+        0,
+    )
+    driver.set_sync("k", b"before")
+    assert driver.get_sync("k") == b"before"
+
+    failover_setup.master.stop()
+
+    # Sentinel needs to detect down-after-ms (2s) and complete failover.
+    # The driver's first call after the master dies will hit the failover error
+    # set, run rediscover(), pick up the promoted replica, and retry.
+    deadline = time.monotonic() + 30
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            driver.set_sync("k", b"after")
+        except (ConnectionError, RuntimeError) as e:
+            last_err = e
+            time.sleep(0.5)
+            continue
+        if driver.get_sync("k") == b"after":
+            return
+        time.sleep(0.5)
+    pytest.fail(f"failover did not complete within 30s; last error: {last_err}")

--- a/tests/rust/test_driver_standard.py
+++ b/tests/rust/test_driver_standard.py
@@ -1,0 +1,31 @@
+from django_cachex._driver import RustValkeyDriver
+
+
+def test_connect_and_round_trip(redis_container):
+    driver = RustValkeyDriver.connect_standard(f"redis://{redis_container.host}:{redis_container.port}/0")
+    driver.flushdb_sync()
+
+    driver.set_sync("k", b"v")
+    assert driver.get_sync("k") == b"v"
+
+
+def test_get_returns_none_for_missing_key(redis_container):
+    driver = RustValkeyDriver.connect_standard(f"redis://{redis_container.host}:{redis_container.port}/0")
+    driver.flushdb_sync()
+
+    assert driver.get_sync("nope") is None
+
+
+def test_set_with_ttl(redis_container):
+    driver = RustValkeyDriver.connect_standard(f"redis://{redis_container.host}:{redis_container.port}/0")
+    driver.flushdb_sync()
+
+    driver.set_sync("k", b"v", ttl=100)
+    assert driver.get_sync("k") == b"v"
+
+
+def test_connection_error_on_bad_host():
+    import pytest
+
+    with pytest.raises(ConnectionError):
+        RustValkeyDriver.connect_standard("redis://127.0.0.1:1/0")


### PR DESCRIPTION
## Summary

Closes #65. Lays the redis-rs connection foundation for the Rust I/O driver.

- **Verbatim port** of [django-vcache `connection.rs`](https://gitlab.com/glitchtip/django-vcache/-/blob/main/src/connection.rs) (MIT, GlitchTip), with attribution. Keep in lockstep — divergence requires discussion.
- **Cargo deps**: `redis 1` (`tokio-comp`, `connection-manager`, `cluster`, `cluster-async`, `tokio-rustls-comp`, `tls-rustls-insecure`, `cache-aio`) and `rustls 0.23` (`ring`).
- **`src/connection.rs`**: `ValkeyConn` enum (Standard / Cluster / Sentinel), dispatch macros, sentinel rediscover loop on `Io | BusyLoading | TryAgain | ReadOnly | connection_dropped`, lazily-init blocking connection, client-side cache config (RESP3 forced).
- **`src/client.rs`**: `RustValkeyDriver` PyO3 class with `connect_standard` / `connect_cluster` / `connect_sentinel` constructors, TLS PEM loading helper (`ssl_ca_certs` / `ssl_certfile` / `ssl_keyfile`), error classifier, `cache_statistics()`. **Slim** test surface: only `set_sync` / `get_sync` / `flushdb_sync` exposed — full sync + async command surface lands in #66.
- **`django_cachex/_rust_clients.py`**: process-wide PID-checked registry keyed by `(mode, location, cache_*, ssl_*)`. One driver per (URL, options) tuple, shared across cache instances.

### Tests (17 new, all passing)

- `test_driver_standard.py` — round-trip set/get/flushdb, missing key returns `None`, bad host raises `ConnectionError`
- `test_driver_cluster.py` — 6-node cluster (3 masters + 3 replicas), multi-key writes
- `test_driver_sentinel.py` — basic sentinel connectivity, unknown service raises
- `test_driver_client_cache.py` — opt-in client-side cache records hits, server invalidations land
- `test_driver_sentinel_failover.py` — master + replica + sentinel; kills master, asserts driver rediscovers via the SentinelConn rediscover loop and resumes serving
- `test_clients_registry.py` — same options reuse driver, different options new instance, PID change clears registry

### Out of scope (deferred)

- TLS integration test (helper code shipped, integration test with TLS-enabled testcontainer deferred — explicitly agreed)
- Full sync + async command surface (#66)
- Django cache backend wiring (#68)

## Test plan

- [x] `cargo build --release` clean
- [x] `pytest tests/rust/` — 32 tests pass (15 prior async-bridge + 17 new)
- [x] `mypy django_cachex/` clean
- [x] `ty check django_cachex/` clean
- [x] `ruff check` clean
- [ ] CI green on 3.14 + 3.14t