### PR TITLE
docs: serializer compatibility + compressor performance tables

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,7 @@
 # Benchmarks
 
-Throughput and memory comparison across cache driver/parser/serializer combos.
+Throughput and memory comparison across cache driver/parser/serializer/compressor
+combos.
 
 Not part of the regular test suite — runs separately because it spins up its
 own Redis and Valkey containers and is slow on purpose (timing accuracy
@@ -24,33 +25,51 @@ depends on letting workloads run).
 - `orjson` — Rust-backed JSON
 - `ormsgpack` — Rust-backed MessagePack
 
+**Compressors** — two views, both with `rust-valkey` + `pickle`:
+
+- *Macro* (`test_compressors_macro`) — end-to-end Django cache ops on a
+  ~14 KiB queryset-shaped payload. Captures the cost of compress/decompress
+  against the savings from sending fewer bytes over the wire.
+- *Micro* (`test_compressors_micro`) — pure compress/decompress in a tight
+  loop. Reports output ratio and MB/s. No driver, no container.
+
+Compressor candidates: `none`, `zlib`, `gzip`, `lzma`, `lz4`, `zstd`.
+
 ## What gets measured
 
-For each config, the runner executes a workload of seven phases — `get`,
-`get-miss`, `set`, `mget` (10-key batch), `mset` (10-key batch), `incr`,
-`delete` — `N_OPS=1000` operations per phase, repeated `K_RUNS=10` times.
+Driver / serializer / compressor-macro tests run a seven-phase workload —
+`get`, `get-miss`, `set`, `mget` (10-key batch), `mset` (10-key batch),
+`incr`, `delete` — `N_OPS=1000` operations per phase, repeated `K_RUNS=10`
+times.
 
 Per-phase timings are reported as median ms and ops/sec across runs. Per-run
 metrics include Python peak memory (`tracemalloc`) and server memory delta
 (`INFO memory.used_memory`). Connection count is sampled once at the end.
+
+Compressor-micro tests measure `compress(payload)` and
+`decompress(compressed)` in a tight loop on a fixed payload, reporting ratio
+and MB/s.
 
 Knobs in [runner.py](runner.py): `N_OPS`, `K_RUNS`, `WARMUP_KEYS`, `MGET_BATCH`.
 
 ## Running
 
 ```console
-# Full matrix (drivers + serializers)
+# Full matrix (drivers + serializers + compressors)
 uv run pytest benchmarks/ -c benchmarks/pytest.ini
 
-# Just drivers
-uv run pytest benchmarks/test_throughput.py::test_drivers -c benchmarks/pytest.ini
-
-# Just serializers
-uv run pytest benchmarks/test_throughput.py::test_serializers -c benchmarks/pytest.ini
+# Just one slice
+uv run pytest benchmarks/test_throughput.py::test_drivers           -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_serializers       -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_compressors_macro -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_compressors_micro -c benchmarks/pytest.ini
 
 # A single config
 uv run pytest 'benchmarks/test_throughput.py::test_drivers[rust-valkey]' -c benchmarks/pytest.ini
 ```
+
+`test_compressors_micro` is the only test that doesn't need Docker — useful
+for quick algorithm comparisons on a laptop without containers running.
 
 A summary table prints at the end of the session.
 

--- a/benchmarks/configs.py
+++ b/benchmarks/configs.py
@@ -22,6 +22,12 @@ class SerializerConfig:
     dotted_path: str | None  # None means default pickle
 
 
+@dataclass(frozen=True)
+class CompressorConfig:
+    id: str
+    dotted_path: str | None  # None means no compression
+
+
 # Drivers we want to compare. The "server" field decides which container URL
 # the runner connects to — we keep redis-py paired with redis-server and
 # valkey-py paired with valkey-server because that's the natural pairing.
@@ -80,5 +86,16 @@ SERIALIZER_CONFIGS: tuple[SerializerConfig, ...] = (
 )
 
 
+COMPRESSOR_CONFIGS: tuple[CompressorConfig, ...] = (
+    CompressorConfig(id="none", dotted_path=None),
+    CompressorConfig(id="zlib", dotted_path="django_cachex.compressors.zlib.ZlibCompressor"),
+    CompressorConfig(id="gzip", dotted_path="django_cachex.compressors.gzip.GzipCompressor"),
+    CompressorConfig(id="lzma", dotted_path="django_cachex.compressors.lzma.LzmaCompressor"),
+    CompressorConfig(id="lz4", dotted_path="django_cachex.compressors.lz4.Lz4Compressor"),
+    CompressorConfig(id="zstd", dotted_path="django_cachex.compressors.zstd.ZStdCompressor"),
+)
+
+
 DRIVER_BY_ID = {c.id: c for c in DRIVER_CONFIGS}
 SERIALIZER_BY_ID = {c.id: c for c in SERIALIZER_CONFIGS}
