### PR TITLE
fix(locmem): serialize compound ops via per-backend RLock

### DIFF
--- a/django_cachex/cache/locmem.py
+++ b/django_cachex/cache/locmem.py
@@ -20,6 +20,7 @@ Usage::
 from __future__ import annotations
 
 import fnmatch
+import threading
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -29,7 +30,18 @@ from django_cachex.cache.mixin import CachexMixin
 from django_cachex.utils import _deep_getsizeof, _format_bytes
 
 if TYPE_CHECKING:
+    import contextlib
+
     from django_cachex.types import ExpiryT, KeyT
+
+
+# Reentrant per-backend-name locks for compound (read-modify-write) ops.
+# Django's stock `LocMemCache._lock` is a non-reentrant `threading.Lock`, so
+# we can't reuse it — wrapping a compound op in `with self._lock:` would
+# deadlock the moment the inner `self.get`/`self.set` re-acquired it.
+# Sharing by `name` mirrors Django's `_locks` dict so multiple LocMemCache
+# instances against the same backing store agree on a single envelope lock.
+_compound_locks: dict[str, threading.RLock] = {}
 
 
 class LocMemCache(CachexMixin, DjangoLocMemCache):
@@ -41,6 +53,22 @@ class LocMemCache(CachexMixin, DjangoLocMemCache):
     """
 
     _cachex_support: str = "cachex"
+
+    def __init__(self, name: str, params: dict[str, Any]) -> None:
+        super().__init__(name, params)
+        # Per-name reentrant lock so concurrent compound ops serialize.
+        # Separate from Django's `self._lock` (non-reentrant) — see the
+        # module docstring on `_compound_locks`.
+        self._compound_lock = _compound_locks.setdefault(name, threading.RLock())
+
+    def _compound_op_lock(self) -> contextlib.AbstractContextManager[Any]:
+        """Reentrant per-backend lock around compound (read-modify-write) ops.
+
+        Serializes concurrent ``lpush``/``sadd``/``hincrby``/etc. on this
+        backend so they don't lose updates. Reentrant so a compound op can
+        nest into another (rare, but the surface allows it).
+        """
+        return self._compound_lock
 
     # =========================================================================
     # Internal accessors

--- a/django_cachex/cache/mixin.py
+++ b/django_cachex/cache/mixin.py
@@ -9,7 +9,9 @@ making them compatible with any BaseCache-conformant backend.
 
 from __future__ import annotations
 
+import contextlib
 import random
+from functools import wraps
 from typing import TYPE_CHECKING, Any
 
 from django_cachex.admin.wrappers import BaseCacheExtensions
@@ -17,7 +19,7 @@ from django_cachex.exceptions import NotSupportedError
 from django_cachex.types import KeyType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping, Sequence
+    from collections.abc import Callable, Iterator, Mapping, Sequence
 
     from django_cachex.types import KeyT
 
@@ -26,6 +28,23 @@ _set = set
 
 # Sentinel for distinguishing "key not found" from "key holds None"
 _MISSING = object()
+
+
+def _compound_op(method: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a read-modify-write op in the backend's compound-op lock.
+
+    ``CachexMixin._compound_op_lock`` is a no-op by default; subclasses with
+    real synchronization (e.g. ``LocMemCache``) override it. Reentrant locks
+    (Django's ``RLock``) make this safe even when ``self.set``/``self.delete``
+    re-acquire the same lock internally.
+    """
+
+    @wraps(method)
+    def wrapper(self: CachexMixin, *args: Any, **kwargs: Any) -> Any:
+        with self._compound_op_lock():
+            return method(self, *args, **kwargs)
+
+    return wrapper
 
 
 class CachexMixin(BaseCacheExtensions):
@@ -46,15 +65,26 @@ class CachexMixin(BaseCacheExtensions):
 
     **Limitations:**
 
