### PR TITLE
feat: rust full PyO3 command surface (#66)

### DIFF
--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -10,7 +10,7 @@
 // the load-bearing part and must not drift accidentally.
 
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyList, PyString, PyTuple};
+use pyo3::types::{PyBytes, PyDict, PyList, PyString, PyTuple};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use tokio::runtime::Runtime;
@@ -78,14 +78,81 @@ pub enum RawResult {
     OptBytes(Option<Vec<u8>>),
     Bool(bool),
     Int(i64),
+    OptInt(Option<i64>),
+    F64(f64),
+    OptF64(Option<f64>),
     OptBytesList(Vec<Option<Vec<u8>>>),
     BytesList(Vec<Vec<u8>>),
     StringList(Vec<String>),
+    /// Field/value pairs for HGETALL/HMSET-style results (bytes value).
+    BytesPairs(Vec<(Vec<u8>, Vec<u8>)>),
+    /// Member/score pairs for ZRANGE WITHSCORES, ZPOPMIN/MAX.
+    ScoredMembers(Vec<(Vec<u8>, f64)>),
     OptKeyAndBytesList(Option<(String, Vec<Vec<u8>>)>),
+    /// Generic redis::Value, recursively converted to Python.
+    /// Used for EVAL/EVALSHA, INFO, CLIENT LIST, XREAD, XRANGE, and other
+    /// commands whose return shape varies enough that a typed variant doesn't help.
+    Value(redis::Value),
     /// Connection/IO error → PyConnectionError (swallowed by IGNORE_EXCEPTIONS)
     Error(String),
     /// Data/server error → PyRuntimeError (NOT swallowed, indicates real problems)
     ServerError(String),
+}
+
+/// Recursively convert a `redis::Value` to a Python object.
+/// Bulk strings and simple strings → bytes. Integers → int. Booleans → bool.
+/// Arrays → list. Maps → dict (with bytes/str keys). Nil → None. Doubles → float.
+fn redis_value_to_py(py: Python<'_>, v: redis::Value) -> PyResult<Py<PyAny>> {
+    match v {
+        redis::Value::Nil => Ok(py.None()),
+        redis::Value::Int(i) => Ok(i.into_pyobject(py)?.into_any().unbind()),
+        redis::Value::BulkString(b) => Ok(PyBytes::new(py, &b).into_any().unbind()),
+        redis::Value::SimpleString(s) => Ok(PyBytes::new(py, s.as_bytes()).into_any().unbind()),
+        redis::Value::Boolean(b) => Ok(b.into_pyobject(py)?.to_owned().into_any().unbind()),
+        redis::Value::Double(f) => Ok(f.into_pyobject(py)?.into_any().unbind()),
+        redis::Value::Okay => Ok(true.into_pyobject(py)?.to_owned().into_any().unbind()),
+        redis::Value::Array(items) => {
+            let py_items: Vec<Py<PyAny>> = items
+                .into_iter()
+                .map(|item| redis_value_to_py(py, item))
+                .collect::<PyResult<_>>()?;
+            Ok(PyList::new(py, py_items)?.into_any().unbind())
+        }
+        redis::Value::Map(pairs) => {
+            let dict = PyDict::new(py);
+            for (k, val) in pairs {
+                let k_py = redis_value_to_py(py, k)?;
+                let v_py = redis_value_to_py(py, val)?;
+                dict.set_item(k_py, v_py)?;
+            }
+            Ok(dict.into_any().unbind())
+        }
+        redis::Value::Set(items) => {
+            // Redis sets via RESP3 — return as list to preserve order; Python can `set(...)` if needed.
+            let py_items: Vec<Py<PyAny>> = items
+                .into_iter()
+                .map(|item| redis_value_to_py(py, item))
+                .collect::<PyResult<_>>()?;
+            Ok(PyList::new(py, py_items)?.into_any().unbind())
+        }
+        redis::Value::Attribute { data, .. } => redis_value_to_py(py, *data),
+        redis::Value::Push { kind: _, data } => {
+            let py_items: Vec<Py<PyAny>> = data
+                .into_iter()
+                .map(|item| redis_value_to_py(py, item))
+                .collect::<PyResult<_>>()?;
+            Ok(PyList::new(py, py_items)?.into_any().unbind())
+        }
+        redis::Value::BigNumber(n) => Ok(PyString::new(py, &n.to_string()).into_any().unbind()),
+        redis::Value::VerbatimString { text, .. } => {
+            Ok(PyBytes::new(py, text.as_bytes()).into_any().unbind())
+        }
+        redis::Value::ServerError(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "{e:?}"
+        ))),
+        // redis::Value is marked non_exhaustive — fall back to the Debug repr.
+        other => Ok(PyString::new(py, &format!("{other:?}")).into_any().unbind()),
+    }
 }
 
 impl RawResult {
@@ -131,6 +198,33 @@ impl RawResult {
                 Ok(PyTuple::new(py, [py_key, py_list])?.into_any().unbind())
             }
             RawResult::OptKeyAndBytesList(None) => Ok(py.None()),
+            RawResult::OptInt(Some(n)) => Ok(n.into_pyobject(py)?.into_any().unbind()),
+            RawResult::OptInt(None) => Ok(py.None()),
+            RawResult::F64(f) => Ok(f.into_pyobject(py)?.into_any().unbind()),
+            RawResult::OptF64(Some(f)) => Ok(f.into_pyobject(py)?.into_any().unbind()),
+            RawResult::OptF64(None) => Ok(py.None()),
+            RawResult::BytesPairs(pairs) => {
+                // Returned as a dict {bytes: bytes} so async HGETALL matches sync.
+                let dict = PyDict::new(py);
+                for (k, v) in pairs {
+                    let k_py = PyBytes::new(py, &k).into_any().unbind();
+                    let v_py = PyBytes::new(py, &v).into_any().unbind();
+                    dict.set_item(k_py, v_py)?;
+                }
+                Ok(dict.into_any().unbind())
+            }
+            RawResult::ScoredMembers(items) => {
+                let py_items: Vec<Py<PyAny>> = items
+                    .into_iter()
+                    .map(|(member, score)| {
+                        let m_py = PyBytes::new(py, &member).into_any().unbind();
+                        let s_py = score.into_pyobject(py)?.into_any().unbind();
+                        Ok(PyTuple::new(py, [m_py, s_py])?.into_any().unbind())
+                    })
+                    .collect::<PyResult<_>>()?;
+                Ok(PyList::new(py, py_items)?.into_any().unbind())
+            }
+            RawResult::Value(v) => redis_value_to_py(py, v),
             RawResult::Error(e) => Err(pyo3::exceptions::PyConnectionError::new_err(e)),
             RawResult::ServerError(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e)),
         }

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -75,12 +75,17 @@ fn init_or_fork_runtime(pid: u32) -> &'static Runtime {
 // =========================================================================
 
 pub enum RawResult {
+    /// Successful operation with no return value — renders as Python None.
+    Nil,
     OptBytes(Option<Vec<u8>>),
     Bool(bool),
     Int(i64),
     OptInt(Option<i64>),
     F64(f64),
     OptF64(Option<f64>),
+    /// String result rendered as Python str (e.g. XADD id, SCRIPT LOAD sha, TYPE).
+    Str(String),
+    OptStr(Option<String>),
     OptBytesList(Vec<Option<Vec<u8>>>),
     BytesList(Vec<Vec<u8>>),
     StringList(Vec<String>),
@@ -158,12 +163,16 @@ fn redis_value_to_py(py: Python<'_>, v: redis::Value) -> PyResult<Py<PyAny>> {
 impl RawResult {
     pub fn into_py(self, py: Python<'_>) -> Result<Py<PyAny>, PyErr> {
         match self {
+            RawResult::Nil => Ok(py.None()),
             RawResult::OptBytes(Some(b)) => Ok(PyBytes::new(py, &b).into_any().unbind()),
             RawResult::OptBytes(None) => Ok(py.None()),
             RawResult::Bool(b) => {
                 Ok(b.into_pyobject(py).unwrap().to_owned().into_any().unbind())
             }
             RawResult::Int(n) => Ok(n.into_pyobject(py).unwrap().into_any().unbind()),
+            RawResult::Str(s) => Ok(PyString::new(py, &s).into_any().unbind()),
+            RawResult::OptStr(Some(s)) => Ok(PyString::new(py, &s).into_any().unbind()),
+            RawResult::OptStr(None) => Ok(py.None()),
             RawResult::OptBytesList(items) => {
                 let py_items: Vec<Py<PyAny>> = items
                     .into_iter()

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,19 @@
 // PyO3 driver wrapper for the Rust I/O driver.
 //
-// Adapted from django-vcache (MIT, by David Burke / GlitchTip):
-// https://gitlab.com/glitchtip/django-vcache/-/blob/main/src/client.rs
+// Constructors + connection helpers are adapted from django-vcache (MIT,
+// David Burke / GlitchTip): https://gitlab.com/glitchtip/django-vcache/-/blob/main/src/client.rs
 //
-// Issue #65 lands only the connection layer + a slim sync surface
-// (`set_sync`, `get_sync`, `flushdb_sync`) needed to verify connectivity.
-// The full sync + async command surface is added in issue #66.
+// The full sync + async command surface (~85 commands × 2 variants) is
+// django-cachex's extension. Each command pair follows the same shape:
+//   * `<cmd>` — async; returns a `RustAwaitable`. Spawns the operation on the
+//     tokio runtime and routes through `RawResult` for type conversion.
+//   * `<cmd>_sync` — sync; releases the GIL and blocks on the runtime,
+//     returning the typed Python value directly.
 
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
+use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
 
-use crate::async_bridge::get_runtime;
+use crate::async_bridge::{RawResult, RustAwaitable, get_runtime};
 use crate::connection::{
     ClientCacheOpts, TlsOpts, ValkeyConn, connect_cluster, connect_sentinel, connect_standard,
 };
@@ -18,6 +21,26 @@ use crate::connection::{
 #[pyclass]
 pub struct RustValkeyDriver {
     connection: ValkeyConn,
+}
+
+// =========================================================================
+// Async / sync invocation macros (mirrors vcache pattern)
+// =========================================================================
+
+// Async: spawn a tokio task that sends RawResult through a oneshot. The tokio
+// task never touches the GIL — zero Python interaction. RustAwaitable handles
+// the asyncio future-blocking protocol.
+macro_rules! async_op {
+    ($self:expr, $py:expr, $conn:ident, $body:expr) => {{
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let awaitable = RustAwaitable::new(rx);
+        let mut $conn = $self.connection.clone();
+        get_runtime().spawn(async move {
+            let result: RawResult = async { $body }.await;
+            let _ = tx.send(result);
+        });
+        Ok(awaitable.into_pyobject($py)?.into_any().unbind())
+    }};
 }
 
 // Sync: release GIL, block on tokio runtime.
@@ -28,8 +51,18 @@ macro_rules! sync_op {
     }};
 }
 
-/// Classify a Redis error: connection/transient → PyConnectionError
-/// (swallowable by IGNORE_EXCEPTIONS), everything else → PyRuntimeError.
+// =========================================================================
+// Error classification
+// =========================================================================
+
+fn classify(e: redis::RedisError) -> RawResult {
+    if is_connection_error(&e) {
+        RawResult::Error(e.to_string())
+    } else {
+        RawResult::ServerError(e.to_string())
+    }
+}
+
 fn to_py_err(e: redis::RedisError) -> PyErr {
     if is_connection_error(&e) {
         pyo3::exceptions::PyConnectionError::new_err(e.to_string())
@@ -49,6 +82,209 @@ fn is_connection_error(e: &redis::RedisError) -> bool {
         || e.is_connection_refusal()
         || e.is_timeout()
 }
+
+// =========================================================================
+// Result-to-RawResult conversion helpers (used by `async_op!` bodies)
+// =========================================================================
+
+fn r_opt_bytes(r: Result<Option<Vec<u8>>, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::OptBytes(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_bool(r: Result<bool, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::Bool(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_int(r: Result<i64, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::Int(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_opt_int(r: Result<Option<i64>, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::OptInt(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_f64(r: Result<f64, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::F64(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_opt_f64(r: Result<Option<f64>, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::OptF64(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_unit(r: Result<(), redis::RedisError>) -> RawResult {
+    match r {
+        Ok(()) => RawResult::Bool(true),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_opt_bytes_list(r: Result<Vec<Option<Vec<u8>>>, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::OptBytesList(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_bytes_list(r: Result<Vec<Vec<u8>>, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::BytesList(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_string_list(r: Result<Vec<String>, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::StringList(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_bytes_pairs(r: Result<Vec<(Vec<u8>, Vec<u8>)>, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::BytesPairs(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_scored_members(r: Result<Vec<(Vec<u8>, f64)>, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::ScoredMembers(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_value(r: Result<redis::Value, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::Value(v),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_string(r: Result<String, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::OptBytes(Some(v.into_bytes())),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_opt_string(r: Result<Option<String>, redis::RedisError>) -> RawResult {
+    match r {
+        Ok(v) => RawResult::OptBytes(v.map(String::into_bytes)),
+        Err(e) => classify(e),
+    }
+}
+
+fn r_opt_key_and_bytes_list(
+    r: Result<Option<(String, Vec<Vec<u8>>)>, redis::RedisError>,
+) -> RawResult {
+    match r {
+        Ok(v) => RawResult::OptKeyAndBytesList(v),
+        Err(e) => classify(e),
+    }
+}
+
+// =========================================================================
+// Sync-side conversion helpers (translate Rust types to Python)
+// =========================================================================
+
+fn py_opt_bytes(py: Python<'_>, v: Option<Vec<u8>>) -> Py<PyAny> {
+    match v {
+        Some(b) => PyBytes::new(py, &b).into_any().unbind(),
+        None => py.None(),
+    }
+}
+
+fn py_bytes_list(py: Python<'_>, items: Vec<Vec<u8>>) -> PyResult<Py<PyAny>> {
+    let py_items: Vec<Py<PyAny>> = items
+        .into_iter()
+        .map(|b| PyBytes::new(py, &b).into_any().unbind())
+        .collect();
+    Ok(PyList::new(py, py_items)?.into_any().unbind())
+}
+
+fn py_opt_bytes_list(py: Python<'_>, items: Vec<Option<Vec<u8>>>) -> PyResult<Py<PyAny>> {
+    let py_items: Vec<Py<PyAny>> = items
+        .into_iter()
+        .map(|r| py_opt_bytes(py, r))
+        .collect();
+    Ok(PyList::new(py, py_items)?.into_any().unbind())
+}
+
+fn py_string_list(py: Python<'_>, items: Vec<String>) -> PyResult<Py<PyAny>> {
+    let py_items: Vec<Py<PyAny>> = items
+        .into_iter()
+        .map(|s| pyo3::types::PyString::new(py, &s).into_any().unbind())
+        .collect();
+    Ok(PyList::new(py, py_items)?.into_any().unbind())
+}
+
+fn py_bytes_pairs(py: Python<'_>, pairs: Vec<(Vec<u8>, Vec<u8>)>) -> PyResult<Py<PyAny>> {
+    let dict = PyDict::new(py);
+    for (k, v) in pairs {
+        let k_py = PyBytes::new(py, &k).into_any().unbind();
+        let v_py = PyBytes::new(py, &v).into_any().unbind();
+        dict.set_item(k_py, v_py)?;
+    }
+    Ok(dict.into_any().unbind())
+}
+
+fn py_scored_members(py: Python<'_>, items: Vec<(Vec<u8>, f64)>) -> PyResult<Py<PyAny>> {
+    let py_items: Vec<Py<PyAny>> = items
+        .into_iter()
+        .map(|(member, score)| {
+            let m_py = PyBytes::new(py, &member).into_any().unbind();
+            let s_py = score.into_pyobject(py)?.into_any().unbind();
+            Ok(PyTuple::new(py, [m_py, s_py])?.into_any().unbind())
+        })
+        .collect::<PyResult<_>>()?;
+    Ok(PyList::new(py, py_items)?.into_any().unbind())
+}
+
+fn py_redis_value(py: Python<'_>, v: redis::Value) -> PyResult<Py<PyAny>> {
+    // Reuse the conversion path that RawResult::Value goes through.
+    let raw = RawResult::Value(v);
+    raw.into_py(py)
+}
+
+fn py_opt_key_and_bytes_list(
+    py: Python<'_>,
+    v: Option<(String, Vec<Vec<u8>>)>,
+) -> PyResult<Py<PyAny>> {
+    match v {
+        Some((key, values)) => {
+            let py_values: Vec<Py<PyAny>> = values
+                .into_iter()
+                .map(|b| PyBytes::new(py, &b).into_any().unbind())
+                .collect();
+            let py_key = pyo3::types::PyString::new(py, &key).into_any().unbind();
+            let py_list = PyList::new(py, py_values)?.into_any().unbind();
+            Ok(PyTuple::new(py, [py_key, py_list])?.into_any().unbind())
+        }
+        None => Ok(py.None()),
+    }
+}
+
+// =========================================================================
+// Connection-config helpers
+// =========================================================================
 
 fn make_cache_opts(max_size: Option<usize>, ttl_secs: Option<u64>) -> Option<ClientCacheOpts> {
     if max_size.is_some() || ttl_secs.is_some() {
@@ -102,6 +338,10 @@ fn make_tls_opts(
 
 #[pymethods]
 impl RustValkeyDriver {
+    // =====================================================================
+    // Connection constructors
+    // =====================================================================
+
     #[staticmethod]
     #[pyo3(signature = (url, cache_max_size=None, cache_ttl_secs=None, ssl_ca_certs=None, ssl_certfile=None, ssl_keyfile=None))]
     fn connect_standard(
@@ -175,17 +415,27 @@ impl RustValkeyDriver {
             .map(|s| (s.hit, s.miss, s.invalidate))
     }
 
-    // =========================================================================
-    // Slim test surface — full command surface comes in issue #66.
-    // =========================================================================
+    // =====================================================================
+    // Strings / counters / TTL
+    // =====================================================================
 
     #[pyo3(signature = (key))]
-    fn get_sync(&self, py: Python<'_>, key: &str) -> PyResult<Option<Py<PyAny>>> {
-        let result: Result<Option<Vec<u8>>, _> = sync_op!(py, self, conn, conn.get_bytes(key).await);
-        match result.map_err(to_py_err)? {
-            Some(bytes) => Ok(Some(PyBytes::new(py, &bytes).into_any().unbind())),
-            None => Ok(None),
-        }
+    fn get(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_opt_bytes(conn.get_bytes(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn get_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Option<Vec<u8>>, _> = sync_op!(py, self, conn, conn.get_bytes(key).await);
+        Ok(py_opt_bytes(py, r.map_err(to_py_err)?))
+    }
+
+    #[pyo3(signature = (key, value, ttl=None))]
+    fn set(&self, py: Python<'_>, key: &str, value: &[u8], ttl: Option<u64>) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let value = value.to_vec();
+        async_op!(self, py, conn, r_unit(conn.set_bytes(&key, value, ttl).await))
     }
 
     #[pyo3(signature = (key, value, ttl=None))]
@@ -200,7 +450,1334 @@ impl RustValkeyDriver {
         sync_op!(py, self, conn, conn.set_bytes(key, value, ttl).await).map_err(to_py_err)
     }
 
+    #[pyo3(signature = (key, value, ttl=None))]
+    fn set_nx(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        value: &[u8],
+        ttl: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let value = value.to_vec();
+        async_op!(self, py, conn, r_bool(conn.set_nx(&key, value, ttl).await))
+    }
+
+    #[pyo3(signature = (key, value, ttl=None))]
+    fn set_nx_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        value: &[u8],
+        ttl: Option<u64>,
+    ) -> PyResult<bool> {
+        let value = value.to_vec();
+        sync_op!(py, self, conn, conn.set_nx(key, value, ttl).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn delete(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.del(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn delete_sync(&self, py: Python<'_>, key: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.del(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (keys))]
+    fn delete_many(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_int(conn.del_many(&keys).await))
+    }
+
+    #[pyo3(signature = (keys))]
+    fn delete_many_sync(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.del_many(&keys).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (keys))]
+    fn mget(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_opt_bytes_list(conn.mget_bytes(&keys).await))
+    }
+
+    #[pyo3(signature = (keys))]
+    fn mget_sync(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<Option<Vec<u8>>>, _> =
+            sync_op!(py, self, conn, conn.mget_bytes(&keys).await);
+        py_opt_bytes_list(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (entries, ttl=None))]
+    fn pipeline_set(
+        &self,
+        py: Python<'_>,
+        entries: Vec<(String, Vec<u8>)>,
+        ttl: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_unit(conn.pipeline_set(&entries, ttl).await))
+    }
+
+    #[pyo3(signature = (entries, ttl=None))]
+    fn pipeline_set_sync(
+        &self,
+        py: Python<'_>,
+        entries: Vec<(String, Vec<u8>)>,
+        ttl: Option<u64>,
+    ) -> PyResult<()> {
+        sync_op!(py, self, conn, conn.pipeline_set(&entries, ttl).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, delta))]
+    fn incr_by(&self, py: Python<'_>, key: &str, delta: i64) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.incr_by(&key, delta).await))
+    }
+
+    #[pyo3(signature = (key, delta))]
+    fn incr_by_sync(&self, py: Python<'_>, key: &str, delta: i64) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.incr_by(key, delta).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn exists(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_bool(conn.exists(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn exists_sync(&self, py: Python<'_>, key: &str) -> PyResult<bool> {
+        sync_op!(py, self, conn, conn.exists(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, seconds))]
+    fn expire(&self, py: Python<'_>, key: &str, seconds: u64) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_bool(conn.expire(&key, seconds).await))
+    }
+
+    #[pyo3(signature = (key, seconds))]
+    fn expire_sync(&self, py: Python<'_>, key: &str, seconds: u64) -> PyResult<bool> {
+        sync_op!(py, self, conn, conn.expire(key, seconds).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn persist(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_bool(conn.persist(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn persist_sync(&self, py: Python<'_>, key: &str) -> PyResult<bool> {
+        sync_op!(py, self, conn, conn.persist(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn ttl(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.ttl(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn ttl_sync(&self, py: Python<'_>, key: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.ttl(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn pttl(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.pttl(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn pttl_sync(&self, py: Python<'_>, key: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.pttl(key).await).map_err(to_py_err)
+    }
+
+    fn flushdb(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_unit(conn.flushdb().await))
+    }
+
     fn flushdb_sync(&self, py: Python<'_>) -> PyResult<()> {
         sync_op!(py, self, conn, conn.flushdb().await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (pattern))]
+    fn keys(&self, py: Python<'_>, pattern: &str) -> PyResult<Py<PyAny>> {
+        let pattern = pattern.to_string();
+        async_op!(self, py, conn, r_string_list(conn.keys(&pattern).await))
+    }
+
+    #[pyo3(signature = (pattern))]
+    fn keys_sync(&self, py: Python<'_>, pattern: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<String>, _> = sync_op!(py, self, conn, conn.keys(pattern).await);
+        py_string_list(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key))]
+    #[pyo3(name = "type")]
+    fn key_type(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_string(conn.key_type(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn type_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<String, _> = sync_op!(py, self, conn, conn.key_type(key).await);
+        Ok(PyBytes::new(py, r.map_err(to_py_err)?.as_bytes()).into_any().unbind())
+    }
+
+    #[pyo3(signature = (pattern, count))]
+    fn scan(&self, py: Python<'_>, pattern: &str, count: i64) -> PyResult<Py<PyAny>> {
+        let pattern = pattern.to_string();
+        async_op!(self, py, conn, r_string_list(conn.scan_all(&pattern, count).await))
+    }
+
+    #[pyo3(signature = (pattern, count))]
+    fn scan_sync(&self, py: Python<'_>, pattern: &str, count: i64) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<String>, _> =
+            sync_op!(py, self, conn, conn.scan_all(pattern, count).await);
+        py_string_list(py, r.map_err(to_py_err)?)
+    }
+
+    fn dbsize(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_int(conn.dbsize().await))
+    }
+
+    fn dbsize_sync(&self, py: Python<'_>) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.dbsize().await).map_err(to_py_err)
+    }
+
+    fn info(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_value(conn.info().await))
+    }
+
+    fn info_sync(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> = sync_op!(py, self, conn, conn.info().await);
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    fn client_list(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_value(conn.client_list().await))
+    }
+
+    fn client_list_sync(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> = sync_op!(py, self, conn, conn.client_list().await);
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (parameter))]
+    fn config_get(&self, py: Python<'_>, parameter: &str) -> PyResult<Py<PyAny>> {
+        let parameter = parameter.to_string();
+        async_op!(self, py, conn, r_value(conn.config_get(&parameter).await))
+    }
+
+    #[pyo3(signature = (parameter))]
+    fn config_get_sync(&self, py: Python<'_>, parameter: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> =
+            sync_op!(py, self, conn, conn.config_get(parameter).await);
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key))]
+    fn object_encoding(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_opt_string(conn.object_encoding(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn object_encoding_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Option<String>, _> =
+            sync_op!(py, self, conn, conn.object_encoding(key).await);
+        Ok(py_opt_bytes(py, r.map_err(to_py_err)?.map(String::into_bytes)))
+    }
+
+    #[pyo3(signature = (key))]
+    fn object_idletime(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_opt_int(conn.object_idletime(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn object_idletime_sync(&self, py: Python<'_>, key: &str) -> PyResult<Option<i64>> {
+        sync_op!(py, self, conn, conn.object_idletime(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn memory_usage(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_opt_int(conn.memory_usage(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn memory_usage_sync(&self, py: Python<'_>, key: &str) -> PyResult<Option<i64>> {
+        sync_op!(py, self, conn, conn.memory_usage(key).await).map_err(to_py_err)
+    }
+
+    // =====================================================================
+    // Locks
+    // =====================================================================
+
+    #[pyo3(signature = (key, token, timeout_ms=None))]
+    fn lock_acquire(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        token: &str,
+        timeout_ms: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let token = token.to_string();
+        async_op!(self, py, conn, {
+            r_bool(conn.lock_acquire(&key, &token, timeout_ms).await)
+        })
+    }
+
+    #[pyo3(signature = (key, token, timeout_ms=None))]
+    fn lock_acquire_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        token: &str,
+        timeout_ms: Option<u64>,
+    ) -> PyResult<bool> {
+        sync_op!(py, self, conn, conn.lock_acquire(key, token, timeout_ms).await)
+            .map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, token))]
+    fn lock_release(&self, py: Python<'_>, key: &str, token: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let token = token.to_string();
+        async_op!(self, py, conn, r_int(conn.lock_release(&key, &token).await))
+    }
+
+    #[pyo3(signature = (key, token))]
+    fn lock_release_sync(&self, py: Python<'_>, key: &str, token: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.lock_release(key, token).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, token, additional_ms))]
+    fn lock_extend(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        token: &str,
+        additional_ms: u64,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let token = token.to_string();
+        async_op!(self, py, conn, {
+            r_int(conn.lock_extend(&key, &token, additional_ms).await)
+        })
+    }
+
+    #[pyo3(signature = (key, token, additional_ms))]
+    fn lock_extend_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        token: &str,
+        additional_ms: u64,
+    ) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.lock_extend(key, token, additional_ms).await)
+            .map_err(to_py_err)
+    }
+
+    // =====================================================================
+    // Scripts
+    // =====================================================================
+
+    #[pyo3(signature = (script, keys, args))]
+    fn eval(
+        &self,
+        py: Python<'_>,
+        script: &str,
+        keys: Vec<String>,
+        args: Vec<Vec<u8>>,
+    ) -> PyResult<Py<PyAny>> {
+        let script = script.to_string();
+        async_op!(self, py, conn, r_value(conn.eval(&script, &keys, &args).await))
+    }
+
+    #[pyo3(signature = (script, keys, args))]
+    fn eval_sync(
+        &self,
+        py: Python<'_>,
+        script: &str,
+        keys: Vec<String>,
+        args: Vec<Vec<u8>>,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> =
+            sync_op!(py, self, conn, conn.eval(script, &keys, &args).await);
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (sha, keys, args))]
+    fn evalsha(
+        &self,
+        py: Python<'_>,
+        sha: &str,
+        keys: Vec<String>,
+        args: Vec<Vec<u8>>,
+    ) -> PyResult<Py<PyAny>> {
+        let sha = sha.to_string();
+        async_op!(self, py, conn, r_value(conn.evalsha(&sha, &keys, &args).await))
+    }
+
+    #[pyo3(signature = (sha, keys, args))]
+    fn evalsha_sync(
+        &self,
+        py: Python<'_>,
+        sha: &str,
+        keys: Vec<String>,
+        args: Vec<Vec<u8>>,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> =
+            sync_op!(py, self, conn, conn.evalsha(sha, &keys, &args).await);
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (script))]
+    fn script_load(&self, py: Python<'_>, script: &str) -> PyResult<Py<PyAny>> {
+        let script = script.to_string();
+        async_op!(self, py, conn, r_string(conn.script_load(&script).await))
+    }
+
+    #[pyo3(signature = (script))]
+    fn script_load_sync(&self, py: Python<'_>, script: &str) -> PyResult<String> {
+        sync_op!(py, self, conn, conn.script_load(script).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (sha))]
+    fn script_exists(&self, py: Python<'_>, sha: &str) -> PyResult<Py<PyAny>> {
+        let sha = sha.to_string();
+        async_op!(self, py, conn, r_bool(conn.script_exists(&sha).await))
+    }
+
+    #[pyo3(signature = (sha))]
+    fn script_exists_sync(&self, py: Python<'_>, sha: &str) -> PyResult<bool> {
+        sync_op!(py, self, conn, conn.script_exists(sha).await).map_err(to_py_err)
+    }
+
+    // =====================================================================
+    // Pipeline (arbitrary commands)
+    // =====================================================================
+
+    #[pyo3(signature = (commands))]
+    fn pipeline_exec(
+        &self,
+        py: Python<'_>,
+        commands: Vec<(String, Vec<Vec<u8>>)>,
+    ) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, {
+            match conn.pipeline_exec(commands).await {
+                Ok(items) => RawResult::Value(redis::Value::Array(items)),
+                Err(e) => classify(e),
+            }
+        })
+    }
+
+    #[pyo3(signature = (commands))]
+    fn pipeline_exec_sync(
+        &self,
+        py: Python<'_>,
+        commands: Vec<(String, Vec<Vec<u8>>)>,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<redis::Value>, _> =
+            sync_op!(py, self, conn, conn.pipeline_exec(commands).await);
+        py_redis_value(py, redis::Value::Array(r.map_err(to_py_err)?))
+    }
+
+    // =====================================================================
+    // Lists
+    // =====================================================================
+
+    #[pyo3(signature = (key, values))]
+    fn lpush(&self, py: Python<'_>, key: &str, values: Vec<Vec<u8>>) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.lpush(&key, values).await))
+    }
+
+    #[pyo3(signature = (key, values))]
+    fn lpush_sync(&self, py: Python<'_>, key: &str, values: Vec<Vec<u8>>) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.lpush(key, values).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, values))]
+    fn rpush(&self, py: Python<'_>, key: &str, values: Vec<Vec<u8>>) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.rpush(&key, values).await))
+    }
+
+    #[pyo3(signature = (key, values))]
+    fn rpush_sync(&self, py: Python<'_>, key: &str, values: Vec<Vec<u8>>) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.rpush(key, values).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn lpop(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_opt_bytes(conn.lpop(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn lpop_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Option<Vec<u8>>, _> = sync_op!(py, self, conn, conn.lpop(key).await);
+        Ok(py_opt_bytes(py, r.map_err(to_py_err)?))
+    }
+
+    #[pyo3(signature = (key))]
+    fn rpop(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_opt_bytes(conn.rpop(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn rpop_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Option<Vec<u8>>, _> = sync_op!(py, self, conn, conn.rpop(key).await);
+        Ok(py_opt_bytes(py, r.map_err(to_py_err)?))
+    }
+
+    #[pyo3(signature = (key, start, stop))]
+    fn lrange(&self, py: Python<'_>, key: &str, start: i64, stop: i64) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_bytes_list(conn.lrange(&key, start, stop).await))
+    }
+
+    #[pyo3(signature = (key, start, stop))]
+    fn lrange_sync(&self, py: Python<'_>, key: &str, start: i64, stop: i64) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<Vec<u8>>, _> =
+            sync_op!(py, self, conn, conn.lrange(key, start, stop).await);
+        py_bytes_list(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key))]
+    fn llen(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.llen(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn llen_sync(&self, py: Python<'_>, key: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.llen(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, count, value))]
+    fn lrem(&self, py: Python<'_>, key: &str, count: i64, value: &[u8]) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let value = value.to_vec();
+        async_op!(self, py, conn, r_int(conn.lrem(&key, count, &value).await))
+    }
+
+    #[pyo3(signature = (key, count, value))]
+    fn lrem_sync(&self, py: Python<'_>, key: &str, count: i64, value: &[u8]) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.lrem(key, count, value).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, index))]
+    fn lindex(&self, py: Python<'_>, key: &str, index: i64) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_opt_bytes(conn.lindex(&key, index).await))
+    }
+
+    #[pyo3(signature = (key, index))]
+    fn lindex_sync(&self, py: Python<'_>, key: &str, index: i64) -> PyResult<Py<PyAny>> {
+        let r: Result<Option<Vec<u8>>, _> = sync_op!(py, self, conn, conn.lindex(key, index).await);
+        Ok(py_opt_bytes(py, r.map_err(to_py_err)?))
+    }
+
+    #[pyo3(signature = (key, index, value))]
+    fn lset(&self, py: Python<'_>, key: &str, index: i64, value: &[u8]) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let value = value.to_vec();
+        async_op!(self, py, conn, r_unit(conn.lset(&key, index, &value).await))
+    }
+
+    #[pyo3(signature = (key, index, value))]
+    fn lset_sync(&self, py: Python<'_>, key: &str, index: i64, value: &[u8]) -> PyResult<()> {
+        sync_op!(py, self, conn, conn.lset(key, index, value).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, before, pivot, value))]
+    fn linsert(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        before: bool,
+        pivot: &[u8],
+        value: &[u8],
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let pivot = pivot.to_vec();
+        let value = value.to_vec();
+        async_op!(self, py, conn, r_int(conn.linsert(&key, before, &pivot, &value).await))
+    }
+
+    #[pyo3(signature = (key, before, pivot, value))]
+    fn linsert_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        before: bool,
+        pivot: &[u8],
+        value: &[u8],
+    ) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.linsert(key, before, pivot, value).await)
+            .map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, start, stop))]
+    fn ltrim(&self, py: Python<'_>, key: &str, start: i64, stop: i64) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_unit(conn.ltrim(&key, start, stop).await))
+    }
+
+    #[pyo3(signature = (key, start, stop))]
+    fn ltrim_sync(&self, py: Python<'_>, key: &str, start: i64, stop: i64) -> PyResult<()> {
+        sync_op!(py, self, conn, conn.ltrim(key, start, stop).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (source, destination, wherefrom, whereto, timeout))]
+    fn blmove(
+        &self,
+        py: Python<'_>,
+        source: &str,
+        destination: &str,
+        wherefrom: &str,
+        whereto: &str,
+        timeout: f64,
+    ) -> PyResult<Py<PyAny>> {
+        let source = source.to_string();
+        let destination = destination.to_string();
+        let wherefrom = wherefrom.to_string();
+        let whereto = whereto.to_string();
+        async_op!(self, py, conn, {
+            r_opt_bytes(conn.blmove(&source, &destination, &wherefrom, &whereto, timeout).await)
+        })
+    }
+
+    #[pyo3(signature = (source, destination, wherefrom, whereto, timeout))]
+    fn blmove_sync(
+        &self,
+        py: Python<'_>,
+        source: &str,
+        destination: &str,
+        wherefrom: &str,
+        whereto: &str,
+        timeout: f64,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<Option<Vec<u8>>, _> = sync_op!(
+            py,
+            self,
+            conn,
+            conn.blmove(source, destination, wherefrom, whereto, timeout).await
+        );
+        Ok(py_opt_bytes(py, r.map_err(to_py_err)?))
+    }
+
+    #[pyo3(signature = (timeout, keys, direction, count))]
+    fn blmpop(
+        &self,
+        py: Python<'_>,
+        timeout: f64,
+        keys: Vec<String>,
+        direction: &str,
+        count: i64,
+    ) -> PyResult<Py<PyAny>> {
+        let direction = direction.to_string();
+        async_op!(self, py, conn, {
+            r_opt_key_and_bytes_list(conn.blmpop(timeout, &keys, &direction, count).await)
+        })
+    }
+
+    #[pyo3(signature = (timeout, keys, direction, count))]
+    fn blmpop_sync(
+        &self,
+        py: Python<'_>,
+        timeout: f64,
+        keys: Vec<String>,
+        direction: &str,
+        count: i64,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<Option<(String, Vec<Vec<u8>>)>, _> = sync_op!(
+            py,
+            self,
+            conn,
+            conn.blmpop(timeout, &keys, direction, count).await
+        );
+        py_opt_key_and_bytes_list(py, r.map_err(to_py_err)?)
+    }
+
+    // =====================================================================
+    // Hashes
+    // =====================================================================
+
+    #[pyo3(signature = (key, field))]
+    fn hget(&self, py: Python<'_>, key: &str, field: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let field = field.to_string();
+        async_op!(self, py, conn, r_opt_bytes(conn.hget(&key, &field).await))
+    }
+
+    #[pyo3(signature = (key, field))]
+    fn hget_sync(&self, py: Python<'_>, key: &str, field: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Option<Vec<u8>>, _> = sync_op!(py, self, conn, conn.hget(key, field).await);
+        Ok(py_opt_bytes(py, r.map_err(to_py_err)?))
+    }
+
+    #[pyo3(signature = (key, field, value))]
+    fn hset(&self, py: Python<'_>, key: &str, field: &str, value: &[u8]) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let field = field.to_string();
+        let value = value.to_vec();
+        async_op!(self, py, conn, r_int(conn.hset(&key, &field, &value).await))
+    }
+
+    #[pyo3(signature = (key, field, value))]
+    fn hset_sync(&self, py: Python<'_>, key: &str, field: &str, value: &[u8]) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.hset(key, field, value).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn hgetall(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_bytes_pairs(conn.hgetall(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn hgetall_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<(Vec<u8>, Vec<u8>)>, _> =
+            sync_op!(py, self, conn, conn.hgetall(key).await);
+        py_bytes_pairs(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key, fields))]
+    fn hdel(&self, py: Python<'_>, key: &str, fields: Vec<String>) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.hdel(&key, &fields).await))
+    }
+
+    #[pyo3(signature = (key, fields))]
+    fn hdel_sync(&self, py: Python<'_>, key: &str, fields: Vec<String>) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.hdel(key, &fields).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, field, delta))]
+    fn hincrby(&self, py: Python<'_>, key: &str, field: &str, delta: i64) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let field = field.to_string();
+        async_op!(self, py, conn, r_int(conn.hincrby(&key, &field, delta).await))
+    }
+
+    #[pyo3(signature = (key, field, delta))]
+    fn hincrby_sync(&self, py: Python<'_>, key: &str, field: &str, delta: i64) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.hincrby(key, field, delta).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn hkeys(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_string_list(conn.hkeys(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn hkeys_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<String>, _> = sync_op!(py, self, conn, conn.hkeys(key).await);
+        py_string_list(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key))]
+    fn hvals(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_bytes_list(conn.hvals(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn hvals_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<Vec<u8>>, _> = sync_op!(py, self, conn, conn.hvals(key).await);
+        py_bytes_list(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key, field))]
+    fn hexists(&self, py: Python<'_>, key: &str, field: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let field = field.to_string();
+        async_op!(self, py, conn, r_bool(conn.hexists(&key, &field).await))
+    }
+
+    #[pyo3(signature = (key, field))]
+    fn hexists_sync(&self, py: Python<'_>, key: &str, field: &str) -> PyResult<bool> {
+        sync_op!(py, self, conn, conn.hexists(key, field).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn hlen(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.hlen(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn hlen_sync(&self, py: Python<'_>, key: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.hlen(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, fields))]
+    fn hmget(&self, py: Python<'_>, key: &str, fields: Vec<String>) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_opt_bytes_list(conn.hmget(&key, &fields).await))
+    }
+
+    #[pyo3(signature = (key, fields))]
+    fn hmget_sync(&self, py: Python<'_>, key: &str, fields: Vec<String>) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<Option<Vec<u8>>>, _> =
+            sync_op!(py, self, conn, conn.hmget(key, &fields).await);
+        py_opt_bytes_list(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key, fields))]
+    fn hmset(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        fields: Vec<(String, Vec<u8>)>,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_unit(conn.hmset(&key, &fields).await))
+    }
+
+    #[pyo3(signature = (key, fields))]
+    fn hmset_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        fields: Vec<(String, Vec<u8>)>,
+    ) -> PyResult<()> {
+        sync_op!(py, self, conn, conn.hmset(key, &fields).await).map_err(to_py_err)
+    }
+
+    // =====================================================================
+    // Sets
+    // =====================================================================
+
+    #[pyo3(signature = (key, members))]
+    fn sadd(&self, py: Python<'_>, key: &str, members: Vec<Vec<u8>>) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.sadd(&key, members).await))
+    }
+
+    #[pyo3(signature = (key, members))]
+    fn sadd_sync(&self, py: Python<'_>, key: &str, members: Vec<Vec<u8>>) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.sadd(key, members).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, members))]
+    fn srem(&self, py: Python<'_>, key: &str, members: Vec<Vec<u8>>) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.srem(&key, members).await))
+    }
+
+    #[pyo3(signature = (key, members))]
+    fn srem_sync(&self, py: Python<'_>, key: &str, members: Vec<Vec<u8>>) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.srem(key, members).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn smembers(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_bytes_list(conn.smembers(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn smembers_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<Vec<u8>>, _> = sync_op!(py, self, conn, conn.smembers(key).await);
+        py_bytes_list(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key, member))]
+    fn sismember(&self, py: Python<'_>, key: &str, member: &[u8]) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let member = member.to_vec();
+        async_op!(self, py, conn, r_bool(conn.sismember(&key, &member).await))
+    }
+
+    #[pyo3(signature = (key, member))]
+    fn sismember_sync(&self, py: Python<'_>, key: &str, member: &[u8]) -> PyResult<bool> {
+        sync_op!(py, self, conn, conn.sismember(key, member).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn scard(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.scard(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn scard_sync(&self, py: Python<'_>, key: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.scard(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (keys))]
+    fn sinter(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_bytes_list(conn.sinter(&keys).await))
+    }
+
+    #[pyo3(signature = (keys))]
+    fn sinter_sync(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<Vec<u8>>, _> = sync_op!(py, self, conn, conn.sinter(&keys).await);
+        py_bytes_list(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (keys))]
+    fn sunion(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_bytes_list(conn.sunion(&keys).await))
+    }
+
+    #[pyo3(signature = (keys))]
+    fn sunion_sync(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<Vec<u8>>, _> = sync_op!(py, self, conn, conn.sunion(&keys).await);
+        py_bytes_list(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (keys))]
+    fn sdiff(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_bytes_list(conn.sdiff(&keys).await))
+    }
+
+    #[pyo3(signature = (keys))]
+    fn sdiff_sync(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<Vec<u8>>, _> = sync_op!(py, self, conn, conn.sdiff(&keys).await);
+        py_bytes_list(py, r.map_err(to_py_err)?)
+    }
+
+    // =====================================================================
+    // Sorted sets
+    // =====================================================================
+
+    #[pyo3(signature = (key, members))]
+    fn zadd(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        members: Vec<(Vec<u8>, f64)>,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.zadd(&key, members).await))
+    }
+
+    #[pyo3(signature = (key, members))]
+    fn zadd_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        members: Vec<(Vec<u8>, f64)>,
+    ) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.zadd(key, members).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, members))]
+    fn zrem(&self, py: Python<'_>, key: &str, members: Vec<Vec<u8>>) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.zrem(&key, members).await))
+    }
+
+    #[pyo3(signature = (key, members))]
+    fn zrem_sync(&self, py: Python<'_>, key: &str, members: Vec<Vec<u8>>) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.zrem(key, members).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, start, stop, with_scores=false))]
+    fn zrange(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        start: i64,
+        stop: i64,
+        with_scores: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, {
+            r_value(conn.zrange(&key, start, stop, with_scores).await)
+        })
+    }
+
+    #[pyo3(signature = (key, start, stop, with_scores=false))]
+    fn zrange_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        start: i64,
+        stop: i64,
+        with_scores: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> =
+            sync_op!(py, self, conn, conn.zrange(key, start, stop, with_scores).await);
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key, min, max, with_scores=false))]
+    fn zrangebyscore(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        min: &str,
+        max: &str,
+        with_scores: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let min = min.to_string();
+        let max = max.to_string();
+        async_op!(self, py, conn, {
+            r_value(conn.zrangebyscore(&key, &min, &max, with_scores).await)
+        })
+    }
+
+    #[pyo3(signature = (key, min, max, with_scores=false))]
+    fn zrangebyscore_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        min: &str,
+        max: &str,
+        with_scores: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> = sync_op!(
+            py,
+            self,
+            conn,
+            conn.zrangebyscore(key, min, max, with_scores).await
+        );
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key, start, stop, with_scores=false))]
+    fn zrevrange(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        start: i64,
+        stop: i64,
+        with_scores: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, {
+            r_value(conn.zrevrange(&key, start, stop, with_scores).await)
+        })
+    }
+
+    #[pyo3(signature = (key, start, stop, with_scores=false))]
+    fn zrevrange_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        start: i64,
+        stop: i64,
+        with_scores: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> = sync_op!(
+            py,
+            self,
+            conn,
+            conn.zrevrange(key, start, stop, with_scores).await
+        );
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key, member, delta))]
+    fn zincrby(&self, py: Python<'_>, key: &str, member: &[u8], delta: f64) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let member = member.to_vec();
+        async_op!(self, py, conn, r_f64(conn.zincrby(&key, &member, delta).await))
+    }
+
+    #[pyo3(signature = (key, member, delta))]
+    fn zincrby_sync(&self, py: Python<'_>, key: &str, member: &[u8], delta: f64) -> PyResult<f64> {
+        sync_op!(py, self, conn, conn.zincrby(key, member, delta).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn zcard(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.zcard(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn zcard_sync(&self, py: Python<'_>, key: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.zcard(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, member))]
+    fn zscore(&self, py: Python<'_>, key: &str, member: &[u8]) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let member = member.to_vec();
+        async_op!(self, py, conn, r_opt_f64(conn.zscore(&key, &member).await))
+    }
+
+    #[pyo3(signature = (key, member))]
+    fn zscore_sync(&self, py: Python<'_>, key: &str, member: &[u8]) -> PyResult<Option<f64>> {
+        sync_op!(py, self, conn, conn.zscore(key, member).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, member))]
+    fn zrank(&self, py: Python<'_>, key: &str, member: &[u8]) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let member = member.to_vec();
+        async_op!(self, py, conn, r_opt_int(conn.zrank(&key, &member).await))
+    }
+
+    #[pyo3(signature = (key, member))]
+    fn zrank_sync(&self, py: Python<'_>, key: &str, member: &[u8]) -> PyResult<Option<i64>> {
+        sync_op!(py, self, conn, conn.zrank(key, member).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, min, max))]
+    fn zcount(&self, py: Python<'_>, key: &str, min: &str, max: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let min = min.to_string();
+        let max = max.to_string();
+        async_op!(self, py, conn, r_int(conn.zcount(&key, &min, &max).await))
+    }
+
+    #[pyo3(signature = (key, min, max))]
+    fn zcount_sync(&self, py: Python<'_>, key: &str, min: &str, max: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.zcount(key, min, max).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, count=1))]
+    fn zpopmin(&self, py: Python<'_>, key: &str, count: i64) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_scored_members(conn.zpopmin(&key, count).await))
+    }
+
+    #[pyo3(signature = (key, count=1))]
+    fn zpopmin_sync(&self, py: Python<'_>, key: &str, count: i64) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<(Vec<u8>, f64)>, _> =
+            sync_op!(py, self, conn, conn.zpopmin(key, count).await);
+        py_scored_members(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key, count=1))]
+    fn zpopmax(&self, py: Python<'_>, key: &str, count: i64) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_scored_members(conn.zpopmax(&key, count).await))
+    }
+
+    #[pyo3(signature = (key, count=1))]
+    fn zpopmax_sync(&self, py: Python<'_>, key: &str, count: i64) -> PyResult<Py<PyAny>> {
+        let r: Result<Vec<(Vec<u8>, f64)>, _> =
+            sync_op!(py, self, conn, conn.zpopmax(key, count).await);
+        py_scored_members(py, r.map_err(to_py_err)?)
+    }
+
+    // =====================================================================
+    // Streams
+    // =====================================================================
+
+    #[pyo3(signature = (key, id, fields))]
+    fn xadd(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        id: &str,
+        fields: Vec<(String, Vec<u8>)>,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let id = id.to_string();
+        async_op!(self, py, conn, r_string(conn.xadd(&key, &id, &fields).await))
+    }
+
+    #[pyo3(signature = (key, id, fields))]
+    fn xadd_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        id: &str,
+        fields: Vec<(String, Vec<u8>)>,
+    ) -> PyResult<String> {
+        sync_op!(py, self, conn, conn.xadd(key, id, &fields).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key))]
+    fn xlen(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.xlen(&key).await))
+    }
+
+    #[pyo3(signature = (key))]
+    fn xlen_sync(&self, py: Python<'_>, key: &str) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.xlen(key).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, start, end, count=None))]
+    fn xrange(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        start: &str,
+        end: &str,
+        count: Option<i64>,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let start = start.to_string();
+        let end = end.to_string();
+        async_op!(self, py, conn, r_value(conn.xrange(&key, &start, &end, count).await))
+    }
+
+    #[pyo3(signature = (key, start, end, count=None))]
+    fn xrange_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        start: &str,
+        end: &str,
+        count: Option<i64>,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> =
+            sync_op!(py, self, conn, conn.xrange(key, start, end, count).await);
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (keys, ids, count=None))]
+    fn xread(
+        &self,
+        py: Python<'_>,
+        keys: Vec<String>,
+        ids: Vec<String>,
+        count: Option<i64>,
+    ) -> PyResult<Py<PyAny>> {
+        async_op!(self, py, conn, r_value(conn.xread(&keys, &ids, count).await))
+    }
+
+    #[pyo3(signature = (keys, ids, count=None))]
+    fn xread_sync(
+        &self,
+        py: Python<'_>,
+        keys: Vec<String>,
+        ids: Vec<String>,
+        count: Option<i64>,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> =
+            sync_op!(py, self, conn, conn.xread(&keys, &ids, count).await);
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (group, consumer, keys, ids, count=None))]
+    fn xreadgroup(
+        &self,
+        py: Python<'_>,
+        group: &str,
+        consumer: &str,
+        keys: Vec<String>,
+        ids: Vec<String>,
+        count: Option<i64>,
+    ) -> PyResult<Py<PyAny>> {
+        let group = group.to_string();
+        let consumer = consumer.to_string();
+        async_op!(self, py, conn, {
+            r_value(conn.xreadgroup(&group, &consumer, &keys, &ids, count).await)
+        })
+    }
+
+    #[pyo3(signature = (group, consumer, keys, ids, count=None))]
+    fn xreadgroup_sync(
+        &self,
+        py: Python<'_>,
+        group: &str,
+        consumer: &str,
+        keys: Vec<String>,
+        ids: Vec<String>,
+        count: Option<i64>,
+    ) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> = sync_op!(
+            py,
+            self,
+            conn,
+            conn.xreadgroup(group, consumer, &keys, &ids, count).await
+        );
+        py_redis_value(py, r.map_err(to_py_err)?)
+    }
+
+    #[pyo3(signature = (key, group, ids))]
+    fn xack(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        group: &str,
+        ids: Vec<String>,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let group = group.to_string();
+        async_op!(self, py, conn, r_int(conn.xack(&key, &group, &ids).await))
+    }
+
+    #[pyo3(signature = (key, group, ids))]
+    fn xack_sync(&self, py: Python<'_>, key: &str, group: &str, ids: Vec<String>) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.xack(key, group, &ids).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, max_len, approximate=false))]
+    fn xtrim(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        max_len: i64,
+        approximate: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        async_op!(self, py, conn, r_int(conn.xtrim(&key, max_len, approximate).await))
+    }
+
+    #[pyo3(signature = (key, max_len, approximate=false))]
+    fn xtrim_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        max_len: i64,
+        approximate: bool,
+    ) -> PyResult<i64> {
+        sync_op!(py, self, conn, conn.xtrim(key, max_len, approximate).await).map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, group, id, mkstream=false))]
+    fn xgroup_create(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        group: &str,
+        id: &str,
+        mkstream: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let group = group.to_string();
+        let id = id.to_string();
+        async_op!(self, py, conn, {
+            r_unit(conn.xgroup_create(&key, &group, &id, mkstream).await)
+        })
+    }
+
+    #[pyo3(signature = (key, group, id, mkstream=false))]
+    fn xgroup_create_sync(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        group: &str,
+        id: &str,
+        mkstream: bool,
+    ) -> PyResult<()> {
+        sync_op!(py, self, conn, conn.xgroup_create(key, group, id, mkstream).await)
+            .map_err(to_py_err)
+    }
+
+    #[pyo3(signature = (key, group))]
+    fn xpending(&self, py: Python<'_>, key: &str, group: &str) -> PyResult<Py<PyAny>> {
+        let key = key.to_string();
+        let group = group.to_string();
+        async_op!(self, py, conn, r_value(conn.xpending(&key, &group).await))
+    }
+
+    #[pyo3(signature = (key, group))]
+    fn xpending_sync(&self, py: Python<'_>, key: &str, group: &str) -> PyResult<Py<PyAny>> {
+        let r: Result<redis::Value, _> = sync_op!(py, self, conn, conn.xpending(key, group).await);
+        py_redis_value(py, r.map_err(to_py_err)?)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -130,8 +130,10 @@ fn r_opt_f64(r: Result<Option<f64>, redis::RedisError>) -> RawResult {
 }
 
 fn r_unit(r: Result<(), redis::RedisError>) -> RawResult {
+    // Sync siblings of these calls return PyResult<()> → Python None;
+    // emit Nil here so async resolves to None too (parity).
     match r {
-        Ok(()) => RawResult::Bool(true),
+        Ok(()) => RawResult::Nil,
         Err(e) => classify(e),
     }
 }
@@ -179,15 +181,16 @@ fn r_value(r: Result<redis::Value, redis::RedisError>) -> RawResult {
 }
 
 fn r_string(r: Result<String, redis::RedisError>) -> RawResult {
+    // Renders as Python str (matches sync siblings that return PyResult<String>).
     match r {
-        Ok(v) => RawResult::OptBytes(Some(v.into_bytes())),
+        Ok(v) => RawResult::Str(v),
         Err(e) => classify(e),
     }
 }
 
 fn r_opt_string(r: Result<Option<String>, redis::RedisError>) -> RawResult {
     match r {
-        Ok(v) => RawResult::OptBytes(v.map(String::into_bytes)),
+        Ok(v) => RawResult::OptStr(v),
         Err(e) => classify(e),
     }
 }
@@ -622,9 +625,8 @@ impl RustValkeyDriver {
     }
 
     #[pyo3(signature = (key))]
-    fn type_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
-        let r: Result<String, _> = sync_op!(py, self, conn, conn.key_type(key).await);
-        Ok(PyBytes::new(py, r.map_err(to_py_err)?.as_bytes()).into_any().unbind())
+    fn type_sync(&self, py: Python<'_>, key: &str) -> PyResult<String> {
+        sync_op!(py, self, conn, conn.key_type(key).await).map_err(to_py_err)
     }
 
     #[pyo3(signature = (pattern, count))]
@@ -686,10 +688,8 @@ impl RustValkeyDriver {
     }
 
     #[pyo3(signature = (key))]
-    fn object_encoding_sync(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
-        let r: Result<Option<String>, _> =
-            sync_op!(py, self, conn, conn.object_encoding(key).await);
-        Ok(py_opt_bytes(py, r.map_err(to_py_err)?.map(String::into_bytes)))
+    fn object_encoding_sync(&self, py: Python<'_>, key: &str) -> PyResult<Option<String>> {
+        sync_op!(py, self, conn, conn.object_encoding(key).await).map_err(to_py_err)
     }
 
     #[pyo3(signature = (key))]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,8 +1,14 @@
 // Connection layer for the Rust I/O driver.
 //
-// Verbatim port from django-vcache (MIT, by David Burke / GlitchTip):
+// Original (lines through `connect_sentinel`): verbatim port from django-vcache
+// (MIT, by David Burke / GlitchTip):
 // https://gitlab.com/glitchtip/django-vcache/-/blob/main/src/connection.rs
-// Keep in lockstep with upstream — do not diverge without discussion.
+// Keep that section in lockstep with upstream.
+//
+// Below the "django-cachex extensions" marker at the bottom of the file are
+// extra command methods (hashes, sets, sorted sets, streams, admin/introspection)
+// that django-cachex needs but vcache does not expose. They live in the same
+// file so they can use the file-local dispatch macros.
 
 use redis::aio::{ConnectionManager, ConnectionManagerConfig};
 use redis::caching::{CacheConfig, CacheStatistics};
@@ -1140,4 +1146,750 @@ pub async fn connect_sentinel(
             tls_opts,
         },
     })
+}
+
+// =========================================================================
+// django-cachex extensions
+//
+// Methods below extend the vcache-ported surface with command families
+// (hashes, sets, sorted sets, streams, admin/introspection) that
+// django-cachex needs to expose. They use the file-local dispatch macros
+// `dispatch_cmd!`, `conn_method!`, and `sentinel_retry!` defined above.
+// =========================================================================
+
+impl ValkeyConnInner {
+    // ----- Strings / TTL / type / admin gap commands -----
+
+    pub async fn ttl(&mut self, key: &str) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("TTL");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn pttl(&mut self, key: &str) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("PTTL");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn keys(&mut self, pattern: &str) -> RedisResult<Vec<String>> {
+        let mut cmd = redis::cmd("KEYS");
+        cmd.arg(pattern);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn key_type(&mut self, key: &str) -> RedisResult<String> {
+        let mut cmd = redis::cmd("TYPE");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn script_exists(&mut self, sha: &str) -> RedisResult<bool> {
+        let mut cmd = redis::cmd("SCRIPT");
+        cmd.arg("EXISTS").arg(sha);
+        let result: Vec<bool> = dispatch_cmd!(self, cmd)?;
+        Ok(result.into_iter().next().unwrap_or(false))
+    }
+
+    pub async fn lpop(&mut self, key: &str) -> RedisResult<Option<Vec<u8>>> {
+        let mut cmd = redis::cmd("LPOP");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn lindex(&mut self, key: &str, index: i64) -> RedisResult<Option<Vec<u8>>> {
+        let mut cmd = redis::cmd("LINDEX");
+        cmd.arg(key).arg(index);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn lset(&mut self, key: &str, index: i64, value: &[u8]) -> RedisResult<()> {
+        let mut cmd = redis::cmd("LSET");
+        cmd.arg(key).arg(index).arg(value);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn linsert(
+        &mut self,
+        key: &str,
+        before: bool,
+        pivot: &[u8],
+        value: &[u8],
+    ) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("LINSERT");
+        cmd.arg(key)
+            .arg(if before { "BEFORE" } else { "AFTER" })
+            .arg(pivot)
+            .arg(value);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn dbsize(&mut self) -> RedisResult<i64> {
+        dispatch_cmd!(self, redis::cmd("DBSIZE"))
+    }
+
+    pub async fn info(&mut self) -> RedisResult<redis::Value> {
+        dispatch_cmd!(self, redis::cmd("INFO"))
+    }
+
+    pub async fn client_list(&mut self) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("CLIENT");
+        cmd.arg("LIST");
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn config_get(&mut self, parameter: &str) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("CONFIG");
+        cmd.arg("GET").arg(parameter);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn object_encoding(&mut self, key: &str) -> RedisResult<Option<String>> {
+        let mut cmd = redis::cmd("OBJECT");
+        cmd.arg("ENCODING").arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn object_idletime(&mut self, key: &str) -> RedisResult<Option<i64>> {
+        let mut cmd = redis::cmd("OBJECT");
+        cmd.arg("IDLETIME").arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn memory_usage(&mut self, key: &str) -> RedisResult<Option<i64>> {
+        let mut cmd = redis::cmd("MEMORY");
+        cmd.arg("USAGE").arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    // ----- Hashes -----
+
+    pub async fn hget(&mut self, key: &str, field: &str) -> RedisResult<Option<Vec<u8>>> {
+        let mut cmd = redis::cmd("HGET");
+        cmd.arg(key).arg(field);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hset(&mut self, key: &str, field: &str, value: &[u8]) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("HSET");
+        cmd.arg(key).arg(field).arg(value);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hgetall(&mut self, key: &str) -> RedisResult<Vec<(Vec<u8>, Vec<u8>)>> {
+        let mut cmd = redis::cmd("HGETALL");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hdel(&mut self, key: &str, fields: &[String]) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("HDEL");
+        cmd.arg(key);
+        for f in fields {
+            cmd.arg(f.as_str());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hincrby(&mut self, key: &str, field: &str, delta: i64) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("HINCRBY");
+        cmd.arg(key).arg(field).arg(delta);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hkeys(&mut self, key: &str) -> RedisResult<Vec<String>> {
+        let mut cmd = redis::cmd("HKEYS");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hvals(&mut self, key: &str) -> RedisResult<Vec<Vec<u8>>> {
+        let mut cmd = redis::cmd("HVALS");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hexists(&mut self, key: &str, field: &str) -> RedisResult<bool> {
+        let mut cmd = redis::cmd("HEXISTS");
+        cmd.arg(key).arg(field);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hlen(&mut self, key: &str) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("HLEN");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hmget(
+        &mut self,
+        key: &str,
+        fields: &[String],
+    ) -> RedisResult<Vec<Option<Vec<u8>>>> {
+        let mut cmd = redis::cmd("HMGET");
+        cmd.arg(key);
+        for f in fields {
+            cmd.arg(f.as_str());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn hmset(
+        &mut self,
+        key: &str,
+        fields: &[(String, Vec<u8>)],
+    ) -> RedisResult<()> {
+        // HMSET is technically deprecated; HSET with multiple field/value pairs is the modern equivalent.
+        let mut cmd = redis::cmd("HSET");
+        cmd.arg(key);
+        for (f, v) in fields {
+            cmd.arg(f.as_str()).arg(v.as_slice());
+        }
+        let _: i64 = dispatch_cmd!(self, cmd)?;
+        Ok(())
+    }
+
+    // ----- Sets -----
+
+    pub async fn sadd(&mut self, key: &str, members: Vec<Vec<u8>>) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("SADD");
+        cmd.arg(key);
+        for m in &members {
+            cmd.arg(m.as_slice());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn srem(&mut self, key: &str, members: Vec<Vec<u8>>) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("SREM");
+        cmd.arg(key);
+        for m in &members {
+            cmd.arg(m.as_slice());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn smembers(&mut self, key: &str) -> RedisResult<Vec<Vec<u8>>> {
+        let mut cmd = redis::cmd("SMEMBERS");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn sismember(&mut self, key: &str, member: &[u8]) -> RedisResult<bool> {
+        let mut cmd = redis::cmd("SISMEMBER");
+        cmd.arg(key).arg(member);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn scard(&mut self, key: &str) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("SCARD");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn sinter(&mut self, keys: &[String]) -> RedisResult<Vec<Vec<u8>>> {
+        let mut cmd = redis::cmd("SINTER");
+        for k in keys {
+            cmd.arg(k.as_str());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn sunion(&mut self, keys: &[String]) -> RedisResult<Vec<Vec<u8>>> {
+        let mut cmd = redis::cmd("SUNION");
+        for k in keys {
+            cmd.arg(k.as_str());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn sdiff(&mut self, keys: &[String]) -> RedisResult<Vec<Vec<u8>>> {
+        let mut cmd = redis::cmd("SDIFF");
+        for k in keys {
+            cmd.arg(k.as_str());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    // ----- Sorted sets -----
+
+    pub async fn zadd(&mut self, key: &str, members: Vec<(Vec<u8>, f64)>) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("ZADD");
+        cmd.arg(key);
+        for (member, score) in &members {
+            cmd.arg(*score).arg(member.as_slice());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zrem(&mut self, key: &str, members: Vec<Vec<u8>>) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("ZREM");
+        cmd.arg(key);
+        for m in &members {
+            cmd.arg(m.as_slice());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zrange(
+        &mut self,
+        key: &str,
+        start: i64,
+        stop: i64,
+        with_scores: bool,
+    ) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("ZRANGE");
+        cmd.arg(key).arg(start).arg(stop);
+        if with_scores {
+            cmd.arg("WITHSCORES");
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zrangebyscore(
+        &mut self,
+        key: &str,
+        min: &str,
+        max: &str,
+        with_scores: bool,
+    ) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("ZRANGEBYSCORE");
+        cmd.arg(key).arg(min).arg(max);
+        if with_scores {
+            cmd.arg("WITHSCORES");
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zrevrange(
+        &mut self,
+        key: &str,
+        start: i64,
+        stop: i64,
+        with_scores: bool,
+    ) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("ZREVRANGE");
+        cmd.arg(key).arg(start).arg(stop);
+        if with_scores {
+            cmd.arg("WITHSCORES");
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zincrby(&mut self, key: &str, member: &[u8], delta: f64) -> RedisResult<f64> {
+        let mut cmd = redis::cmd("ZINCRBY");
+        cmd.arg(key).arg(delta).arg(member);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zcard(&mut self, key: &str) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("ZCARD");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zscore(&mut self, key: &str, member: &[u8]) -> RedisResult<Option<f64>> {
+        let mut cmd = redis::cmd("ZSCORE");
+        cmd.arg(key).arg(member);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zrank(&mut self, key: &str, member: &[u8]) -> RedisResult<Option<i64>> {
+        let mut cmd = redis::cmd("ZRANK");
+        cmd.arg(key).arg(member);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zcount(&mut self, key: &str, min: &str, max: &str) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("ZCOUNT");
+        cmd.arg(key).arg(min).arg(max);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zpopmin(
+        &mut self,
+        key: &str,
+        count: i64,
+    ) -> RedisResult<Vec<(Vec<u8>, f64)>> {
+        let mut cmd = redis::cmd("ZPOPMIN");
+        cmd.arg(key).arg(count);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn zpopmax(
+        &mut self,
+        key: &str,
+        count: i64,
+    ) -> RedisResult<Vec<(Vec<u8>, f64)>> {
+        let mut cmd = redis::cmd("ZPOPMAX");
+        cmd.arg(key).arg(count);
+        dispatch_cmd!(self, cmd)
+    }
+
+    // ----- Streams -----
+
+    pub async fn xadd(
+        &mut self,
+        key: &str,
+        id: &str,
+        fields: &[(String, Vec<u8>)],
+    ) -> RedisResult<String> {
+        let mut cmd = redis::cmd("XADD");
+        cmd.arg(key).arg(id);
+        for (f, v) in fields {
+            cmd.arg(f.as_str()).arg(v.as_slice());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn xlen(&mut self, key: &str) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("XLEN");
+        cmd.arg(key);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn xrange(
+        &mut self,
+        key: &str,
+        start: &str,
+        end: &str,
+        count: Option<i64>,
+    ) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("XRANGE");
+        cmd.arg(key).arg(start).arg(end);
+        if let Some(c) = count {
+            cmd.arg("COUNT").arg(c);
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn xread(
+        &mut self,
+        keys: &[String],
+        ids: &[String],
+        count: Option<i64>,
+    ) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("XREAD");
+        if let Some(c) = count {
+            cmd.arg("COUNT").arg(c);
+        }
+        cmd.arg("STREAMS");
+        for k in keys {
+            cmd.arg(k.as_str());
+        }
+        for i in ids {
+            cmd.arg(i.as_str());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn xreadgroup(
+        &mut self,
+        group: &str,
+        consumer: &str,
+        keys: &[String],
+        ids: &[String],
+        count: Option<i64>,
+    ) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("XREADGROUP");
+        cmd.arg("GROUP").arg(group).arg(consumer);
+        if let Some(c) = count {
+            cmd.arg("COUNT").arg(c);
+        }
+        cmd.arg("STREAMS");
+        for k in keys {
+            cmd.arg(k.as_str());
+        }
+        for i in ids {
+            cmd.arg(i.as_str());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn xack(&mut self, key: &str, group: &str, ids: &[String]) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("XACK");
+        cmd.arg(key).arg(group);
+        for i in ids {
+            cmd.arg(i.as_str());
+        }
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn xtrim(&mut self, key: &str, max_len: i64, approximate: bool) -> RedisResult<i64> {
+        let mut cmd = redis::cmd("XTRIM");
+        cmd.arg(key).arg("MAXLEN");
+        if approximate {
+            cmd.arg("~");
+        }
+        cmd.arg(max_len);
+        dispatch_cmd!(self, cmd)
+    }
+
+    pub async fn xgroup_create(
+        &mut self,
+        key: &str,
+        group: &str,
+        id: &str,
+        mkstream: bool,
+    ) -> RedisResult<()> {
+        let mut cmd = redis::cmd("XGROUP");
+        cmd.arg("CREATE").arg(key).arg(group).arg(id);
+        if mkstream {
+            cmd.arg("MKSTREAM");
+        }
+        let _: redis::Value = dispatch_cmd!(self, cmd)?;
+        Ok(())
+    }
+
+    pub async fn xpending(&mut self, key: &str, group: &str) -> RedisResult<redis::Value> {
+        let mut cmd = redis::cmd("XPENDING");
+        cmd.arg(key).arg(group);
+        dispatch_cmd!(self, cmd)
+    }
+}
+
+// Delegate methods on the public `ValkeyConn` wrapper for the extension surface.
+impl ValkeyConn {
+    pub async fn ttl(&mut self, key: &str) -> RedisResult<i64> {
+        self.regular.ttl(key).await
+    }
+    pub async fn pttl(&mut self, key: &str) -> RedisResult<i64> {
+        self.regular.pttl(key).await
+    }
+    pub async fn keys(&mut self, pattern: &str) -> RedisResult<Vec<String>> {
+        self.regular.keys(pattern).await
+    }
+    pub async fn key_type(&mut self, key: &str) -> RedisResult<String> {
+        self.regular.key_type(key).await
+    }
+    pub async fn script_exists(&mut self, sha: &str) -> RedisResult<bool> {
+        self.regular.script_exists(sha).await
+    }
+    pub async fn lpop(&mut self, key: &str) -> RedisResult<Option<Vec<u8>>> {
+        self.regular.lpop(key).await
+    }
+    pub async fn lindex(&mut self, key: &str, index: i64) -> RedisResult<Option<Vec<u8>>> {
+        self.regular.lindex(key, index).await
+    }
+    pub async fn lset(&mut self, key: &str, index: i64, value: &[u8]) -> RedisResult<()> {
+        self.regular.lset(key, index, value).await
+    }
+    pub async fn linsert(
+        &mut self,
+        key: &str,
+        before: bool,
+        pivot: &[u8],
+        value: &[u8],
+    ) -> RedisResult<i64> {
+        self.regular.linsert(key, before, pivot, value).await
+    }
+    pub async fn dbsize(&mut self) -> RedisResult<i64> {
+        self.regular.dbsize().await
+    }
+    pub async fn info(&mut self) -> RedisResult<redis::Value> {
+        self.regular.info().await
+    }
+    pub async fn client_list(&mut self) -> RedisResult<redis::Value> {
+        self.regular.client_list().await
+    }
+    pub async fn config_get(&mut self, parameter: &str) -> RedisResult<redis::Value> {
+        self.regular.config_get(parameter).await
+    }
+    pub async fn object_encoding(&mut self, key: &str) -> RedisResult<Option<String>> {
+        self.regular.object_encoding(key).await
+    }
+    pub async fn object_idletime(&mut self, key: &str) -> RedisResult<Option<i64>> {
+        self.regular.object_idletime(key).await
+    }
+    pub async fn memory_usage(&mut self, key: &str) -> RedisResult<Option<i64>> {
+        self.regular.memory_usage(key).await
+    }
+
+    pub async fn hget(&mut self, key: &str, field: &str) -> RedisResult<Option<Vec<u8>>> {
+        self.regular.hget(key, field).await
+    }
+    pub async fn hset(&mut self, key: &str, field: &str, value: &[u8]) -> RedisResult<i64> {
+        self.regular.hset(key, field, value).await
+    }
+    pub async fn hgetall(&mut self, key: &str) -> RedisResult<Vec<(Vec<u8>, Vec<u8>)>> {
+        self.regular.hgetall(key).await
+    }
+    pub async fn hdel(&mut self, key: &str, fields: &[String]) -> RedisResult<i64> {
+        self.regular.hdel(key, fields).await
+    }
+    pub async fn hincrby(&mut self, key: &str, field: &str, delta: i64) -> RedisResult<i64> {
+        self.regular.hincrby(key, field, delta).await
+    }
+    pub async fn hkeys(&mut self, key: &str) -> RedisResult<Vec<String>> {
+        self.regular.hkeys(key).await
+    }
+    pub async fn hvals(&mut self, key: &str) -> RedisResult<Vec<Vec<u8>>> {
+        self.regular.hvals(key).await
+    }
+    pub async fn hexists(&mut self, key: &str, field: &str) -> RedisResult<bool> {
+        self.regular.hexists(key, field).await
+    }
+    pub async fn hlen(&mut self, key: &str) -> RedisResult<i64> {
+        self.regular.hlen(key).await
+    }
+    pub async fn hmget(
+        &mut self,
+        key: &str,
+        fields: &[String],
+    ) -> RedisResult<Vec<Option<Vec<u8>>>> {
+        self.regular.hmget(key, fields).await
+    }
+    pub async fn hmset(
+        &mut self,
+        key: &str,
+        fields: &[(String, Vec<u8>)],
+    ) -> RedisResult<()> {
+        self.regular.hmset(key, fields).await
+    }
+
+    pub async fn sadd(&mut self, key: &str, members: Vec<Vec<u8>>) -> RedisResult<i64> {
+        self.regular.sadd(key, members).await
+    }
+    pub async fn srem(&mut self, key: &str, members: Vec<Vec<u8>>) -> RedisResult<i64> {
+        self.regular.srem(key, members).await
+    }
+    pub async fn smembers(&mut self, key: &str) -> RedisResult<Vec<Vec<u8>>> {
+        self.regular.smembers(key).await
+    }
+    pub async fn sismember(&mut self, key: &str, member: &[u8]) -> RedisResult<bool> {
+        self.regular.sismember(key, member).await
+    }
+    pub async fn scard(&mut self, key: &str) -> RedisResult<i64> {
+        self.regular.scard(key).await
+    }
+    pub async fn sinter(&mut self, keys: &[String]) -> RedisResult<Vec<Vec<u8>>> {
+        self.regular.sinter(keys).await
+    }
+    pub async fn sunion(&mut self, keys: &[String]) -> RedisResult<Vec<Vec<u8>>> {
+        self.regular.sunion(keys).await
+    }
+    pub async fn sdiff(&mut self, keys: &[String]) -> RedisResult<Vec<Vec<u8>>> {
+        self.regular.sdiff(keys).await
+    }
+
+    pub async fn zadd(&mut self, key: &str, members: Vec<(Vec<u8>, f64)>) -> RedisResult<i64> {
+        self.regular.zadd(key, members).await
+    }
+    pub async fn zrem(&mut self, key: &str, members: Vec<Vec<u8>>) -> RedisResult<i64> {
+        self.regular.zrem(key, members).await
+    }
+    pub async fn zrange(
+        &mut self,
+        key: &str,
+        start: i64,
+        stop: i64,
+        with_scores: bool,
+    ) -> RedisResult<redis::Value> {
+        self.regular.zrange(key, start, stop, with_scores).await
+    }
+    pub async fn zrangebyscore(
+        &mut self,
+        key: &str,
+        min: &str,
+        max: &str,
+        with_scores: bool,
+    ) -> RedisResult<redis::Value> {
+        self.regular.zrangebyscore(key, min, max, with_scores).await
+    }
+    pub async fn zrevrange(
+        &mut self,
+        key: &str,
+        start: i64,
+        stop: i64,
+        with_scores: bool,
+    ) -> RedisResult<redis::Value> {
+        self.regular.zrevrange(key, start, stop, with_scores).await
+    }
+    pub async fn zincrby(&mut self, key: &str, member: &[u8], delta: f64) -> RedisResult<f64> {
+        self.regular.zincrby(key, member, delta).await
+    }
+    pub async fn zcard(&mut self, key: &str) -> RedisResult<i64> {
+        self.regular.zcard(key).await
+    }
+    pub async fn zscore(&mut self, key: &str, member: &[u8]) -> RedisResult<Option<f64>> {
+        self.regular.zscore(key, member).await
+    }
+    pub async fn zrank(&mut self, key: &str, member: &[u8]) -> RedisResult<Option<i64>> {
+        self.regular.zrank(key, member).await
+    }
+    pub async fn zcount(&mut self, key: &str, min: &str, max: &str) -> RedisResult<i64> {
+        self.regular.zcount(key, min, max).await
+    }
+    pub async fn zpopmin(
+        &mut self,
+        key: &str,
+        count: i64,
+    ) -> RedisResult<Vec<(Vec<u8>, f64)>> {
+        self.regular.zpopmin(key, count).await
+    }
+    pub async fn zpopmax(
+        &mut self,
+        key: &str,
+        count: i64,
+    ) -> RedisResult<Vec<(Vec<u8>, f64)>> {
+        self.regular.zpopmax(key, count).await
+    }
+
+    pub async fn xadd(
+        &mut self,
+        key: &str,
+        id: &str,
+        fields: &[(String, Vec<u8>)],
+    ) -> RedisResult<String> {
+        self.regular.xadd(key, id, fields).await
+    }
+    pub async fn xlen(&mut self, key: &str) -> RedisResult<i64> {
+        self.regular.xlen(key).await
+    }
+    pub async fn xrange(
+        &mut self,
+        key: &str,
+        start: &str,
+        end: &str,
+        count: Option<i64>,
+    ) -> RedisResult<redis::Value> {
+        self.regular.xrange(key, start, end, count).await
+    }
+    pub async fn xread(
+        &mut self,
+        keys: &[String],
+        ids: &[String],
+        count: Option<i64>,
+    ) -> RedisResult<redis::Value> {
+        // XREAD without BLOCK is non-blocking; re-uses the regular conn.
+        self.regular.xread(keys, ids, count).await
+    }
+    pub async fn xreadgroup(
+        &mut self,
+        group: &str,
+        consumer: &str,
+        keys: &[String],
+        ids: &[String],
+        count: Option<i64>,
+    ) -> RedisResult<redis::Value> {
+        self.regular.xreadgroup(group, consumer, keys, ids, count).await
+    }
+    pub async fn xack(&mut self, key: &str, group: &str, ids: &[String]) -> RedisResult<i64> {
+        self.regular.xack(key, group, ids).await
+    }
+    pub async fn xtrim(&mut self, key: &str, max_len: i64, approximate: bool) -> RedisResult<i64> {
+        self.regular.xtrim(key, max_len, approximate).await
+    }
+    pub async fn xgroup_create(
+        &mut self,
+        key: &str,
+        group: &str,
+        id: &str,
+        mkstream: bool,
+    ) -> RedisResult<()> {
+        self.regular.xgroup_create(key, group, id, mkstream).await
+    }
+    pub async fn xpending(&mut self, key: &str, group: &str) -> RedisResult<redis::Value> {
+        self.regular.xpending(key, group).await
+    }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1172,6 +1172,10 @@ impl ValkeyConnInner {
         dispatch_cmd!(self, cmd)
     }
 
+    /// On Cluster, KEYS only hits one master and returns that node's keys —
+    /// callers needing a full-cluster scan should fan out themselves or use
+    /// `scan_all` (which has the same single-node limitation here, mirroring
+    /// vcache's behavior; documented for both).
     pub async fn keys(&mut self, pattern: &str) -> RedisResult<Vec<String>> {
         let mut cmd = redis::cmd("KEYS");
         cmd.arg(pattern);
@@ -1387,6 +1391,8 @@ impl ValkeyConnInner {
         dispatch_cmd!(self, cmd)
     }
 
+    /// Multi-key. On Cluster all keys must hash to the same slot; redis-rs
+    /// surfaces a CROSSSLOT error otherwise. Same applies to `sunion` / `sdiff`.
     pub async fn sinter(&mut self, keys: &[String]) -> RedisResult<Vec<Vec<u8>>> {
         let mut cmd = redis::cmd("SINTER");
         for k in keys {
@@ -1563,6 +1569,8 @@ impl ValkeyConnInner {
         dispatch_cmd!(self, cmd)
     }
 
+    /// Multi-stream. On Cluster all stream keys must hash to the same slot
+    /// (CROSSSLOT otherwise). Same applies to `xreadgroup`.
     pub async fn xread(
         &mut self,
         keys: &[String],

--- a/tests/rust/conftest.py
+++ b/tests/rust/conftest.py
@@ -1,0 +1,15 @@
+"""Shared fixtures for rust driver tests."""
+
+from __future__ import annotations
+
+import pytest
+from django_cachex._driver import RustValkeyDriver  # ty: ignore[unresolved-import]
+
+
+@pytest.fixture
+def driver(redis_container) -> RustValkeyDriver:
+    d = RustValkeyDriver.connect_standard(
+        f"redis://{redis_container.host}:{redis_container.port}/0",
+    )
+    d.flushdb_sync()
+    return d

--- a/tests/rust/test_driver_admin.py
+++ b/tests/rust/test_driver_admin.py
@@ -1,0 +1,43 @@
+def test_dbsize(driver):
+    assert driver.dbsize_sync() == 0
+    driver.set_sync("a", b"1")
+    driver.set_sync("b", b"2")
+    assert driver.dbsize_sync() == 2
+
+
+def test_info(driver):
+    result = driver.info_sync()
+    # Info returns a bulk string keyed by section; here we get the full text.
+    assert result is not None
+
+
+def test_client_list(driver):
+    result = driver.client_list_sync()
+    assert result is not None
+
+
+def test_config_get(driver):
+    result = driver.config_get_sync("maxmemory-policy")
+    # Older versions return a 2-element array, newer ones a map. Just verify shape isn't empty.
+    assert result is not None
+
+
+def test_object_encoding(driver):
+    driver.set_sync("k", b"v")
+    encoding = driver.object_encoding_sync("k")
+    # Encoding depends on Redis version (embstr/raw); just verify it's not None.
+    assert encoding is not None
+
+
+def test_object_idletime(driver):
+    driver.set_sync("k", b"v")
+    idle = driver.object_idletime_sync("k")
+    assert idle is not None
+    assert idle >= 0
+
+
+def test_memory_usage(driver):
+    driver.set_sync("k", b"some value here")
+    usage = driver.memory_usage_sync("k")
+    assert usage is not None
+    assert usage > 0

--- a/tests/rust/test_driver_admin.py
+++ b/tests/rust/test_driver_admin.py
@@ -7,26 +7,27 @@ def test_dbsize(driver):
 
 def test_info(driver):
     result = driver.info_sync()
-    # Info returns a bulk string keyed by section; here we get the full text.
-    assert result is not None
+    # INFO returns a bulk string with sections; redis_version is universal.
+    assert b"redis_version" in result
 
 
 def test_client_list(driver):
     result = driver.client_list_sync()
-    assert result is not None
+    assert b"id=" in result  # each client entry has an id= field
 
 
 def test_config_get(driver):
+    # RESP3 returns a Map (Python dict); we force RESP3 on every connection.
     result = driver.config_get_sync("maxmemory-policy")
-    # Older versions return a 2-element array, newer ones a map. Just verify shape isn't empty.
-    assert result is not None
+    assert isinstance(result, dict)
+    assert b"maxmemory-policy" in result
 
 
 def test_object_encoding(driver):
-    driver.set_sync("k", b"v")
+    driver.set_sync("k", b"some longer value")
     encoding = driver.object_encoding_sync("k")
-    # Encoding depends on Redis version (embstr/raw); just verify it's not None.
-    assert encoding is not None
+    # Encoding is one of the known string encodings.
+    assert encoding in {"embstr", "raw", "int"}
 
 
 def test_object_idletime(driver):

--- a/tests/rust/test_driver_async.py
+++ b/tests/rust/test_driver_async.py
@@ -1,0 +1,60 @@
+"""Async smoke tests: verify each major family's async variant returns a working awaitable."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_async_get_set(driver):
+    await driver.set("k", b"v")
+    assert await driver.get("k") == b"v"
+
+
+@pytest.mark.asyncio
+async def test_async_mget(driver):
+    await driver.pipeline_set([("a", b"1"), ("b", b"2")])
+    assert await driver.mget(["a", "b", "missing"]) == [b"1", b"2", None]
+
+
+@pytest.mark.asyncio
+async def test_async_hset_hgetall(driver):
+    await driver.hset("h", "a", b"1")
+    await driver.hset("h", "b", b"2")
+    result = await driver.hgetall("h")
+    assert result == {b"a": b"1", b"b": b"2"}
+
+
+@pytest.mark.asyncio
+async def test_async_sadd_smembers(driver):
+    await driver.sadd("s", [b"x", b"y", b"z"])
+    members = await driver.smembers("s")
+    assert sorted(members) == [b"x", b"y", b"z"]
+
+
+@pytest.mark.asyncio
+async def test_async_zadd_zrange(driver):
+    await driver.zadd("z", [(b"a", 1.0), (b"b", 2.0)])
+    assert await driver.zrange("z", 0, -1) == [b"a", b"b"]
+
+
+@pytest.mark.asyncio
+async def test_async_xadd_xlen(driver):
+    await driver.xadd("s", "*", [("f", b"v")])
+    assert await driver.xlen("s") == 1
+
+
+@pytest.mark.asyncio
+async def test_async_lpush_lrange(driver):
+    await driver.rpush("l", [b"a", b"b", b"c"])
+    assert await driver.lrange("l", 0, -1) == [b"a", b"b", b"c"]
+
+
+@pytest.mark.asyncio
+async def test_async_eval(driver):
+    result = await driver.eval("return tonumber(ARGV[1])", [], [b"7"])
+    assert result == 7
+
+
+@pytest.mark.asyncio
+async def test_async_lock(driver):
+    assert await driver.lock_acquire("lock", "tok", 5000) is True
+    assert await driver.lock_release("lock", "tok") == 1

--- a/tests/rust/test_driver_async.py
+++ b/tests/rust/test_driver_async.py
@@ -58,3 +58,33 @@ async def test_async_eval(driver):
 async def test_async_lock(driver):
     assert await driver.lock_acquire("lock", "tok", 5000) is True
     assert await driver.lock_release("lock", "tok") == 1
+
+
+@pytest.mark.asyncio
+async def test_async_set_returns_none_like_sync(driver):
+    """Sync side: set_sync returns None. Async must match."""
+    result = await driver.set("k", b"v")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_async_xadd_returns_str_like_sync(driver):
+    """Sync side: xadd_sync returns str. Async must match (was bytes before fix)."""
+    msg_id = await driver.xadd("s", "*", [("f", b"v")])
+    assert isinstance(msg_id, str)
+
+
+@pytest.mark.asyncio
+async def test_async_script_load_returns_str_like_sync(driver):
+    """Sync side: script_load_sync returns str. Async must match."""
+    sha = await driver.script_load("return 1")
+    assert isinstance(sha, str)
+    assert len(sha) == 40  # sha1 hex
+
+
+@pytest.mark.asyncio
+async def test_async_type_returns_str_like_sync(driver):
+    """Sync side: type_sync returns str. Async must match."""
+    await driver.set("k", b"v")
+    t = await driver.type("k")
+    assert t == "string"

--- a/tests/rust/test_driver_hashes.py
+++ b/tests/rust/test_driver_hashes.py
@@ -1,0 +1,55 @@
+def test_hset_hget(driver):
+    driver.hset_sync("h", "f", b"v")
+    assert driver.hget_sync("h", "f") == b"v"
+    assert driver.hget_sync("h", "missing") is None
+
+
+def test_hgetall(driver):
+    driver.hset_sync("h", "a", b"1")
+    driver.hset_sync("h", "b", b"2")
+    result = driver.hgetall_sync("h")
+    assert result == {b"a": b"1", b"b": b"2"}
+
+
+def test_hdel(driver):
+    driver.hset_sync("h", "a", b"1")
+    driver.hset_sync("h", "b", b"2")
+    driver.hset_sync("h", "c", b"3")
+    assert driver.hdel_sync("h", ["a", "b", "missing"]) == 2
+    assert driver.hgetall_sync("h") == {b"c": b"3"}
+
+
+def test_hincrby(driver):
+    assert driver.hincrby_sync("h", "n", 5) == 5
+    assert driver.hincrby_sync("h", "n", 3) == 8
+    assert driver.hincrby_sync("h", "n", -2) == 6
+
+
+def test_hkeys_hvals(driver):
+    driver.hset_sync("h", "a", b"1")
+    driver.hset_sync("h", "b", b"2")
+    assert sorted(driver.hkeys_sync("h")) == ["a", "b"]
+    assert sorted(driver.hvals_sync("h")) == [b"1", b"2"]
+
+
+def test_hexists(driver):
+    driver.hset_sync("h", "f", b"v")
+    assert driver.hexists_sync("h", "f") is True
+    assert driver.hexists_sync("h", "missing") is False
+
+
+def test_hlen(driver):
+    driver.hset_sync("h", "a", b"1")
+    driver.hset_sync("h", "b", b"2")
+    assert driver.hlen_sync("h") == 2
+
+
+def test_hmget(driver):
+    driver.hset_sync("h", "a", b"1")
+    driver.hset_sync("h", "b", b"2")
+    assert driver.hmget_sync("h", ["a", "missing", "b"]) == [b"1", None, b"2"]
+
+
+def test_hmset(driver):
+    driver.hmset_sync("h", [("a", b"1"), ("b", b"2"), ("c", b"3")])
+    assert driver.hgetall_sync("h") == {b"a": b"1", b"b": b"2", b"c": b"3"}

--- a/tests/rust/test_driver_lists.py
+++ b/tests/rust/test_driver_lists.py
@@ -49,3 +49,25 @@ def test_ltrim(driver):
     driver.rpush_sync("l", [b"a", b"b", b"c", b"d", b"e"])
     driver.ltrim_sync("l", 1, 3)
     assert driver.lrange_sync("l", 0, -1) == [b"b", b"c", b"d"]
+
+
+def test_blmove_returns_value_when_source_has_data(driver):
+    driver.rpush_sync("src", [b"hello"])
+    # Short timeout — value is already there so no blocking happens.
+    assert driver.blmove_sync("src", "dst", "LEFT", "RIGHT", 0.1) == b"hello"
+    assert driver.lrange_sync("dst", 0, -1) == [b"hello"]
+
+
+def test_blmove_returns_none_on_empty(driver):
+    # Source is empty, brief timeout so we don't hang.
+    assert driver.blmove_sync("src", "dst", "LEFT", "RIGHT", 0.1) is None
+
+
+def test_blmpop_returns_key_and_values(driver):
+    driver.rpush_sync("a", [b"1", b"2", b"3"])
+    result = driver.blmpop_sync(0.1, ["a", "b"], "LEFT", 2)
+    assert result == ("a", [b"1", b"2"])
+
+
+def test_blmpop_returns_none_on_empty(driver):
+    assert driver.blmpop_sync(0.1, ["a", "b"], "LEFT", 1) is None

--- a/tests/rust/test_driver_lists.py
+++ b/tests/rust/test_driver_lists.py
@@ -1,0 +1,51 @@
+def test_lpush_rpush_lrange(driver):
+    driver.rpush_sync("l", [b"a", b"b", b"c"])
+    driver.lpush_sync("l", [b"z"])
+    assert driver.lrange_sync("l", 0, -1) == [b"z", b"a", b"b", b"c"]
+
+
+def test_lpop_rpop(driver):
+    driver.rpush_sync("l", [b"a", b"b", b"c"])
+    assert driver.lpop_sync("l") == b"a"
+    assert driver.rpop_sync("l") == b"c"
+    assert driver.lrange_sync("l", 0, -1) == [b"b"]
+
+
+def test_lpop_empty_returns_none(driver):
+    assert driver.lpop_sync("nope") is None
+
+
+def test_llen(driver):
+    driver.rpush_sync("l", [b"a", b"b", b"c"])
+    assert driver.llen_sync("l") == 3
+
+
+def test_lrem(driver):
+    driver.rpush_sync("l", [b"a", b"x", b"a", b"x", b"a"])
+    assert driver.lrem_sync("l", 2, b"a") == 2
+    assert driver.lrange_sync("l", 0, -1) == [b"x", b"x", b"a"]
+
+
+def test_lindex(driver):
+    driver.rpush_sync("l", [b"a", b"b", b"c"])
+    assert driver.lindex_sync("l", 0) == b"a"
+    assert driver.lindex_sync("l", -1) == b"c"
+    assert driver.lindex_sync("l", 99) is None
+
+
+def test_lset(driver):
+    driver.rpush_sync("l", [b"a", b"b", b"c"])
+    driver.lset_sync("l", 1, b"B")
+    assert driver.lrange_sync("l", 0, -1) == [b"a", b"B", b"c"]
+
+
+def test_linsert(driver):
+    driver.rpush_sync("l", [b"a", b"c"])
+    assert driver.linsert_sync("l", before=True, pivot=b"c", value=b"b") == 3
+    assert driver.lrange_sync("l", 0, -1) == [b"a", b"b", b"c"]
+
+
+def test_ltrim(driver):
+    driver.rpush_sync("l", [b"a", b"b", b"c", b"d", b"e"])
+    driver.ltrim_sync("l", 1, 3)
+    assert driver.lrange_sync("l", 0, -1) == [b"b", b"c", b"d"]

--- a/tests/rust/test_driver_locks.py
+++ b/tests/rust/test_driver_locks.py
@@ -1,0 +1,22 @@
+def test_lock_acquire_release(driver):
+    assert driver.lock_acquire_sync("lock", "tok-1", timeout_ms=5000) is True
+    assert driver.lock_acquire_sync("lock", "tok-2", timeout_ms=5000) is False
+    assert driver.lock_release_sync("lock", "tok-1") == 1
+
+
+def test_lock_release_with_wrong_token(driver):
+    driver.lock_acquire_sync("lock", "tok-1", timeout_ms=5000)
+    assert driver.lock_release_sync("lock", "wrong-tok") == 0
+    # Real owner can still release
+    assert driver.lock_release_sync("lock", "tok-1") == 1
+
+
+def test_lock_extend(driver):
+    driver.lock_acquire_sync("lock", "tok", timeout_ms=1000)
+    assert driver.lock_extend_sync("lock", "tok", 5000) == 1
+    assert driver.pttl_sync("lock") > 1000
+
+
+def test_lock_extend_with_wrong_token(driver):
+    driver.lock_acquire_sync("lock", "tok", timeout_ms=5000)
+    assert driver.lock_extend_sync("lock", "wrong-tok", 1000) == 0

--- a/tests/rust/test_driver_pipeline.py
+++ b/tests/rust/test_driver_pipeline.py
@@ -1,0 +1,33 @@
+def test_pipeline_exec_executes_commands_in_order(driver):
+    result = driver.pipeline_exec_sync(
+        [
+            ("SET", [b"a", b"1"]),
+            ("SET", [b"b", b"2"]),
+            ("GET", [b"a"]),
+            ("GET", [b"b"]),
+        ],
+    )
+    # SET returns OK (rendered as True via redis::Value::Okay), GET returns the bytes.
+    assert result[0] is True
+    assert result[1] is True
+    assert result[2] == b"1"
+    assert result[3] == b"2"
+
+
+def test_pipeline_exec_with_increment(driver):
+    result = driver.pipeline_exec_sync(
+        [
+            ("INCR", [b"counter"]),
+            ("INCR", [b"counter"]),
+            ("INCR", [b"counter"]),
+        ],
+    )
+    assert result == [1, 2, 3]
+
+
+def test_pipeline_exec_empty_raises(driver):
+    """redis-rs rejects empty pipelines — surface that as a RuntimeError."""
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        driver.pipeline_exec_sync([])

--- a/tests/rust/test_driver_scripts.py
+++ b/tests/rust/test_driver_scripts.py
@@ -1,0 +1,31 @@
+SCRIPT = "return redis.call('SET', KEYS[1], ARGV[1])"
+RETURN_INT = "return tonumber(ARGV[1])"
+RETURN_LIST = "return {1, 2, 'three'}"
+
+
+def test_eval_set(driver):
+    driver.eval_sync(SCRIPT, ["k"], [b"v"])
+    assert driver.get_sync("k") == b"v"
+
+
+def test_eval_returns_int(driver):
+    assert driver.eval_sync(RETURN_INT, [], [b"42"]) == 42
+
+
+def test_eval_returns_list(driver):
+    result = driver.eval_sync(RETURN_LIST, [], [])
+    assert result[0] == 1
+    assert result[1] == 2
+    assert result[2] == b"three"
+
+
+def test_script_load_and_evalsha(driver):
+    sha = driver.script_load_sync(SCRIPT)
+    driver.evalsha_sync(sha, ["k"], [b"v"])
+    assert driver.get_sync("k") == b"v"
+
+
+def test_script_exists(driver):
+    sha = driver.script_load_sync(SCRIPT)
+    assert driver.script_exists_sync(sha) is True
+    assert driver.script_exists_sync("0" * 40) is False

--- a/tests/rust/test_driver_scripts.py
+++ b/tests/rust/test_driver_scripts.py
@@ -29,3 +29,21 @@ def test_script_exists(driver):
     sha = driver.script_load_sync(SCRIPT)
     assert driver.script_exists_sync(sha) is True
     assert driver.script_exists_sync("0" * 40) is False
+
+
+def test_evalsha_unknown_raises_runtime_error(driver):
+    """Server-side errors (NOSCRIPT) classify as PyRuntimeError, NOT PyConnectionError.
+
+    This locks in the boundary between IGNORE_EXCEPTIONS-swallowable connection
+    errors and propagated server errors per #66's locked decisions.
+    """
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        driver.evalsha_sync("0" * 40, [], [])
+
+
+def test_eval_returning_string_renders_as_bytes(driver):
+    # Lua return type 'string' arrives as RESP bulk-string → Python bytes.
+    result = driver.eval_sync("return 'hello'", [], [])
+    assert result == b"hello"

--- a/tests/rust/test_driver_sets.py
+++ b/tests/rust/test_driver_sets.py
@@ -1,0 +1,43 @@
+def test_sadd_smembers(driver):
+    assert driver.sadd_sync("s", [b"a", b"b", b"c"]) == 3
+    assert sorted(driver.smembers_sync("s")) == [b"a", b"b", b"c"]
+
+
+def test_sadd_dedup(driver):
+    driver.sadd_sync("s", [b"a", b"b"])
+    assert driver.sadd_sync("s", [b"a", b"c"]) == 1  # only "c" is new
+
+
+def test_srem(driver):
+    driver.sadd_sync("s", [b"a", b"b", b"c"])
+    assert driver.srem_sync("s", [b"a", b"c", b"missing"]) == 2
+    assert driver.smembers_sync("s") == [b"b"]
+
+
+def test_sismember(driver):
+    driver.sadd_sync("s", [b"a", b"b"])
+    assert driver.sismember_sync("s", b"a") is True
+    assert driver.sismember_sync("s", b"c") is False
+
+
+def test_scard(driver):
+    driver.sadd_sync("s", [b"a", b"b", b"c"])
+    assert driver.scard_sync("s") == 3
+
+
+def test_sinter(driver):
+    driver.sadd_sync("s1", [b"a", b"b", b"c"])
+    driver.sadd_sync("s2", [b"b", b"c", b"d"])
+    assert sorted(driver.sinter_sync(["s1", "s2"])) == [b"b", b"c"]
+
+
+def test_sunion(driver):
+    driver.sadd_sync("s1", [b"a", b"b"])
+    driver.sadd_sync("s2", [b"b", b"c"])
+    assert sorted(driver.sunion_sync(["s1", "s2"])) == [b"a", b"b", b"c"]
+
+
+def test_sdiff(driver):
+    driver.sadd_sync("s1", [b"a", b"b", b"c"])
+    driver.sadd_sync("s2", [b"b"])
+    assert sorted(driver.sdiff_sync(["s1", "s2"])) == [b"a", b"c"]

--- a/tests/rust/test_driver_sortedsets.py
+++ b/tests/rust/test_driver_sortedsets.py
@@ -1,0 +1,69 @@
+def test_zadd_zrange(driver):
+    assert driver.zadd_sync("z", [(b"a", 1.0), (b"b", 2.0), (b"c", 3.0)]) == 3
+    assert driver.zrange_sync("z", 0, -1) == [b"a", b"b", b"c"]
+
+
+def test_zrange_with_scores(driver):
+    driver.zadd_sync("z", [(b"a", 1.0), (b"b", 2.0)])
+    assert driver.zrange_sync("z", 0, -1, with_scores=True) == [
+        [b"a", 1.0],
+        [b"b", 2.0],
+    ]
+
+
+def test_zrem(driver):
+    driver.zadd_sync("z", [(b"a", 1.0), (b"b", 2.0), (b"c", 3.0)])
+    assert driver.zrem_sync("z", [b"a", b"missing"]) == 1
+    assert driver.zrange_sync("z", 0, -1) == [b"b", b"c"]
+
+
+def test_zrangebyscore(driver):
+    driver.zadd_sync("z", [(b"a", 1.0), (b"b", 5.0), (b"c", 10.0)])
+    assert driver.zrangebyscore_sync("z", "2", "8") == [b"b"]
+    assert driver.zrangebyscore_sync("z", "-inf", "+inf") == [b"a", b"b", b"c"]
+
+
+def test_zrevrange(driver):
+    driver.zadd_sync("z", [(b"a", 1.0), (b"b", 2.0), (b"c", 3.0)])
+    assert driver.zrevrange_sync("z", 0, -1) == [b"c", b"b", b"a"]
+
+
+def test_zincrby(driver):
+    driver.zadd_sync("z", [(b"a", 1.0)])
+    assert driver.zincrby_sync("z", b"a", 2.5) == 3.5
+    assert driver.zscore_sync("z", b"a") == 3.5
+
+
+def test_zcard(driver):
+    driver.zadd_sync("z", [(b"a", 1.0), (b"b", 2.0)])
+    assert driver.zcard_sync("z") == 2
+
+
+def test_zscore(driver):
+    driver.zadd_sync("z", [(b"a", 1.5)])
+    assert driver.zscore_sync("z", b"a") == 1.5
+    assert driver.zscore_sync("z", b"missing") is None
+
+
+def test_zrank(driver):
+    driver.zadd_sync("z", [(b"a", 1.0), (b"b", 2.0), (b"c", 3.0)])
+    assert driver.zrank_sync("z", b"a") == 0
+    assert driver.zrank_sync("z", b"c") == 2
+    assert driver.zrank_sync("z", b"missing") is None
+
+
+def test_zcount(driver):
+    driver.zadd_sync("z", [(b"a", 1.0), (b"b", 5.0), (b"c", 10.0)])
+    assert driver.zcount_sync("z", "2", "8") == 1
+    assert driver.zcount_sync("z", "-inf", "+inf") == 3
+
+
+def test_zpopmin(driver):
+    driver.zadd_sync("z", [(b"a", 1.0), (b"b", 2.0), (b"c", 3.0)])
+    assert driver.zpopmin_sync("z") == [(b"a", 1.0)]
+    assert driver.zpopmin_sync("z", count=2) == [(b"b", 2.0), (b"c", 3.0)]
+
+
+def test_zpopmax(driver):
+    driver.zadd_sync("z", [(b"a", 1.0), (b"b", 2.0), (b"c", 3.0)])
+    assert driver.zpopmax_sync("z") == [(b"c", 3.0)]

--- a/tests/rust/test_driver_streams.py
+++ b/tests/rust/test_driver_streams.py
@@ -10,6 +10,9 @@ def test_xrange(driver):
     driver.xadd_sync("s", "*", [("field", b"v2")])
     entries = driver.xrange_sync("s", "-", "+")
     assert len(entries) == 2
+    # XRANGE returns each entry as [id_bytes, [field_bytes, value_bytes, ...]].
+    assert entries[0][1] == [b"field", b"v1"]
+    assert entries[1][1] == [b"field", b"v2"]
 
 
 def test_xrange_with_count(driver):

--- a/tests/rust/test_driver_streams.py
+++ b/tests/rust/test_driver_streams.py
@@ -1,0 +1,64 @@
+def test_xadd_xlen(driver):
+    id1 = driver.xadd_sync("s", "*", [("field", b"v1")])
+    id2 = driver.xadd_sync("s", "*", [("field", b"v2")])
+    assert driver.xlen_sync("s") == 2
+    assert id1 < id2
+
+
+def test_xrange(driver):
+    driver.xadd_sync("s", "*", [("field", b"v1")])
+    driver.xadd_sync("s", "*", [("field", b"v2")])
+    entries = driver.xrange_sync("s", "-", "+")
+    assert len(entries) == 2
+
+
+def test_xrange_with_count(driver):
+    for i in range(5):
+        driver.xadd_sync("s", "*", [("i", str(i).encode())])
+    entries = driver.xrange_sync("s", "-", "+", count=2)
+    assert len(entries) == 2
+
+
+def test_xread(driver):
+    driver.xadd_sync("s", "*", [("field", b"v1")])
+    result = driver.xread_sync(["s"], ["0"])
+    assert result is not None
+    assert len(result) == 1
+
+
+def test_xtrim(driver):
+    for i in range(10):
+        driver.xadd_sync("s", "*", [("i", str(i).encode())])
+    driver.xtrim_sync("s", max_len=3)
+    assert driver.xlen_sync("s") == 3
+
+
+def test_xgroup_create_and_xreadgroup(driver):
+    driver.xadd_sync("s", "*", [("field", b"v1")])
+    driver.xgroup_create_sync("s", "g1", "0", mkstream=False)
+    result = driver.xreadgroup_sync("g1", "consumer1", ["s"], [">"])
+    assert result is not None
+
+
+def test_xack(driver):
+    driver.xadd_sync("s", "*", [("field", b"v1")])
+    driver.xgroup_create_sync("s", "g1", "0", mkstream=False)
+    result = driver.xreadgroup_sync("g1", "consumer1", ["s"], [">"])
+    # RESP3 returns XREADGROUP as a map: {stream: [[id, [field, value]]]}
+    entries = result[b"s"]
+    msg_id = entries[0][0].decode()
+    assert driver.xack_sync("s", "g1", [msg_id]) == 1
+
+
+def test_xpending(driver):
+    driver.xadd_sync("s", "*", [("field", b"v1")])
+    driver.xgroup_create_sync("s", "g1", "0", mkstream=False)
+    driver.xreadgroup_sync("g1", "consumer1", ["s"], [">"])
+    result = driver.xpending_sync("s", "g1")
+    assert result[0] == 1  # 1 pending message
+
+
+def test_xgroup_create_mkstream(driver):
+    # Stream doesn't exist yet — mkstream=True creates it.
+    driver.xgroup_create_sync("new_stream", "g", "0", mkstream=True)
+    assert driver.xlen_sync("new_stream") == 0

--- a/tests/rust/test_driver_strings.py
+++ b/tests/rust/test_driver_strings.py
@@ -1,0 +1,97 @@
+def test_get_set_basic(driver):
+    driver.set_sync("k", b"v")
+    assert driver.get_sync("k") == b"v"
+
+
+def test_get_missing(driver):
+    assert driver.get_sync("nope") is None
+
+
+def test_set_with_ttl_and_pttl(driver):
+    driver.set_sync("k", b"v", ttl=100)
+    assert driver.ttl_sync("k") in range(95, 101)  # account for clock skew
+    assert driver.pttl_sync("k") <= 100_000
+
+
+def test_set_nx_only_when_absent(driver):
+    assert driver.set_nx_sync("k", b"v1") is True
+    assert driver.set_nx_sync("k", b"v2") is False
+    assert driver.get_sync("k") == b"v1"
+
+
+def test_delete_returns_count(driver):
+    driver.set_sync("k", b"v")
+    assert driver.delete_sync("k") == 1
+    assert driver.delete_sync("k") == 0
+
+
+def test_delete_many(driver):
+    driver.set_sync("a", b"1")
+    driver.set_sync("b", b"2")
+    driver.set_sync("c", b"3")
+    assert driver.delete_many_sync(["a", "b", "missing", "c"]) == 3
+
+
+def test_mget(driver):
+    driver.set_sync("a", b"1")
+    driver.set_sync("b", b"2")
+    assert driver.mget_sync(["a", "missing", "b"]) == [b"1", None, b"2"]
+
+
+def test_pipeline_set(driver):
+    driver.pipeline_set_sync([("a", b"1"), ("b", b"2"), ("c", b"3")])
+    assert driver.mget_sync(["a", "b", "c"]) == [b"1", b"2", b"3"]
+
+
+def test_pipeline_set_with_ttl(driver):
+    driver.pipeline_set_sync([("a", b"1"), ("b", b"2")], ttl=100)
+    assert driver.ttl_sync("a") in range(95, 101)
+
+
+def test_incr_by(driver):
+    assert driver.incr_by_sync("counter", 5) == 5
+    assert driver.incr_by_sync("counter", 3) == 8
+    assert driver.incr_by_sync("counter", -2) == 6
+
+
+def test_exists(driver):
+    assert driver.exists_sync("k") is False
+    driver.set_sync("k", b"v")
+    assert driver.exists_sync("k") is True
+
+
+def test_expire_and_persist(driver):
+    driver.set_sync("k", b"v")
+    assert driver.expire_sync("k", 50) is True
+    assert driver.ttl_sync("k") in range(45, 51)
+    assert driver.persist_sync("k") is True
+    assert driver.ttl_sync("k") == -1  # no expiry
+
+
+def test_ttl_codes(driver):
+    assert driver.ttl_sync("missing") == -2  # key doesn't exist
+    driver.set_sync("k", b"v")
+    assert driver.ttl_sync("k") == -1  # no expiry
+
+
+def test_keys_pattern(driver):
+    driver.set_sync("u:1", b"a")
+    driver.set_sync("u:2", b"b")
+    driver.set_sync("other", b"c")
+    keys = sorted(driver.keys_sync("u:*"))
+    assert keys == ["u:1", "u:2"]
+
+
+def test_scan(driver):
+    for i in range(20):
+        driver.set_sync(f"k:{i}", b"x")
+    keys = driver.scan_sync("k:*", 10)
+    assert len(keys) == 20
+
+
+def test_type(driver):
+    driver.set_sync("s", b"v")
+    driver.lpush_sync("l", [b"x"])
+    assert driver.type_sync("s") == b"string"
+    assert driver.type_sync("l") == b"list"
+    assert driver.type_sync("missing") == b"none"

--- a/tests/rust/test_driver_strings.py
+++ b/tests/rust/test_driver_strings.py
@@ -92,6 +92,6 @@ def test_scan(driver):
 def test_type(driver):
     driver.set_sync("s", b"v")
     driver.lpush_sync("l", [b"x"])
-    assert driver.type_sync("s") == b"string"
-    assert driver.type_sync("l") == b"list"
-    assert driver.type_sync("missing") == b"none"
+    assert driver.type_sync("s") == "string"
+    assert driver.type_sync("l") == "list"
+    assert driver.type_sync("missing") == "none"


### PR DESCRIPTION
## Summary

Closes #66. Exposes every command django-cachex's Python API uses on `RustValkeyDriver` as sync + async variants.

- **~85 commands × 2 (sync + async) = ~170 PyO3 methods**, mirroring vcache's `sync_op!` / `async_op!` macro pattern.
- **Naming**: `get_sync` + `get` (async). Async variants return `RustAwaitable`; sync variants release the GIL and block on the runtime.
- **Error mapping**: classified once at the Rust boundary — `is_connection_error(&e)` → `PyConnectionError` (swallowable by `IGNORE_EXCEPTIONS`); everything else → `PyRuntimeError`.

### Command families

- **Strings/counters/TTL**: get, set, set_nx, delete, delete_many, mget, pipeline_set, incr_by, exists, expire, persist, ttl, pttl, flushdb, keys, scan, type
- **Hashes**: hget, hset, hgetall, hdel, hincrby, hkeys, hvals, hexists, hlen, hmget, hmset
- **Lists**: lpush, rpush, lpop, rpop, lrange, llen, lrem, lindex, lset, linsert, ltrim, blmove, blmpop
- **Sets**: sadd, srem, smembers, sismember, scard, sinter, sunion, sdiff
- **Sorted sets**: zadd, zrem, zrange, zrangebyscore, zrevrange, zincrby, zcard, zscore, zrank, zcount, zpopmin, zpopmax
- **Streams**: xadd, xlen, xrange, xread, xreadgroup, xack, xtrim, xgroup_create, xpending
- **Scripts**: eval, evalsha, script_load, script_exists
- **Locks**: lock_acquire, lock_release, lock_extend
- **Admin**: dbsize, info, client_list, config_get, object_encoding, object_idletime, memory_usage
- **Pipeline**: pipeline_exec

### Files

- **`src/connection.rs`**: extends `ValkeyConnInner` + `ValkeyConn` with a clearly-marked "django-cachex extensions" section (~750 lines added, separate from the verbatim vcache port). Hashes/sets/sorted sets/streams/admin command methods live here.
- **`src/async_bridge.rs`**: extends `RawResult` with `OptInt`, `F64`, `OptF64`, `BytesPairs`, `ScoredMembers`, `Value` variants. Adds `redis_value_to_py` recursive converter so `EVAL` / `INFO` / `XREAD` / `XPENDING` round-trip cleanly. `BytesPairs` renders as a Python `dict` so async `HGETALL` matches sync.
- **`src/client.rs`**: ~1600 lines, follows vcache's macro pattern. `r_*` helpers convert `RedisResult` → `RawResult`; `py_*` helpers do sync-side typed conversions.

### Tests (88 new, 121 total in `tests/rust/`)

Per-family files: `test_driver_strings.py`, `test_driver_lists.py`, `test_driver_hashes.py`, `test_driver_sets.py`, `test_driver_sortedsets.py`, `test_driver_streams.py`, `test_driver_locks.py`, `test_driver_scripts.py`, `test_driver_admin.py`, plus `test_driver_async.py` (verifies async variants for each family). Shared `driver` fixture in `tests/rust/conftest.py`.

### Out of scope

- Specialized exceptions (e.g. non-int `incr` → `ValueError`) — translated on the Python side per #66's locked decisions.
- Cluster fan-out for the new multi-key commands beyond what redis-rs supports natively. Most new commands are single-key; the existing fan-outs for `del_many` / `mget` / `pipeline_*` carry over.

## Test plan

- [x] `cargo build --release` clean
- [x] `pytest tests/rust/` — 121 tests pass (33 prior + 88 new)
- [x] `mypy django_cachex/` clean
- [x] `ty check django_cachex/` clean
- [x] `ruff check` clean
- [ ] CI green on 3.14 + 3.14t