+COMPRESSOR_BY_ID = {c.id: c for c in COMPRESSOR_CONFIGS}

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
-from benchmarks.runner import BenchmarkResult, format_table
+from benchmarks.runner import BenchmarkResult, MicroResult, format_micro_table, format_table
 
 
 def _start(image: str) -> tuple[str, str]:
@@ -69,4 +69,25 @@ def results() -> Iterator[_Results]:
         print("BENCHMARK SUMMARY")
         print("=" * 80)
         print(format_table(sink.items))
+        print("=" * 80)
+
+
+class _MicroResults:
+    def __init__(self) -> None:
+        self.items: list[MicroResult] = []
+
+    def add(self, r: MicroResult) -> None:
+        self.items.append(r)
+
+
+@pytest.fixture(scope="session")
+def micro_results() -> Iterator[_MicroResults]:
+    sink = _MicroResults()
+    yield sink
+    if sink.items:
+        print()
+        print("=" * 80)
+        print("COMPRESSOR MICRO SUMMARY")
+        print("=" * 80)
+        print(format_micro_table(sink.items))
         print("=" * 80)

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.test import override_settings
 
-from benchmarks.configs import DriverConfig, SerializerConfig
+from benchmarks.configs import CompressorConfig, DriverConfig, SerializerConfig
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -58,6 +58,7 @@ class BenchmarkResult:
     driver_id: str
     serializer_id: str
     server: str
+    compressor_id: str = ""
     phases: dict[str, PhaseTiming] = field(default_factory=dict)
     py_peak_kb_per_run: list[float] = field(default_factory=list)
     server_used_memory_delta_kb_per_run: list[float] = field(default_factory=list)
@@ -65,17 +66,36 @@ class BenchmarkResult:
 
     @property
     def label(self) -> str:
-        return f"{self.driver_id}+{self.serializer_id}@{self.server}"
+        compressor = f"+{self.compressor_id}" if self.compressor_id else ""
+        return f"{self.driver_id}+{self.serializer_id}{compressor}@{self.server}"
+
+
+@dataclass
+class MicroResult:
+    """Pure compress/decompress numbers — no driver, no network, no Django."""
+
+    compressor_id: str
+    input_bytes: int
+    output_bytes: int
+    compress_mb_s: float
+    decompress_mb_s: float
+
+    @property
+    def ratio(self) -> float:
+        return self.output_bytes / self.input_bytes if self.input_bytes else 0.0
 
 
 def build_caches(
     driver: DriverConfig,
     serializer: SerializerConfig,
     location: str,
+    compressor: CompressorConfig | None = None,
 ) -> dict[str, dict[str, Any]]:
     options = dict(driver.options)
     if serializer.dotted_path is not None:
         options["serializer"] = serializer.dotted_path