-    - **Thread safety:** Compound read-modify-write operations (e.g. ``lpush``:
-      get list, append, set) are NOT atomic. Two concurrent calls may lose a
-      write. Use locking externally if needed.
+    - **Thread safety:** Compound read-modify-write ops (``lpush``, ``sadd``,
+      ``hset``, ``hincrby``, ``zadd``, …) are wrapped in
+      ``self._compound_op_lock()``, which defaults to a no-op. Subclasses
+      with thread-safe locking primitives (e.g. ``LocMemCache``, which has
+      ``self._lock``) should override the hook to make these ops atomic.
     - **Type detection:** ``type()`` inspects the stored Python value. Sorted
       sets (stored as ``dict[Any, float]``) are indistinguishable from hashes
       (``dict[str, Any]``) when the sorted set has string keys.
     """
 
     _cachex_support = "wrapped"
+
+    def _compound_op_lock(self) -> contextlib.AbstractContextManager[Any]:
+        """Context manager around compound (read-modify-write) ops.
+
+        Default is a no-op. Subclasses with locking primitives should override
+        this — e.g. ``LocMemCache`` returns ``self._lock`` so concurrent
+        ``lpush``/``sadd``/``hincrby``/etc. on the same key don't lose updates.
+        """
+        return contextlib.nullcontext()
 
     # =========================================================================
     # Key Operations
@@ -143,6 +173,7 @@ class CachexMixin(BaseCacheExtensions):
     # List Operations
     # =========================================================================
 
+    @_compound_op
     def lpush(self, key: KeyT, *values: Any, version: int | None = None) -> int:
         """Prepend values to the head of a list."""
         current = self._get_list(key, version=version)
@@ -153,6 +184,7 @@ class CachexMixin(BaseCacheExtensions):
         self.set(key, new_list, timeout=timeout, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return len(new_list)
 
+    @_compound_op
     def rpush(self, key: KeyT, *values: Any, version: int | None = None) -> int:
         """Append values to the tail of a list."""
         current = self._get_list(key, version=version)
@@ -163,6 +195,7 @@ class CachexMixin(BaseCacheExtensions):
         self.set(key, new_list, timeout=timeout, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return len(new_list)
 
+    @_compound_op
     def lpop(self, key: KeyT, count: int | None = None, version: int | None = None) -> list[Any]:
         """Remove and return element(s) from the head of a list."""
         current = self._get_list(key, version=version)
@@ -178,6 +211,7 @@ class CachexMixin(BaseCacheExtensions):
             self.delete(key, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return popped
 
+    @_compound_op
     def rpop(self, key: KeyT, count: int | None = None, version: int | None = None) -> list[Any]:
         """Remove and return element(s) from the tail of a list."""
         current = self._get_list(key, version=version)
@@ -214,6 +248,7 @@ class CachexMixin(BaseCacheExtensions):
             return 0
         return len(current)
 
+    @_compound_op
     def lrem(  # noqa: PLR0912
         self,
         key: KeyT,
@@ -253,6 +288,7 @@ class CachexMixin(BaseCacheExtensions):
                 self.delete(key, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return removed
 
+    @_compound_op
     def ltrim(self, key: KeyT, start: int, end: int, version: int | None = None) -> bool:
         """Trim a list to the specified range (inclusive end, Redis-style)."""
         current = self._get_list(key, version=version)
@@ -284,6 +320,7 @@ class CachexMixin(BaseCacheExtensions):
         except IndexError:
             return None
 
+    @_compound_op
     def lset(self, key: KeyT, index: int, value: Any, version: int | None = None) -> bool:
         """Set element at index in list."""
         current = self._get_list(key, version=version)
@@ -299,6 +336,7 @@ class CachexMixin(BaseCacheExtensions):
         self.set(key, current, timeout=timeout, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return True
 
+    @_compound_op
     def linsert(self, key: KeyT, where: str, pivot: Any, value: Any, version: int | None = None) -> int:
         """Insert value before or after pivot in list."""
         current = self._get_list(key, version=version)
@@ -358,6 +396,7 @@ class CachexMixin(BaseCacheExtensions):
     # Set Operations
     # =========================================================================
 
+    @_compound_op
     def sadd(self, key: KeyT, *members: Any, version: int | None = None) -> int:
         """Add members to a set."""
         current = self._get_set(key, version=version)
@@ -369,6 +408,7 @@ class CachexMixin(BaseCacheExtensions):
         self.set(key, current, timeout=timeout, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return len(current) - before
 
+    @_compound_op
     def srem(self, key: KeyT, *members: Any, version: int | None = None) -> int:
         """Remove members from a set."""
         current = self._get_set(key, version=version)
@@ -398,6 +438,7 @@ class CachexMixin(BaseCacheExtensions):
         current = self._get_set(key, version=version)
         return _set() if current is None else _set(current)
 
+    @_compound_op
     def spop(self, key: KeyT, count: int | None = None, version: int | None = None) -> Any | _set[Any]:
         """Remove and return random member(s) from set."""
         current = self._get_set(key, version=version)
@@ -485,6 +526,7 @@ class CachexMixin(BaseCacheExtensions):
     # Hash Operations
     # =========================================================================
 
+    @_compound_op
     def hset(  # noqa: C901
         self,
         key: KeyT,
@@ -521,6 +563,7 @@ class CachexMixin(BaseCacheExtensions):
         self.set(key, current, timeout=timeout, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return added
 
+    @_compound_op
     def hdel(self, key: KeyT, *fields: str, version: int | None = None) -> int:
         """Delete hash fields."""
         current = self._get_hash(key, version=version)
@@ -574,6 +617,7 @@ class CachexMixin(BaseCacheExtensions):
             return [None] * len(fields)
         return [current.get(f) for f in fields]
 
+    @_compound_op
     def hsetnx(self, key: KeyT, field: str, value: Any, version: int | None = None) -> bool:
         """Set field in hash only if it doesn't exist."""
         current = self._get_hash(key, version=version)
@@ -586,6 +630,7 @@ class CachexMixin(BaseCacheExtensions):
         self.set(key, current, timeout=timeout, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return True
 
+    @_compound_op
     def hincrby(self, key: KeyT, field: str, amount: int = 1, version: int | None = None) -> int:
         """Increment integer value of field in hash."""
         current = self._get_hash(key, version=version)
@@ -596,6 +641,7 @@ class CachexMixin(BaseCacheExtensions):
         self.set(key, current, timeout=timeout, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return current[field]
 
+    @_compound_op
     def hincrbyfloat(self, key: KeyT, field: str, amount: float = 1.0, version: int | None = None) -> float:
         """Increment float value of field in hash."""
         current = self._get_hash(key, version=version)
@@ -628,6 +674,7 @@ class CachexMixin(BaseCacheExtensions):
     # Sorted Set Operations
     # =========================================================================
 
+    @_compound_op
     def zadd(
         self,
         key: KeyT,
@@ -772,6 +819,7 @@ class CachexMixin(BaseCacheExtensions):
             return filtered
         return [m for m, _ in filtered]
 
+    @_compound_op
     def zrem(self, key: KeyT, *members: Any, version: int | None = None) -> int:
         """Remove members from a sorted set."""
         current = self._get_zset(key, version=version)
@@ -788,6 +836,7 @@ class CachexMixin(BaseCacheExtensions):
                 self.delete(key, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return removed
 
+    @_compound_op
     def zincrby(self, key: KeyT, amount: float, member: Any, version: int | None = None) -> float:
         """Increment the score of a member."""
         current = self._get_zset(key, version=version) or {}
@@ -811,6 +860,7 @@ class CachexMixin(BaseCacheExtensions):
         hi = float("inf") if max_score == "+inf" else float(max_score)
         return sum(1 for s in current.values() if lo <= s <= hi)
 
+    @_compound_op
     def zpopmin(self, key: KeyT, count: int = 1, version: int | None = None) -> list[tuple[Any, float]]:
         """Remove and return members with lowest scores."""
         current = self._get_zset(key, version=version)
@@ -827,6 +877,7 @@ class CachexMixin(BaseCacheExtensions):
             self.delete(key, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return popped
 
+    @_compound_op
     def zpopmax(self, key: KeyT, count: int = 1, version: int | None = None) -> list[tuple[Any, float]]:
         """Remove and return members with highest scores."""
         current = self._get_zset(key, version=version)
@@ -850,6 +901,7 @@ class CachexMixin(BaseCacheExtensions):
             return [None] * len(members)
         return [current.get(m) for m in members]
 
+    @_compound_op
     def zremrangebyscore(
         self,
         key: KeyT,
@@ -874,6 +926,7 @@ class CachexMixin(BaseCacheExtensions):
                 self.delete(key, version=version)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return len(to_remove)
 
+    @_compound_op
     def zremrangebyrank(self, key: KeyT, start: int, end: int, version: int | None = None) -> int:
         """Remove members by rank range."""
         current = self._get_zset(key, version=version)

--- a/tests/cache/test_cache_concurrent.py
+++ b/tests/cache/test_cache_concurrent.py
@@ -1,0 +1,193 @@
+"""Concurrent thread-safety tests for cache compound data-structure ops.
+
+Targets the read-modify-write race in ``CachexMixin`` (#62): operations like
+``lpush``/``sadd``/``hset``/``hincrby``/``zadd``/``zincrby`` are implemented as
+GET-then-SET, so two concurrent calls on the same key can lose data.
+
+The ``fast_thread_switching`` fixture lowers ``sys.setswitchinterval`` so the
+interpreter switches threads far more aggressively, dramatically increasing
+the chance of catching the race within the test's iteration budget.
+
+Backends covered:
+
+- ``LocMemCache`` (``CachexMixin``) — RED until #62 is fixed.
+- Redis-backed via the existing ``cache`` fixture — uses native atomic
+  Redis commands, so these tests serve as cross-backend smoke coverage.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+import pytest
+
+from django_cachex.cache.locmem import LocMemCache
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from django_cachex.cache import KeyValueCache
+
+
+N_THREADS = 8
+OPS_PER_THREAD = 50
+
+
+@pytest.fixture
+def fast_thread_switching() -> Iterator[None]:
+    """Lower the GIL switch interval to provoke thread interleavings.
+
+    Default is 5ms; we drop to 1µs so the interpreter switches threads far
+    more aggressively. This dramatically increases the chance of catching
+    GET-then-SET races within the iteration budget. No-op on free-threaded
+    Python (3.14t) — but ops still interleave naturally there.
+    """
+    old = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        yield
+    finally:
+        sys.setswitchinterval(old)
+
+
+@pytest.fixture
+def locmem_cache() -> Iterator[LocMemCache]:
+    """Fresh ``LocMemCache`` with a unique name (no shared storage)."""
+    cache = LocMemCache(name=f"test-concurrent-{uuid.uuid4().hex}", params={})
+    try:
+        yield cache
+    finally:
+        cache.clear()
+
+
+def _run_in_threads(worker: Callable[[int], None], n_threads: int = N_THREADS) -> None:
+    """Run ``worker(tid)`` in ``n_threads`` threads, all released by a barrier."""
+    barrier = threading.Barrier(n_threads)
+
+    def runner(tid: int) -> None:
+        barrier.wait()
+        worker(tid)
+
+    with ThreadPoolExecutor(max_workers=n_threads) as pool:
+        for f in [pool.submit(runner, t) for t in range(n_threads)]:
+            f.result()
+
+
+# =============================================================================
+# CachexMixin race tests (RED on main, GREEN once #62 is fixed)
+# =============================================================================
+
+
+def test_locmem_lpush_concurrent_no_data_loss(
+    locmem_cache: LocMemCache,
+    fast_thread_switching: None,
+) -> None:
+    """Every lpush'd value must survive — no GET-then-SET overwrites."""
+    key = "lpush-race"
+
+    def worker(tid: int) -> None:
+        for i in range(OPS_PER_THREAD):
+            locmem_cache.lpush(key, f"t{tid}-i{i}")
+
+    _run_in_threads(worker)
+
+    result = locmem_cache.lrange(key, 0, -1)
+    assert len(result) == N_THREADS * OPS_PER_THREAD
+    assert len(set(result)) == N_THREADS * OPS_PER_THREAD
+
+
+def test_locmem_sadd_concurrent_no_data_loss(
+    locmem_cache: LocMemCache,
+    fast_thread_switching: None,
+) -> None:
+    """Every sadd'd member must survive."""
+    key = "sadd-race"
+
+    def worker(tid: int) -> None:
+        for i in range(OPS_PER_THREAD):
+            locmem_cache.sadd(key, f"t{tid}-i{i}")
+
+    _run_in_threads(worker)
+
+    members = locmem_cache.smembers(key)
+    assert len(members) == N_THREADS * OPS_PER_THREAD
+
+
+def test_locmem_hincrby_concurrent_conservation(
+    locmem_cache: LocMemCache,
+    fast_thread_switching: None,
+) -> None:
+    """Total increments on one field must equal N_THREADS * OPS_PER_THREAD."""
+    key = "hincrby-race"
+    field = "counter"
+
+    def worker(tid: int) -> None:
+        for _ in range(OPS_PER_THREAD):
+            locmem_cache.hincrby(key, field, 1)
+
+    _run_in_threads(worker)
+
+    assert locmem_cache.hget(key, field) == N_THREADS * OPS_PER_THREAD
+
+
+def test_locmem_zincrby_concurrent_conservation(
+    locmem_cache: LocMemCache,
+    fast_thread_switching: None,
+) -> None:
+    """Total increments on one member's score must equal N_THREADS * OPS_PER_THREAD."""
+    key = "zincrby-race"
+    member = "winner"
+
+    def worker(tid: int) -> None:
+        for _ in range(OPS_PER_THREAD):
+            locmem_cache.zincrby(key, 1.0, member)
+
+    _run_in_threads(worker)
+
+    assert locmem_cache.zscore(key, member) == float(N_THREADS * OPS_PER_THREAD)
+
+
+# =============================================================================
+# Redis backend smoke tests — same shape on the existing `cache` fixture
+# (default / cluster / sentinel / sentinel_opts x py / rust drivers).
+# These exercise native server-side atomic commands and should always pass.
+# =============================================================================
+
+
+def test_redis_lpush_concurrent_no_data_loss(
+    cache: KeyValueCache,
+    fast_thread_switching: None,
+) -> None:
+    key = "concurrent-lpush"
+    cache.delete(key)
+
+    def worker(tid: int) -> None:
+        for i in range(OPS_PER_THREAD):
+            cache.lpush(key, f"t{tid}-i{i}")
+
+    _run_in_threads(worker)
+
+    result = cache.lrange(key, 0, -1)
+    assert len(result) == N_THREADS * OPS_PER_THREAD
+    assert len(set(result)) == N_THREADS * OPS_PER_THREAD
+
+
+def test_redis_hincrby_concurrent_conservation(
+    cache: KeyValueCache,
+    fast_thread_switching: None,
+) -> None:
+    key = "concurrent-hincrby"
+    field = "counter"
+    cache.delete(key)
+
+    def worker(tid: int) -> None:
+        for _ in range(OPS_PER_THREAD):
+            cache.hincrby(key, field, 1)
+
+    _run_in_threads(worker)
+
+    assert cache.hget(key, field) == N_THREADS * OPS_PER_THREAD


### PR DESCRIPTION
## Summary

Closes #62.

`CachexMixin`'s read-modify-write ops (`lpush`/`sadd`/`hset`/`hincrby`/`zadd`/...) were non-atomic GET-then-SET. Two concurrent calls on the same key could each read the same value, modify their copy, and overwrite each other on write — silently losing data.

This PR makes those ops atomic in `LocMemCache`, the only `CachexMixin` user that has a real synchronization primitive available. `DatabaseCache` keeps the documented (no-op) default; row-level locking can be added later under the same hook.

## Approach

- Add `_compound_op_lock()` hook on `CachexMixin` — no-op `nullcontext()` default.
- Add `@_compound_op` decorator that wraps a method body in `self._compound_op_lock()`.
- Decorate all 23 RMW ops in `mixin.py` (lists, sets, hashes, sorted sets).
- `LocMemCache` overrides the hook to return a per-name `RLock` shared via a module-level `_compound_locks` dict.

A separate `RLock` is needed because Django's `LocMemCache._lock` is a non-reentrant `threading.Lock`; reusing it would deadlock the moment the wrapped op called `self.get`/`self.set` internally.

## Tests

`tests/cache/test_cache_concurrent.py`:
- 4 `LocMemCache` tests (`lpush`/`sadd`/`hincrby`/`zincrby`) — each spawns 8 threads × 50 ops on the same key behind a `Barrier`, then asserts no data loss.
- 2 Redis smoke tests on the existing `cache` fixture (default/cluster/sentinel/sentinel_opts × py/rust) — same shape, validates that native server-side atomic commands stay atomic across the matrix.
- `fast_thread_switching` fixture lowers `sys.setswitchinterval` from 5ms → 1µs to provoke interleavings within the test budget.

On `main` the LocMem tests reliably lose 70%+ of increments (e.g. `zincrby` lost 325 of 400). With the fix they're solid.

This replaces the closed #41 — see that PR's closing comment for why the previous test approach didn't actually exercise this bug.

## Test plan

- [x] 4 LocMem tests RED on `main`, GREEN on this branch
- [x] 12 Redis smoke tests pass across full py-driver matrix
- [x] Full py-driver suite: 2666 passed, 37 skipped, 0 regressions
- [x] All pre-commit hooks green (ruff, mypy, ty)