+    if compressor is not None and compressor.dotted_path is not None:
+        options["compressor"] = compressor.dotted_path
     return {
         "default": {
             "BACKEND": driver.backend,
@@ -101,6 +121,25 @@ def _build_payload() -> dict[str, Any]:
         "score": 3.14159,
         "nested": {"a": 1, "b": 2, "c": [1, 2, 3]},
     }
+
+
+def _build_payload_large() -> list[dict[str, Any]]:
+    # ~15 KiB pickled — queryset-shaped, well above the 256 B compression
+    # threshold. Used for compressor benchmarks where a small payload would
+    # bypass compression entirely.
+    return [
+        {
+            "id": i,
+            "name": f"user-{i:05d}",
+            "email": f"user{i}@example.com",
+            "is_active": i % 7 != 0,
+            "created_at": "2026-01-01T12:00:00",
+            "tags": ["alpha", "beta", "gamma", "delta"][: (i % 4) + 1],
+            "score": float(i * 0.137),
+            "bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " * (i % 3 + 1),
+        }
+        for i in range(80)
+    ]
 
 
 def _bench_get(cache, n: int) -> None:
@@ -173,6 +212,9 @@ def run_benchmark(
     driver: DriverConfig,
     serializer: SerializerConfig,
     location: str,
+    *,
+    compressor: CompressorConfig | None = None,
+    payload_kind: str = "small",
 ) -> BenchmarkResult:
     """Run the workload K_RUNS times and return aggregated metrics."""
 
@@ -180,12 +222,13 @@ def run_benchmark(
         driver_id=driver.id,
         serializer_id=serializer.id,
         server=driver.server,
+        compressor_id=compressor.id if compressor is not None else "",
     )
     for name in ("get", "get-miss", "set", "mget", "mset", "incr", "delete"):
         result.phases[name] = PhaseTiming(name=name)
 
-    caches = build_caches(driver, serializer, location)
-    payload = _build_payload()
+    caches = build_caches(driver, serializer, location, compressor=compressor)
+    payload = _build_payload_large() if payload_kind == "large" else _build_payload()
 
     with override_settings(CACHES=caches):
         from django.core.cache import cache
@@ -254,9 +297,81 @@ def run_benchmark(
     return result
 
 
+def run_compressor_micro(
+    compressor: CompressorConfig,
+    *,
+    n_runs: int = 20,
+    n_ops: int = 200,
+) -> MicroResult | None:
+    """Pure compress/decompress throughput on the large benchmark payload.
+
+    No driver, no Django, no network — just the algorithm against a fixed
+    blob. Returns None for the no-compression baseline.
+    """
+    from django.utils.module_loading import import_string
+
+    if compressor.dotted_path is None:
+        return None
+
+    import pickle as _pickle
+
+    payload = _pickle.dumps(_build_payload_large())
+    cls = import_string(compressor.dotted_path)
+    instance = cls()
+    compressed = instance._compress(payload)
+
+    def _median_seconds(fn: Callable[[], None]) -> float:
+        samples = []
+        for _ in range(n_runs):
+            start = time.perf_counter()
+            for _ in range(n_ops):
+                fn()
+            samples.append(time.perf_counter() - start)
+        return median(samples)
+
+    t_comp = _median_seconds(lambda: instance._compress(payload))
+    t_decomp = _median_seconds(lambda: instance.decompress(compressed))
+
+    return MicroResult(
+        compressor_id=compressor.id,
+        input_bytes=len(payload),
+        output_bytes=len(compressed),
+        compress_mb_s=(len(payload) * n_ops) / t_comp / 1_000_000,
+        decompress_mb_s=(len(payload) * n_ops) / t_decomp / 1_000_000,
+    )
+
+
+def format_micro_table(results: list[MicroResult]) -> str:
+    """Table of compressor micro results — absolute MB/s plus output ratio."""
+    if not results:
+        return "(no micro results)"
+    header = ["compressor", "out %", "compress (MB/s)", "decompress (MB/s)"]
+    rows: list[list[str]] = []
+    for r in results:
+        rows.append(
+            [
+                r.compressor_id,
+                f"{r.ratio:.1%}",
+                f"{r.compress_mb_s:,.1f}",
+                f"{r.decompress_mb_s:,.1f}",
+            ],
+        )
+    widths = [len(h) for h in header]
+    for row in rows:
+        widths = [max(w, len(c)) for w, c in zip(widths, row, strict=True)]
+    sep = "  ".join("-" * w for w in widths)
+    lines = ["  ".join(h.ljust(w) for h, w in zip(header, widths, strict=True)), sep]
+    for row in rows:
+        lines.append(
+            "  ".join(c.rjust(w) if i else c.ljust(w) for i, (c, w) in enumerate(zip(row, widths, strict=True))),
+        )
+    return "\n".join(lines)
+
+
 def format_summary(result: BenchmarkResult) -> str:
+    compressor = f"  compressor={result.compressor_id}" if result.compressor_id else ""
     lines = [
-        f"  driver={result.driver_id}  serializer={result.serializer_id}  server={result.server}",
+        f"  driver={result.driver_id}  serializer={result.serializer_id}{compressor}  server={result.server}",
         f"  {'phase':<10} {'med (ms)':>10} {'p95 (ms)':>10} {'ops/sec':>12}",
     ]
     for phase in result.phases.values():

--- a/benchmarks/test_throughput.py
+++ b/benchmarks/test_throughput.py
@@ -1,11 +1,16 @@
-"""Driver and serializer throughput benchmarks.
+"""Driver, serializer and compressor throughput benchmarks.
 
-Two parametrized tests:
+Parametrized tests:
 
 - ``test_drivers`` — fixed pickle serializer, varies the driver. Isolates the
   driver/parser/connection stack.
 - ``test_serializers`` — fixed rust-valkey driver, varies the serializer.
   Isolates serializer cost (driver overhead is minimal at that point).
+- ``test_compressors_macro`` — fixed rust-valkey + pickle, varies the
+  compressor on a large payload. End-to-end ops/sec showing the compress
+  cost vs network savings tradeoff in real cache calls.
+- ``test_compressors_micro`` — pure compress/decompress in-process, no
+  driver or container. Reports ratio and MB/s for each compressor.
 
 Each test runs the workload K_RUNS times and feeds aggregated metrics into a
 session-scoped ``results`` sink that prints a final table at session end.
@@ -15,8 +20,14 @@ from __future__ import annotations
 
 import pytest
 
-from benchmarks.configs import DRIVER_BY_ID, DRIVER_CONFIGS, SERIALIZER_BY_ID, SERIALIZER_CONFIGS
-from benchmarks.runner import format_summary, run_benchmark
+from benchmarks.configs import (
+    COMPRESSOR_CONFIGS,
+    DRIVER_BY_ID,
+    DRIVER_CONFIGS,
+    SERIALIZER_BY_ID,
+    SERIALIZER_CONFIGS,
+)
+from benchmarks.runner import format_summary, run_benchmark, run_compressor_micro
 
 
 @pytest.mark.parametrize("driver", DRIVER_CONFIGS, ids=lambda c: c.id)
@@ -43,3 +54,41 @@ def test_serializers(serializer, server_url, results, capsys) -> None:
     with capsys.disabled():
         print()
         print(format_summary(result))
+
+
+@pytest.mark.parametrize("compressor", COMPRESSOR_CONFIGS, ids=lambda c: c.id)
+def test_compressors_macro(compressor, server_url, results, capsys) -> None:
+    rust_driver = DRIVER_BY_ID["rust-valkey"]
+    pickle_serializer = SERIALIZER_BY_ID["pickle"]
+    location = server_url(rust_driver.server)
+
+    result = run_benchmark(
+        rust_driver,
+        pickle_serializer,
+        location,
+        compressor=compressor,
+        payload_kind="large",
+    )
+    results.add(result)
+
+    with capsys.disabled():
+        print()
+        print(format_summary(result))
+
+
+@pytest.mark.parametrize("compressor", COMPRESSOR_CONFIGS, ids=lambda c: c.id)
+def test_compressors_micro(compressor, micro_results, capsys) -> None:
+    micro = run_compressor_micro(compressor)
+    if micro is None:
+        pytest.skip("no-compression baseline has no micro numbers")
+    micro_results.add(micro)
+
+    with capsys.disabled():
+        print()
+        print(
+            f"  compressor={micro.compressor_id}  "
+            f"input={micro.input_bytes:,} B  "
+            f"output={micro.output_bytes:,} B ({micro.ratio:.1%})  "
+            f"compress={micro.compress_mb_s:,.1f} MB/s  "
+            f"decompress={micro.decompress_mb_s:,.1f} MB/s",
+        )

--- a/docs/user-guide/compression.md
+++ b/docs/user-guide/compression.md
@@ -18,22 +18,66 @@ CACHES = {
 
 ## Available Compressors
 
-| Compressor | Speed | Ratio | Dependency |
-|------------|-------|-------|------------|
-| `django_cachex.compressors.zlib.ZlibCompressor` | Medium | Good | Built-in |
-| `django_cachex.compressors.gzip.GzipCompressor` | Medium | Good | Built-in |
-| `django_cachex.compressors.lzma.LzmaCompressor` | Slow | Best | Built-in |
-| `django_cachex.compressors.lz4.Lz4Compressor` | Fast | Moderate | `django-cachex[lz4]` |
-| `django_cachex.compressors.zstd.ZStdCompressor` | Fast | Good | `django-cachex[zstd]` (Python < 3.14) |
+| Compressor | Extra |
+|------------|-------|
+| `django_cachex.compressors.zlib.ZlibCompressor` | — (stdlib) |
+| `django_cachex.compressors.gzip.GzipCompressor` | — (stdlib) |
+| `django_cachex.compressors.lzma.LzmaCompressor` | — (stdlib) |
+| `django_cachex.compressors.lz4.Lz4Compressor` | `lz4` |
+| `django_cachex.compressors.zstd.ZStdCompressor` | `zstd` (Python < 3.14) |
 
 Install optional dependencies:
 
 ```console
-uv add django-cachex[lz4]   # For LZ4
-uv add django-cachex[zstd]  # For Zstandard (Python < 3.14 only)
+uv add django-cachex[lz4]
+uv add django-cachex[zstd]   # Python 3.14+ uses the stdlib `compression.zstd` module instead
 ```
 
-Zstandard uses the built-in `compression.zstd` module on Python 3.14+.
+## Performance
+
+Two views — pick whichever matches the decision you're making.
+
+### Micro: algorithm in isolation
+
+Pure compress/decompress in a tight loop, no driver, no network. Output
+size is a percentage of the input (i.e. the no-compression baseline);
+compress/decompress are absolute MB/s on the benchmark host.
+
+| Compressor | Output size¹ | Compress² | Decompress² |
+|------------|:-----------:|:--------:|:----------:|
+| `zlib`     | 12%         | ~190 MB/s   | ~1.3 GB/s   |
+| `gzip`     | 12%         | ~150 MB/s   | ~1.2 GB/s   |
+| `lzma`     | 11%         | **~13 MB/s** | ~490 MB/s  |
+| `lz4`      | 17%         | **~3.1 GB/s** | **~7.7 GB/s** |
+| `zstd`     | 11%         | ~820 MB/s   | ~2.2 GB/s   |
+
+### Macro: end-to-end via Django cache
+
+Same compressors, but measured through `cache.get()` / `cache.set()` /
+`cache.get_many()` / `cache.set_many()` against a real Valkey server.
+Throughput factor is normalized to **no compression** — so the table reads
+"this is what enabling each compressor costs you."
+
+| Compressor | Throughput vs no-compression³ |
+|------------|:-----------------------------:|
+| no compression | 1.00×                     |
+| `zlib`         | 0.70×                     |
+| `gzip`         | 0.65×                     |
+| `lzma`         | **0.26×**                 |
+| `lz4`          | **0.99×**                 |
+| `zstd`         | **0.90×**                 |
+
+Picking guide:
+
+- **`zstd`** is the all-rounder — same ratio as `lzma` at ~60× the compress speed, and only ~10 % slower end-to-end than running with no compression at all. Default choice if available.
+- **`lz4`** when CPU is the bottleneck and a ~40 % larger payload is acceptable. End-to-end throughput is statistically indistinguishable from no compression while still cutting payload size 6×.
+- **`lzma`** only when output size matters more than write latency — and even then `zstd` is usually a better trade now (same ratio, ~3× faster end-to-end).
+- **`zlib`** / **`gzip`** are nearly identical — pick `zlib` unless you need gzip's framing for an external consumer.
+- **No compression** sets the throughput ceiling but stores ~8× more server memory. Outside narrow latency-critical paths, compression almost always wins.
+
+¹ Compressed size as a percentage of the input (~14 KiB pickled queryset-shaped payload).
+² Absolute compress/decompress throughput in a tight loop (200 ops × 20 runs, median, single core). Numbers are hardware-dependent — use the ratios between rows, not the absolute values. Real-world impact also depends on payload compressibility — text/JSON compresses ~10×, already-compressed bytes barely shrink.
+³ Geometric mean of `get`/`set`/`mget`/`mset` ops/sec end-to-end via Django cache → `rust-valkey` driver → localhost Valkey, normalized to running without a compressor. Reproduce with the [benchmarks](https://github.com/e1plus/django-cachex/tree/main/benchmarks) harness.
 
 ## Fallback for Migration
 

--- a/docs/user-guide/serializers.md
+++ b/docs/user-guide/serializers.md
@@ -18,17 +18,60 @@ CACHES = {
 
 ## Available Serializers
 
-| Serializer | Description |
-|------------|-------------|
-| `django_cachex.serializers.pickle.PickleSerializer` | Python pickle (default) - supports all Python types |
-| `django_cachex.serializers.json.JSONSerializer` | JSON - interoperable but limited to JSON types |
-| `django_cachex.serializers.msgpack.MessagePackSerializer` | MessagePack - fast and compact binary format |
+| Serializer | Description | Extra |
+|------------|-------------|-------|
+| `django_cachex.serializers.pickle.PickleSerializer` | Python pickle (default) — supports nearly all Python types | — |
+| `django_cachex.serializers.json.JSONSerializer` | JSON via Django's `DjangoJSONEncoder` — best Django type coverage of the JSON family | — |
+| `django_cachex.serializers.msgpack.MessagePackSerializer` | Pure-Python MessagePack — compact binary format | `msgpack` |
+| `django_cachex.serializers.orjson.OrjsonSerializer` | Rust-backed JSON — fastest JSON, fewer types than `DjangoJSONEncoder` | `orjson` |
+| `django_cachex.serializers.ormsgpack.OrMessagePackSerializer` | Rust-backed MessagePack — fastest overall in our benchmarks | `ormsgpack` |
 
-MessagePack requires the optional dependency:
+Install optional serializers via the matching extra:
 
 ```console
 uv add django-cachex[msgpack]
+uv add django-cachex[orjson]
+uv add django-cachex[ormsgpack]
 ```
+
+## Type compatibility
+
+Round-trip behaviour for common Python types. Legend: **✓** preserved (same
+type back), **~** encoded but returns as a different type (caller must convert
+on read), **✗** raises `SerializerError` on `dumps`.
+
+| Type | pickle | json (Django) | msgpack | orjson | ormsgpack |
+|------|:------:|:-------------:|:-------:|:------:|:---------:|
+| **Throughput vs pickle**¹ | **1.00×** | **0.72×** | **1.06×** | **1.10×** | **1.13×** |
+| JSON primitives (`str`, `int`, `float`, `bool`, `None`, `list`, `dict`) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `bytes` | ✓ | ✗ | ✓ | ✗ | ✓ |
+| `tuple` | ✓ | ~ list | ~ list | ~ list | ~ list |
+| `set` / `frozenset` | ✓ | ✗ | ✗ | ✗ | ✗ |
+| `datetime` / `date` / `time` | ✓ | ~ str | ✗ | ~ str | ~ str |
+| `timedelta` | ✓ | ~ str | ✗ | ✗ | ✗ |
+| `Decimal` | ✓ | ~ str | ✗ | ✗ | ✗ |
+| `UUID` | ✓ | ~ str | ✗ | ~ str | ~ str |
+| `complex` | ✓ | ✗ | ✗ | ✗ | ✗ |
+| `dataclass` instance | ✓ | ✗ | ✗ | ~ dict | ~ dict |
+| `Enum` | ✓ | ✗ | ✗ | ~ value | ~ value |
+
+¹ End-to-end Django cache → `rust-valkey` driver → localhost Valkey,
+~150 B payload, geometric mean of `get`/`set`/`mget`/`mset` ops/sec.
+Real network or larger payloads dampen the spread. Reproduce with the
+[benchmarks](https://github.com/e1plus/django-cachex/tree/main/benchmarks) harness.
+
+Notes:
+
+- The "~" cells are not bugs — they reflect what the underlying format can
+  represent. `Decimal("1.99")` round-trips through `DjangoJSONEncoder` as the
+  string `"1.99"`; if you need a `Decimal` back, convert on read.
+- `orjson` natively encodes `dataclass` and `Enum` values, but loses the
+  original type on the way back (becomes a `dict` or the underlying value).
+- For arbitrary Django model instances or types not listed above, prefer
+  `pickle` or write a custom serializer.
+- If you need maximum speed and your values are JSON-compatible (or you
+  pre-convert `Decimal`/`datetime` to strings), `orjson` and `ormsgpack` are
+  significantly faster than the pure-Python equivalents.
 
 ## Fallback for Migration
 


### PR DESCRIPTION
## Summary

- Adds a **type compatibility matrix** for all five serializers (pickle, json, msgpack, orjson, ormsgpack) plus a single end-to-end throughput factor — derived from an empirical probe, not guessed.
- Adds **micro + macro compressor benchmarks** to `benchmarks/` and renders both in the docs. Macro uses `no compression` as the baseline so the table reads "this is what enabling each compressor costs you."
- Extends the benchmark harness with `CompressorConfig`, `test_compressors_macro`, and `test_compressors_micro` (the micro test runs without Docker — quick algorithm check on a laptop).

## Test plan

- [x] Full benchmark suite runs green: `uv run pytest benchmarks/ -c benchmarks/pytest.ini`
- [x] Compressor numbers are reproducible from the harness
- [x] Pre-commit hooks pass (ruff, mypy, ty, etc.)