### PR TITLE
fix(client): share async pool across per-task instances + ASGI/async benchmark expansion

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,6 +16,9 @@ depends on letting workloads run).
 - `valkey-py` — pure-Python parser
 - `valkey-py+libvalkey` — C parser
 - `rust-valkey` — our Rust extension driver
+- `django (builtin)` — Django's official built-in `django.core.cache.backends.redis.RedisCache`
+  (since 4.0). Not the third-party `jazzband/django-redis` package — that one is
+  unrelated. Included as an external reference point.
 
 **Serializers** (with `rust-valkey` driver, since driver overhead is smallest there):
 
@@ -35,16 +38,68 @@ depends on letting workloads run).
 
 Compressor candidates: `none`, `zlib`, `gzip`, `lzma`, `lz4`, `zstd`.
 
+**Request cycle** (`test_drivers_request_cycle`) — same workload as
+`test_drivers`, but each cache op runs inside a real Django request cycle:
+`Client().get(url)` → URL resolve → `CommonMiddleware` → view function →
+response → `request_finished` signal. The view in [urls.py](urls.py) does
+exactly one cache op per request, so ops/sec is on the same scale as
+`test_drivers` and you can read off the per-op overhead Django adds. Driver
+ids are suffixed with `#req` in the final summary so the request-cycle rows
+sit next to their direct counterparts.
+
+**ASGI** (`test_drivers_asgi`) — full-stack benchmark in the shape of
+[`django-vcache`'s `bench_compare.py`](https://gitlab.com/glitchtip/django-vcache/-/blob/main/bench_compare.py):
+
+- Spawns a real **`granian`** ASGI server (4 workers) per driver
+- Drives load with **`httpx.AsyncClient`** (100 concurrent connections,
+  20 second duration by default; bump `ASGI_CONCURRENCY` /
+  `ASGI_DURATION_S` in `test_throughput.py` for hero numbers)
+- Each request hits `/bench/mixed/`, which does six async cache ops —
+  `aget`, `aget_many`(3 keys), `aset`, `aset` (large, ~2.5 KiB to trigger
+  compression), `aincr`, `aget` (large)
+- Samples server RSS and Valkey/Redis `connected_clients` every 5 seconds
+  during the run; reports init / peak / final / settled (post-cooldown)
+
+This is the only benchmark that reliably surfaces connection-pool growth
+under realistic load — sync direct, async direct, and request-cycle tests
+all show stable connection counts because the workload is too well-behaved
+to stress the pool. The ASGI benchmark hits the pool from four worker
+processes simultaneously, which is enough to expose any per-call client
+pattern.
+
+To match django-vcache's exact methodology (which also adds simulated
+network latency to amplify connection-lifetime issues), run the script
+inside a Docker container with `--cap-add NET_ADMIN` and apply
+`tc qdisc add dev eth0 root netem delay 1ms` against the cache server's
+interface. Without latency the directional ranking is the same; with it,
+the magnitude grows dramatically.
+
+**Async** — two views via `aget` / `aset` / `aget_many` / etc.:
+
+- *Serial* (`test_drivers_async_serial`) — `await cache.aget(...)` one op at
+  a time. Direct comparison with sync; the gap reveals asyncio-loop
+  overhead and, for backends without native async, the cost of Django's
+  `sync_to_async` fallback. Ids suffixed with `#async`.
+- *Concurrent* (`test_drivers_async_concurrent`) — `asyncio.gather` of
+  `ASYNC_CONCURRENCY` (default 50) ops in flight. Stresses the connection
+  pool: peak connections jump to roughly the concurrency level for backends
+  with native async + per-op pool checkout. The intended use is also to
+  hunt for connection leaks (peak should plateau and `Δ` should stay 0;
+  if `Δ` grows phase over phase, the backend is leaking). Ids suffixed
+  with `#asyncN` where N is the concurrency level.
+
 ## What gets measured
 
-Driver / serializer / compressor-macro tests run a seven-phase workload —
-`get`, `get-miss`, `set`, `mget` (10-key batch), `mset` (10-key batch),
-`incr`, `delete` — `N_OPS=1000` operations per phase, repeated `K_RUNS=10`
-times.
+Driver / serializer / compressor-macro / request-cycle tests run a
+seven-phase workload — `get`, `get-miss`, `set`, `mget` (10-key batch),
+`mset` (10-key batch), `incr`, `delete` — `N_OPS=1000` operations per phase,
+repeated `K_RUNS=10` times.
 
 Per-phase timings are reported as median ms and ops/sec across runs. Per-run
 metrics include Python peak memory (`tracemalloc`) and server memory delta
-(`INFO memory.used_memory`). Connection count is sampled once at the end.
+(`INFO memory.used_memory`). Connections are sampled before the workload
+(baseline) and after every phase across every run; the summary reports peak
+and `Δ` (peak − baseline).
 
 Compressor-micro tests measure `compress(payload)` and
 `decompress(compressed)` in a tight loop on a fixed payload, reporting ratio
@@ -59,10 +114,14 @@ Knobs in [runner.py](runner.py): `N_OPS`, `K_RUNS`, `WARMUP_KEYS`, `MGET_BATCH`.
 uv run pytest benchmarks/ -c benchmarks/pytest.ini
 
 # Just one slice
-uv run pytest benchmarks/test_throughput.py::test_drivers           -c benchmarks/pytest.ini
-uv run pytest benchmarks/test_throughput.py::test_serializers       -c benchmarks/pytest.ini
-uv run pytest benchmarks/test_throughput.py::test_compressors_macro -c benchmarks/pytest.ini
-uv run pytest benchmarks/test_throughput.py::test_compressors_micro -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_drivers                  -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_serializers              -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_compressors_macro        -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_compressors_micro        -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_drivers_request_cycle    -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_drivers_async_serial     -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_drivers_async_concurrent -c benchmarks/pytest.ini
+uv run pytest benchmarks/test_throughput.py::test_drivers_asgi             -c benchmarks/pytest.ini
 
 # A single config
 uv run pytest 'benchmarks/test_throughput.py::test_drivers[rust-valkey]' -c benchmarks/pytest.ini

--- a/benchmarks/asgi.py
+++ b/benchmarks/asgi.py
@@ -1,0 +1,14 @@
+"""ASGI entrypoint for the ASGI benchmark — granian imports this."""
+
+from __future__ import annotations
+
+import os
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "benchmarks.asgi_settings")
+django.setup()
+
+from django.core.asgi import get_asgi_application  # noqa: E402
+
+application = get_asgi_application()

--- a/benchmarks/asgi_settings.py
+++ b/benchmarks/asgi_settings.py
@@ -1,0 +1,50 @@
+"""Django settings for the ASGI-bench subprocess.
+
+Reads CACHES from environment variables so the parent benchmark process can
+parametrize the backend without writing per-driver settings modules:
+
+- ``BENCH_CACHE_BACKEND`` — dotted path of the cache backend class.
+- ``BENCH_CACHE_LOCATION`` — Redis/Valkey URL.
+- ``BENCH_CACHE_OPTIONS_JSON`` — optional, JSON-encoded ``OPTIONS`` dict.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+SECRET_KEY = "django_benchmarks_secret_key"  # noqa: S105
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    },
+}
+
+USE_TZ = False
+
+ROOT_URLCONF = "benchmarks.urls"
+
+ALLOWED_HOSTS = ["*"]
+
+DEBUG = False
+
+# Match the request-cycle test: minimal middleware so we measure cache work,
+# not unrelated framework overhead.
+MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
+]
+
+CACHES = {
+    "default": {
+        "BACKEND": os.environ["BENCH_CACHE_BACKEND"],
+        "LOCATION": os.environ["BENCH_CACHE_LOCATION"],
+        "OPTIONS": json.loads(os.environ.get("BENCH_CACHE_OPTIONS_JSON", "{}")),
+    },
+}

--- a/benchmarks/configs.py
+++ b/benchmarks/configs.py
@@ -74,6 +74,20 @@ DRIVER_CONFIGS: tuple[DriverConfig, ...] = (
         options={},
         server="valkey",
     ),
+    # Django's official built-in Redis cache backend (added in Django 4.0,
+    # `django.core.cache.backends.redis.RedisCache`). Not to be confused with
+    # the third-party `jazzband/django-redis` package — that one ships under
+    # `django_redis.cache.RedisCache` and is unrelated.
+    #
+    # Useful as an external reference point: its `get_client()` instantiates
+    # a fresh `redis.Redis` per cache call, sharing only the pool. Makes it
+    # an interesting subject for our connection tracking.
+    DriverConfig(
+        id="django (builtin)",
+        backend="django.core.cache.backends.redis.RedisCache",
+        options={},
+        server="redis",
+    ),
 )
 
 

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -8,7 +8,14 @@ import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
-from benchmarks.runner import BenchmarkResult, MicroResult, format_micro_table, format_table
+from benchmarks.runner import (
+    AsgiResult,
+    BenchmarkResult,
+    MicroResult,
+    format_asgi_table,
+    format_micro_table,
+    format_table,
+)
 
 
 def _start(image: str) -> tuple[str, str]:
@@ -90,4 +97,25 @@ def micro_results() -> Iterator[_MicroResults]:
         print("COMPRESSOR MICRO SUMMARY")
         print("=" * 80)
         print(format_micro_table(sink.items))
+        print("=" * 80)
+
+
+class _AsgiResults:
+    def __init__(self) -> None:
+        self.items: list[AsgiResult] = []
+
+    def add(self, r: AsgiResult) -> None:
+        self.items.append(r)
+
+
+@pytest.fixture(scope="session")
+def asgi_results() -> Iterator[_AsgiResults]:
+    sink = _AsgiResults()
+    yield sink
+    if sink.items:
+        print()
+        print("=" * 80)
+        print("ASGI BENCHMARK SUMMARY")
+        print("=" * 80)
+        print(format_asgi_table(sink.items))
         print("=" * 80)

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -7,6 +7,7 @@ when the questions you care about change.
 
 from __future__ import annotations
 
+import asyncio
 import gc
 import time
 import tracemalloc
@@ -62,12 +63,58 @@ class BenchmarkResult:
     phases: dict[str, PhaseTiming] = field(default_factory=dict)
     py_peak_kb_per_run: list[float] = field(default_factory=list)
     server_used_memory_delta_kb_per_run: list[float] = field(default_factory=list)
-    server_connections_after: int = 0
+    server_connections_baseline: int = 0
+    server_connections_samples: list[int] = field(default_factory=list)
 
     @property
     def label(self) -> str:
         compressor = f"+{self.compressor_id}" if self.compressor_id else ""
         return f"{self.driver_id}+{self.serializer_id}{compressor}@{self.server}"
+
+    @property
+    def server_connections_peak(self) -> int:
+        return max([self.server_connections_baseline, *self.server_connections_samples], default=0)
+
+    @property
+    def server_connections_delta(self) -> int:
+        """Peak connections opened by the workload above the baseline."""
+        return max(0, self.server_connections_peak - self.server_connections_baseline)
+
+
+@dataclass
+class AsgiResult:
+    """Result of a full-stack ASGI benchmark.
+
+    Mirrors the metrics django-vcache's ``bench_compare.py`` reports so the
+    two harnesses produce comparable numbers.
+    """
+
+    driver_id: str
+    serializer_id: str
+    server: str
+    requests_per_sec: float
+    avg_latency_ms: float
+    p99_latency_ms: float
+    total_requests: int
+    errors: int
+    initial_rss_mb: float
+    peak_rss_mb: float
+    final_rss_mb: float
+    settled_rss_mb: float
+    initial_conns: int
+    peak_conns: int
+    final_conns: int
+    settled_conns: int
+    duration_s: float
+    concurrency: int
+
+    @property
+    def label(self) -> str:
+        return f"{self.driver_id}+{self.serializer_id}@{self.server}"
+
+    @property
+    def rss_growth_mb(self) -> float:
+        return self.final_rss_mb - self.initial_rss_mb
 
 
 @dataclass
@@ -183,32 +230,133 @@ def _bench_delete(cache, n: int) -> None:
         cache.delete(f"del:{i}")
 
 
-def _server_used_memory(cache) -> int | None:
+# Async phase helpers. ``concurrency=1`` mirrors the sync workload one op
+# at a time. ``concurrency>1`` issues that many ops in flight via
+# ``asyncio.gather``, which is where per-call client patterns can stress
+# the connection pool.
+
+
+async def _abench_get(cache, n: int, concurrency: int) -> None:
+    if concurrency <= 1:
+        for i in range(n):
+            await cache.aget(f"warm:{i % WARMUP_KEYS}")
+        return
+    for chunk in range(0, n, concurrency):
+        size = min(concurrency, n - chunk)
+        await asyncio.gather(*(cache.aget(f"warm:{(chunk + j) % WARMUP_KEYS}") for j in range(size)))
+
+
+async def _abench_get_miss(cache, n: int, concurrency: int) -> None:
+    if concurrency <= 1:
+        for i in range(n):
+            await cache.aget(f"miss:{i}")
+        return
+    for chunk in range(0, n, concurrency):
+        size = min(concurrency, n - chunk)
+        await asyncio.gather(*(cache.aget(f"miss:{chunk + j}") for j in range(size)))
+
+
+async def _abench_set(cache, n: int, concurrency: int, payload: Any) -> None:
+    if concurrency <= 1:
+        for i in range(n):
+            await cache.aset(f"set:{i}", payload)
+        return
+    for chunk in range(0, n, concurrency):
+        size = min(concurrency, n - chunk)
+        await asyncio.gather(*(cache.aset(f"set:{chunk + j}", payload) for j in range(size)))
+
+
+async def _abench_mget(cache, n: int, concurrency: int) -> None:
+    keys = [f"warm:{j}" for j in range(MGET_BATCH)]
+    if concurrency <= 1:
+        for _ in range(n):
+            await cache.aget_many(keys)
+        return
+    for chunk in range(0, n, concurrency):
+        size = min(concurrency, n - chunk)
+        await asyncio.gather(*(cache.aget_many(keys) for _ in range(size)))
+
+
+async def _abench_mset(cache, n: int, concurrency: int, payload: Any) -> None:
+    batch = {f"mset:{j}": payload for j in range(MGET_BATCH)}
+    if concurrency <= 1:
+        for _ in range(n):
+            await cache.aset_many(batch)
+        return
+    for chunk in range(0, n, concurrency):
+        size = min(concurrency, n - chunk)
+        await asyncio.gather(*(cache.aset_many(batch) for _ in range(size)))
+
+
+async def _abench_incr(cache, n: int, concurrency: int) -> None:
+    # Concurrent INCRs on the same key are still well-defined (Redis serializes
+    # them server-side); we just want pool pressure on the client side.
+    await cache.aset("counter", 0)
+    if concurrency <= 1:
+        for _ in range(n):
+            await cache.aincr("counter")
+        return
+    for chunk in range(0, n, concurrency):
+        size = min(concurrency, n - chunk)
+        await asyncio.gather(*(cache.aincr("counter") for _ in range(size)))
+
+
+async def _abench_delete(cache, n: int, concurrency: int) -> None:
+    for i in range(n):
+        await cache.aset(f"del:{i}", 1)
+    if concurrency <= 1:
+        for i in range(n):
+            await cache.adelete(f"del:{i}")
+        return
+    for chunk in range(0, n, concurrency):
+        size = min(concurrency, n - chunk)
+        await asyncio.gather(*(cache.adelete(f"del:{chunk + j}") for j in range(size)))
+
+
+def _open_info_client(location: str):
+    """Side-channel redis-py client for INFO sampling.
+
+    Used regardless of the cache backend under test, so backends without an
+    ``info()`` method (Django's built-in ``RedisCache``) still report memory
+    and connection metrics. Works against Valkey too — same RESP protocol.
+    """
+    import redis
+
+    return redis.Redis.from_url(location)
+
+
+def _server_used_memory(info_client) -> int | None:
     try:
-        info = cache.info()
+        info = info_client.info("memory")
     except Exception:
         return None
-    used = info.get("used_memory") if isinstance(info, dict) else None
-    if used is None and isinstance(info, dict):
-        # Some backends nest under "memory" section.
-        used = info.get("memory", {}).get("used_memory") if isinstance(info.get("memory"), dict) else None
-    return int(used) if used is not None else None
+    if not isinstance(info, dict):
+        return None
+    val = info.get("used_memory")
+    return int(val) if val is not None else None
 
 
-def _server_connections(cache) -> int | None:
+def _server_connections(info_client) -> int | None:
     try:
-        info = cache.info()
+        info = info_client.info("clients")
     except Exception:
         return None
     if not isinstance(info, dict):
         return None
     val = info.get("connected_clients")
-    if val is None and isinstance(info.get("clients"), dict):
-        val = info["clients"].get("connected_clients")
     return int(val) if val is not None else None
 
 
-def run_benchmark(
+def _flush_cache(cache) -> None:
+    """Uniform flush across django-cachex backends and Django's RedisCache."""
+    flush_db = getattr(cache, "flush_db", None)
+    if callable(flush_db):
+        flush_db()
+    else:
+        cache.clear()
+
+
+def run_benchmark(  # noqa: PLR0915 — phase-by-phase flow is the readable shape here
     driver: DriverConfig,
     serializer: SerializerConfig,
     location: str,
@@ -230,69 +378,650 @@ def run_benchmark(
     caches = build_caches(driver, serializer, location, compressor=compressor)
     payload = _build_payload_large() if payload_kind == "large" else _build_payload()
 
-    with override_settings(CACHES=caches):
-        from django.core.cache import cache
+    info_client = _open_info_client(location)
+    try:
+        with override_settings(CACHES=caches):
+            from django.core.cache import cache
 
-        cache.flush_db()
+            _flush_cache(cache)
 
-        # Warmup: populate known keys for get/mget phases.
-        for i in range(WARMUP_KEYS):
-            cache.set(f"warm:{i}", payload)
+            # Warmup: populate known keys for get/mget phases.
+            for i in range(WARMUP_KEYS):
+                cache.set(f"warm:{i}", payload)
 
-        # One untimed pass through every phase to prime connections, server
-        # working set, and any lazy serializer state.
-        _bench_get(cache, 100)
-        _bench_set(cache, 100, payload)
-        _bench_mget(cache, 10)
-        _bench_mset(cache, 10, payload)
-        _bench_incr(cache, 100)
-        _bench_delete(cache, 100)
+            # One untimed pass through every phase to prime connections, server
+            # working set, and any lazy serializer state.
+            _bench_get(cache, 100)
+            _bench_set(cache, 100, payload)
+            _bench_mget(cache, 10)
+            _bench_mset(cache, 10, payload)
+            _bench_incr(cache, 100)
+            _bench_delete(cache, 100)
 
-        before_used = _server_used_memory(cache) or 0
+            before_used = _server_used_memory(info_client) or 0
 
-        for _ in range(K_RUNS):
-            gc.collect()
-            tracemalloc.start()
+            # Record baseline connection count after warmup but before any timed
+            # phases, so per-phase samples reveal what the workload itself opens.
+            baseline_conns = _server_connections(info_client)
+            if baseline_conns is not None:
+                result.server_connections_baseline = baseline_conns
 
-            run_before_used = _server_used_memory(cache) or 0
+            def _sample_conns() -> None:
+                v = _server_connections(info_client)
+                if v is not None:
+                    result.server_connections_samples.append(v)
 
-            _, t = _phase("get", lambda: _bench_get(cache, N_OPS))
-            result.phases["get"].seconds_per_run.append(t)
+            for _ in range(K_RUNS):
+                gc.collect()
+                tracemalloc.start()
 
-            _, t = _phase("get-miss", lambda: _bench_get_miss(cache, N_OPS))
-            result.phases["get-miss"].seconds_per_run.append(t)
+                run_before_used = _server_used_memory(info_client) or 0
 
-            _, t = _phase("set", lambda: _bench_set(cache, N_OPS, payload))
-            result.phases["set"].seconds_per_run.append(t)
+                _, t = _phase("get", lambda: _bench_get(cache, N_OPS))
+                result.phases["get"].seconds_per_run.append(t)
+                _sample_conns()
 
-            _, t = _phase("mget", lambda: _bench_mget(cache, N_OPS // MGET_BATCH))
-            result.phases["mget"].seconds_per_run.append(t * MGET_BATCH)  # normalize to per-key
+                _, t = _phase("get-miss", lambda: _bench_get_miss(cache, N_OPS))
+                result.phases["get-miss"].seconds_per_run.append(t)
+                _sample_conns()
 
-            _, t = _phase("mset", lambda: _bench_mset(cache, N_OPS // MGET_BATCH, payload))
-            result.phases["mset"].seconds_per_run.append(t * MGET_BATCH)  # normalize to per-key
+                _, t = _phase("set", lambda: _bench_set(cache, N_OPS, payload))
+                result.phases["set"].seconds_per_run.append(t)
+                _sample_conns()
 
-            _, t = _phase("incr", lambda: _bench_incr(cache, N_OPS))
-            result.phases["incr"].seconds_per_run.append(t)
+                _, t = _phase("mget", lambda: _bench_mget(cache, N_OPS // MGET_BATCH))
+                result.phases["mget"].seconds_per_run.append(t * MGET_BATCH)  # normalize to per-key
+                _sample_conns()
 
-            _, t = _phase("delete", lambda: _bench_delete(cache, N_OPS))
-            result.phases["delete"].seconds_per_run.append(t)
+                _, t = _phase("mset", lambda: _bench_mset(cache, N_OPS // MGET_BATCH, payload))
+                result.phases["mset"].seconds_per_run.append(t * MGET_BATCH)  # normalize to per-key
+                _sample_conns()
 
-            _, peak = tracemalloc.get_traced_memory()
-            tracemalloc.stop()
-            result.py_peak_kb_per_run.append(peak / 1024)
+                _, t = _phase("incr", lambda: _bench_incr(cache, N_OPS))
+                result.phases["incr"].seconds_per_run.append(t)
+                _sample_conns()
 
-            run_after_used = _server_used_memory(cache) or 0
-            result.server_used_memory_delta_kb_per_run.append(
-                max(0, (run_after_used - run_before_used) / 1024),
+                _, t = _phase("delete", lambda: _bench_delete(cache, N_OPS))
+                result.phases["delete"].seconds_per_run.append(t)
+                _sample_conns()
+
+                _, peak = tracemalloc.get_traced_memory()
+                tracemalloc.stop()
+                result.py_peak_kb_per_run.append(peak / 1024)
+
+                run_after_used = _server_used_memory(info_client) or 0
+                result.server_used_memory_delta_kb_per_run.append(
+                    max(0, (run_after_used - run_before_used) / 1024),
+                )
+
+            _flush_cache(cache)
+            # Avoid reporting startup churn — record absolute used_memory once at end.
+            _ = before_used
+    finally:
+        info_client.close()
+
+    return result
+
+
+# Minimal middleware list for the request-cycle benchmark. CommonMiddleware
+# is the only one a typical Django app always has; SessionMiddleware /
+# AuthenticationMiddleware would pull in DB queries that distort cache timing.
+_REQUEST_CYCLE_MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
+]
+
+
+def run_request_cycle_benchmark(  # noqa: PLR0915 — phase-by-phase flow is readable
+    driver: DriverConfig,
+    serializer: SerializerConfig,
+    location: str,
+    *,
+    compressor: CompressorConfig | None = None,
+    payload_kind: str = "small",
+) -> BenchmarkResult:
+    """Same workload as ``run_benchmark``, but every cache op is wrapped in a
+    real Django request cycle (URL resolve, middleware, view dispatch,
+    ``request_started`` / ``request_finished`` signals).
+
+    Throughput is reported in ops/sec on the same scale as ``run_benchmark``,
+    so the two are directly comparable — the gap is the per-request overhead
+    Django itself adds when cache work happens inside a view.
+    """
+
+    from django.test import Client
+
+    from benchmarks import urls as benchmark_urls
+
+    benchmark_urls.set_payload_kind(payload_kind)
+
+    result = BenchmarkResult(
+        driver_id=driver.id,
+        serializer_id=serializer.id,
+        server=driver.server,
+        compressor_id=compressor.id if compressor is not None else "",
+    )
+    for name in ("get", "get-miss", "set", "mget", "mset", "incr", "delete"):
+        result.phases[name] = PhaseTiming(name=name)
+
+    caches = build_caches(driver, serializer, location, compressor=compressor)
+    payload = _build_payload_large() if payload_kind == "large" else _build_payload()
+
+    overrides = {
+        "CACHES": caches,
+        "ROOT_URLCONF": "benchmarks.urls",
+        "MIDDLEWARE": _REQUEST_CYCLE_MIDDLEWARE,
+        "ALLOWED_HOSTS": ["*"],
+        "DEBUG": False,
+    }
+
+    def _drive(client: Client, url_template: str, n: int) -> None:
+        for i in range(n):
+            client.get(url_template.format(i=i))
+
+    info_client = _open_info_client(location)
+    try:
+        with override_settings(**overrides):
+            from django.core.cache import cache
+
+            _flush_cache(cache)
+
+            # Populate the keys read by the get/mget views.
+            for i in range(WARMUP_KEYS):
+                cache.set(f"warm:{i}", payload)
+
+            # Django's built-in RedisCache.incr() raises if the key is missing,
+            # so the counter has to exist before the incr view ever runs.
+            cache.set("counter", 0)
+
+            client = Client()
+
+            # Untimed warmup so the connection pool, URL resolver cache, and
+            # serializer all see the workload before timing begins.
+            _drive(client, "/bench/get/{i}/", 100)
+            _drive(client, "/bench/set/{i}/", 100)
+            _drive(client, "/bench/mget/{i}/", 10)
+            _drive(client, "/bench/mset/{i}/", 10)
+            _drive(client, "/bench/incr/{i}/", 100)
+            _drive(client, "/bench/delete/{i}/", 100)
+
+            baseline_conns = _server_connections(info_client)
+            if baseline_conns is not None:
+                result.server_connections_baseline = baseline_conns
+
+            def _sample_conns() -> None:
+                v = _server_connections(info_client)
+                if v is not None:
+                    result.server_connections_samples.append(v)
+
+            for _ in range(K_RUNS):
+                gc.collect()
+                tracemalloc.start()
+                run_before_used = _server_used_memory(info_client) or 0
+
+                _, t = _phase("get", lambda: _drive(client, "/bench/get/{i}/", N_OPS))
+                result.phases["get"].seconds_per_run.append(t)
+                _sample_conns()
+
+                _, t = _phase("get-miss", lambda: _drive(client, "/bench/get-miss/{i}/", N_OPS))
+                result.phases["get-miss"].seconds_per_run.append(t)
+                _sample_conns()
+
+                _, t = _phase("set", lambda: _drive(client, "/bench/set/{i}/", N_OPS))
+                result.phases["set"].seconds_per_run.append(t)
+                _sample_conns()
+
+                # Batch ops: one HTTP request per batch; normalize timing per-key
+                # so ops/sec is on the same scale as the direct benchmark.
+                _, t = _phase("mget", lambda: _drive(client, "/bench/mget/{i}/", N_OPS // MGET_BATCH))
+                result.phases["mget"].seconds_per_run.append(t * MGET_BATCH)
+                _sample_conns()
+
+                _, t = _phase("mset", lambda: _drive(client, "/bench/mset/{i}/", N_OPS // MGET_BATCH))
+                result.phases["mset"].seconds_per_run.append(t * MGET_BATCH)
+                _sample_conns()
+
+                # incr resets the counter inside the view's cache call; pre-set it
+                # once per run to mirror the direct benchmark.
+                cache.set("counter", 0)
+                _, t = _phase("incr", lambda: _drive(client, "/bench/incr/{i}/", N_OPS))
+                result.phases["incr"].seconds_per_run.append(t)
+                _sample_conns()
+
+                # delete needs keys to delete; populate first.
+                for i in range(N_OPS):
+                    cache.set(f"del:{i}", 1)
+                _, t = _phase("delete", lambda: _drive(client, "/bench/delete/{i}/", N_OPS))
+                result.phases["delete"].seconds_per_run.append(t)
+                _sample_conns()
+
+                _, peak = tracemalloc.get_traced_memory()
+                tracemalloc.stop()
+                result.py_peak_kb_per_run.append(peak / 1024)
+
+                run_after_used = _server_used_memory(info_client) or 0
+                result.server_used_memory_delta_kb_per_run.append(
+                    max(0, (run_after_used - run_before_used) / 1024),
+                )
+
+            _flush_cache(cache)
+    finally:
+        info_client.close()
+
+    return result
+
+
+def _total_rss_kb(parent_pid: int) -> float:
+    """Sum RSS of a process and its direct children, in KiB.
+
+    Granian spawns one parent + N workers; we want the total resident set
+    so growth shows up regardless of which worker grew.
+    """
+    import shutil
+    import subprocess
+    from pathlib import Path
+
+    total = 0.0
+    try:
+        with Path(f"/proc/{parent_pid}/status").open() as f:
+            for raw in f:
+                if raw.startswith("VmRSS:"):
+                    total += float(raw.split()[1])
+                    break
+    except FileNotFoundError, ProcessLookupError:
+        return 0.0
+
+    ps = shutil.which("ps")
+    if ps is None:
+        return total
+    try:
+        result = subprocess.run(  # noqa: S603 — args are constants, no user input
+            [ps, "--ppid", str(parent_pid), "-o", "rss="],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except Exception:
+        return total
+    for raw in result.stdout.strip().splitlines():
+        stripped = raw.strip()
+        if stripped:
+            total += float(stripped)
+    return total
+
+
+def _wait_for_port(host: str, port: int, timeout_s: float = 15.0) -> bool:
+    import socket
+
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return True
+        except OSError:
+            time.sleep(0.2)
+    return False
+
+
+def run_asgi_benchmark(  # noqa: C901, PLR0915 — orchestrates many phases in one function for readability
+    driver: DriverConfig,
+    serializer: SerializerConfig,
+    location: str,
+    *,
+    duration_s: int = 30,
+    concurrency: int = 300,
+    workers: int = 4,
+    port: int = 8787,
+    sample_every_s: float = 5.0,
+    cooldown_s: float = 5.0,
+) -> AsgiResult:
+    """Full-stack ASGI benchmark: granian + httpx + 6-op view.
+
+    Mirrors django-vcache's ``bench_compare.py`` methodology: spawn a real
+    ASGI server, hit it with a configurable number of concurrent HTTP
+    clients for a fixed duration, sample peak server RSS and Valkey/Redis
+    ``connected_clients`` along the way. The view does six async cache ops
+    per request — get / aget_many / aset / aset (large) / aincr / aget
+    (large) — to exercise the full backend surface in one workload.
+
+    Latency simulation (e.g. ``tc qdisc add dev eth0 root netem delay 1ms``)
+    is the missing ingredient versus django-vcache's claims about
+    `RedisCache` connection growth — without RTT, sync_to_async threads
+    finish too quickly to pile up. Run this benchmark inside a Docker
+    container with ``--cap-add NET_ADMIN`` and apply ``netem`` against the
+    Valkey/Redis interface to reproduce vcache's numbers.
+    """
+
+    import asyncio as _asyncio
+    import json
+    import os
+    import subprocess
+    import sys
+
+    import httpx
+
+    options_for_env = dict(driver.options)
+    if serializer.dotted_path is not None:
+        options_for_env["serializer"] = serializer.dotted_path
+
+    env = {
+        **os.environ,
+        "DJANGO_SETTINGS_MODULE": "benchmarks.asgi_settings",
+        "BENCH_CACHE_BACKEND": driver.backend,
+        "BENCH_CACHE_LOCATION": location,
+        "BENCH_CACHE_OPTIONS_JSON": json.dumps(options_for_env),
+    }
+
+    info_client = _open_info_client(location)
+    info_client.flushdb()
+
+    proc = subprocess.Popen(  # noqa: S603 — args are sys.executable + constants
+        [
+            sys.executable,
+            "-m",
+            "granian",
+            "--interface",
+            "asgi",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--workers",
+            str(workers),
+            "--no-ws",
+            "benchmarks.asgi:application",
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    try:
+        if not _wait_for_port("127.0.0.1", port, timeout_s=15.0):
+            raise RuntimeError("granian did not start in time")
+
+        # Seed cache + give workers a moment to spawn.
+        time.sleep(1.0)
+        with httpx.Client(timeout=5.0) as c:
+            r = c.get(f"http://127.0.0.1:{port}/bench/seed/")
+            r.raise_for_status()
+
+        initial_rss = _total_rss_kb(proc.pid) / 1024.0
+        initial_conns = _server_connections(info_client) or 0
+        peak_rss = initial_rss
+        peak_conns = initial_conns
+
+        async def _load() -> tuple[int, int, list[float]]:
+            """Generate load with ``concurrency`` httpx clients for ``duration_s``.
+
+            Returns (total_requests, errors, per-request latency samples).
+            """
+
+            url = f"http://127.0.0.1:{port}/bench/mixed/"
+            stop_at = time.perf_counter() + duration_s
+            latencies: list[float] = []
+            total = 0
+            errors = 0
+
+            async def _client_loop(client: httpx.AsyncClient) -> tuple[int, int, list[float]]:
+                local_lat: list[float] = []
+                t = 0
+                e = 0
+                while time.perf_counter() < stop_at:
+                    start = time.perf_counter()
+                    try:
+                        resp = await client.get(url)
+                        local_lat.append((time.perf_counter() - start) * 1000)
+                        if resp.status_code >= 400:
+                            e += 1
+                    except Exception:
+                        e += 1
+                    t += 1
+                return t, e, local_lat
+
+            limits = httpx.Limits(
+                max_connections=concurrency * 2,
+                max_keepalive_connections=concurrency * 2,
             )
+            async with httpx.AsyncClient(timeout=30.0, limits=limits) as client:
+                tasks = [_asyncio.create_task(_client_loop(client)) for _ in range(concurrency)]
 
-        connections = _server_connections(cache)
-        if connections is not None:
-            result.server_connections_after = connections
+                # Sampler runs alongside the load.
+                sample_task = _asyncio.create_task(_sampler())
+                results = await _asyncio.gather(*tasks)
+                sample_task.cancel()
 
-        cache.flush_db()
-        # Avoid reporting startup churn — record absolute used_memory once at end.
-        _ = before_used
+            for t, e, lats in results:
+                total += t
+                errors += e
+                latencies.extend(lats)
+            return total, errors, latencies
+
+        async def _sampler() -> None:
+            nonlocal peak_rss, peak_conns
+            try:
+                while True:
+                    await _asyncio.sleep(sample_every_s)
+                    rss = _total_rss_kb(proc.pid) / 1024.0
+                    conns = _server_connections(info_client) or 0
+                    peak_rss = max(peak_rss, rss)
+                    peak_conns = max(peak_conns, conns)
+            except _asyncio.CancelledError:
+                return
+
+        load_started = time.perf_counter()
+        total_requests, errors, latencies = _asyncio.run(_load())
+        actual_duration = time.perf_counter() - load_started
+
+        final_rss = _total_rss_kb(proc.pid) / 1024.0
+        final_conns = _server_connections(info_client) or 0
+        peak_rss = max(peak_rss, final_rss)
+        peak_conns = max(peak_conns, final_conns)
+
+        # Cooldown: let GC settle and connections close, then re-sample.
+        time.sleep(cooldown_s)
+        settled_rss = _total_rss_kb(proc.pid) / 1024.0
+        settled_conns = _server_connections(info_client) or 0
+
+        rps = total_requests / actual_duration if actual_duration else 0.0
+        avg_lat = mean(latencies) if latencies else 0.0
+        p99_lat = sorted(latencies)[int(round(0.99 * (len(latencies) - 1)))] if latencies else 0.0
+
+        return AsgiResult(
+            driver_id=driver.id,
+            serializer_id=serializer.id,
+            server=driver.server,
+            requests_per_sec=rps,
+            avg_latency_ms=avg_lat,
+            p99_latency_ms=p99_lat,
+            total_requests=total_requests,
+            errors=errors,
+            initial_rss_mb=initial_rss,
+            peak_rss_mb=peak_rss,
+            final_rss_mb=final_rss,
+            settled_rss_mb=settled_rss,
+            initial_conns=initial_conns,
+            peak_conns=peak_conns,
+            final_conns=final_conns,
+            settled_conns=settled_conns,
+            duration_s=actual_duration,
+            concurrency=concurrency,
+        )
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        info_client.close()
+
+
+def format_asgi_summary(result: AsgiResult) -> str:
+    return (
+        f"  driver={result.driver_id}  serializer={result.serializer_id}  server={result.server}\n"
+        f"  duration={result.duration_s:.1f}s  concurrency={result.concurrency}  "
+        f"workers via granian (started by runner)\n"
+        f"  requests={result.total_requests:,}  errors={result.errors}  "
+        f"req/s={result.requests_per_sec:,.0f}\n"
+        f"  latency avg={result.avg_latency_ms:.1f}ms  p99={result.p99_latency_ms:.1f}ms\n"
+        f"  RSS init={result.initial_rss_mb:.1f}  peak={result.peak_rss_mb:.1f}  "
+        f"final={result.final_rss_mb:.1f}  settled={result.settled_rss_mb:.1f} MB  "
+        f"(growth {result.rss_growth_mb:+.1f} MB)\n"
+        f"  conns init={result.initial_conns}  peak={result.peak_conns}  "
+        f"final={result.final_conns}  settled={result.settled_conns}"
+    )
+
+
+def format_asgi_table(results: list[AsgiResult]) -> str:
+    if not results:
+        return "(no asgi results)"
+    header = ["config", "req/s", "avg ms", "p99 ms", "RSS init", "RSS peak", "RSS final", "conns peak", "conns settled"]
+    rows: list[list[str]] = []
+    for r in results:
+        rows.append(
+            [
+                r.label,
+                f"{r.requests_per_sec:,.0f}",
+                f"{r.avg_latency_ms:.1f}",
+                f"{r.p99_latency_ms:.1f}",
+                f"{r.initial_rss_mb:.0f}",
+                f"{r.peak_rss_mb:.0f}",
+                f"{r.final_rss_mb:.0f}",
+                str(r.peak_conns),
+                str(r.settled_conns),
+            ],
+        )
+    widths = [len(h) for h in header]
+    for row in rows:
+        widths = [max(w, len(c)) for w, c in zip(widths, row, strict=True)]
+    sep = "  ".join("-" * w for w in widths)
+    lines = ["  ".join(h.ljust(w) for h, w in zip(header, widths, strict=True)), sep]
+    for row in rows:
+        lines.append(
+            "  ".join(c.rjust(w) if i else c.ljust(w) for i, (c, w) in enumerate(zip(row, widths, strict=True))),
+        )
+    return "\n".join(lines)
+
+
+async def _run_async_workload(
+    cache,
+    info_client,
+    payload: Any,
+    concurrency: int,
+    result: BenchmarkResult,
+) -> None:
+    await cache.aclear()
+
+    # Warmup: populate known keys for get/mget phases.
+    for i in range(WARMUP_KEYS):
+        await cache.aset(f"warm:{i}", payload)
+
+    # Pre-set the incr counter for backends (e.g. Django's built-in
+    # RedisCache) that raise on incr against a missing key.
+    await cache.aset("counter", 0)
+
+    # One untimed pass per phase to warm up async transports / serializers.
+    await _abench_get(cache, 100, concurrency)
+    await _abench_set(cache, 100, concurrency, payload)
+    await _abench_mget(cache, 10, concurrency)
+    await _abench_mset(cache, 10, concurrency, payload)
+    await _abench_incr(cache, 100, concurrency)
+    await _abench_delete(cache, 100, concurrency)
+
+    baseline_conns = _server_connections(info_client)
+    if baseline_conns is not None:
+        result.server_connections_baseline = baseline_conns
+
+    def _sample_conns() -> None:
+        v = _server_connections(info_client)
+        if v is not None:
+            result.server_connections_samples.append(v)
+
+    async def _phase_async(name: str, coro_factory) -> None:
+        start = time.perf_counter()
+        await coro_factory()
+        result.phases[name].seconds_per_run.append(time.perf_counter() - start)
+        _sample_conns()
+
+    for _ in range(K_RUNS):
+        gc.collect()
+        tracemalloc.start()
+        run_before_used = _server_used_memory(info_client) or 0
+
+        await _phase_async("get", lambda: _abench_get(cache, N_OPS, concurrency))
+        await _phase_async("get-miss", lambda: _abench_get_miss(cache, N_OPS, concurrency))
+        await _phase_async("set", lambda: _abench_set(cache, N_OPS, concurrency, payload))
+
+        # Batch ops: same per-key normalisation as the sync path.
+        n_batches = N_OPS // MGET_BATCH
+        start = time.perf_counter()
+        await _abench_mget(cache, n_batches, concurrency)
+        result.phases["mget"].seconds_per_run.append((time.perf_counter() - start) * MGET_BATCH)
+        _sample_conns()
+
+        start = time.perf_counter()
+        await _abench_mset(cache, n_batches, concurrency, payload)
+        result.phases["mset"].seconds_per_run.append((time.perf_counter() - start) * MGET_BATCH)
+        _sample_conns()
+
+        await _phase_async("incr", lambda: _abench_incr(cache, N_OPS, concurrency))
+        await _phase_async("delete", lambda: _abench_delete(cache, N_OPS, concurrency))
+
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        result.py_peak_kb_per_run.append(peak / 1024)
+
+        run_after_used = _server_used_memory(info_client) or 0
+        result.server_used_memory_delta_kb_per_run.append(
+            max(0, (run_after_used - run_before_used) / 1024),
+        )
+
+    await cache.aclear()
+
+
+def run_async_benchmark(
+    driver: DriverConfig,
+    serializer: SerializerConfig,
+    location: str,
+    *,
+    compressor: CompressorConfig | None = None,
+    payload_kind: str = "small",
+    concurrency: int = 1,
+) -> BenchmarkResult:
+    """Async equivalent of ``run_benchmark``.
+
+    ``concurrency=1`` is serial async — every ``aget`` is awaited before the
+    next is issued, giving a one-to-one comparison with the sync benchmark
+    (the gap reveals overhead of the async path: native ``aget`` vs
+    ``sync_to_async`` fallback).
+
+    ``concurrency>1`` issues that many ops in flight via ``asyncio.gather``,
+    stressing the connection pool and surfacing per-call client patterns
+    (e.g. Django's built-in ``RedisCache.get_client()``) that hold a fresh
+    ``redis.Redis`` instance per concurrent op.
+    """
+
+    result = BenchmarkResult(
+        driver_id=driver.id,
+        serializer_id=serializer.id,
+        server=driver.server,
+        compressor_id=compressor.id if compressor is not None else "",
+    )
+    for name in ("get", "get-miss", "set", "mget", "mset", "incr", "delete"):
+        result.phases[name] = PhaseTiming(name=name)
+
+    caches = build_caches(driver, serializer, location, compressor=compressor)
+    payload = _build_payload_large() if payload_kind == "large" else _build_payload()
+
+    info_client = _open_info_client(location)
+    try:
+        with override_settings(CACHES=caches):
+            from django.core.cache import cache
+
+            asyncio.run(_run_async_workload(cache, info_client, payload, concurrency, result))
+    finally:
+        info_client.close()
 
     return result
 
@@ -382,7 +1111,8 @@ def format_summary(result: BenchmarkResult) -> str:
     lines.append(
         f"  py-peak-mem ~ {mean(result.py_peak_kb_per_run):.1f} KiB/run  "
         f"server-mem-delta ~ {mean(result.server_used_memory_delta_kb_per_run):.1f} KiB/run  "
-        f"server-conns-after = {result.server_connections_after}",
+        f"server-conns base/peak/Δ = {result.server_connections_baseline}/"
+        f"{result.server_connections_peak}/{result.server_connections_delta}",
     )
     return "\n".join(lines)
 
@@ -392,7 +1122,7 @@ def format_table(results: list[BenchmarkResult]) -> str:
     if not results:
         return "(no benchmark results)"
     phase_names = list(results[0].phases.keys())
-    header = ["config"] + [f"{p} (ops/s)" for p in phase_names] + ["py-mem KiB", "srv-mem KiB", "conns"]
+    header = ["config"] + [f"{p} (ops/s)" for p in phase_names] + ["py-mem KiB", "srv-mem KiB", "conns peak", "conns Δ"]
     widths = [len(h) for h in header]
     rows: list[list[str]] = []
     for r in results:
@@ -401,7 +1131,8 @@ def format_table(results: list[BenchmarkResult]) -> str:
             row.append(f"{r.phases[p].ops_per_sec:,.0f}")
         row.append(f"{mean(r.py_peak_kb_per_run):.0f}")
         row.append(f"{mean(r.server_used_memory_delta_kb_per_run):.0f}")
-        row.append(str(r.server_connections_after))
+        row.append(str(r.server_connections_peak))
+        row.append(str(r.server_connections_delta))
         rows.append(row)
         widths = [max(w, len(c)) for w, c in zip(widths, row, strict=True)]
 

--- a/benchmarks/settings.py
+++ b/benchmarks/settings.py
@@ -16,6 +16,10 @@ DATABASES = {
 
 USE_TZ = False
 
+ROOT_URLCONF = "benchmarks.urls"
+
+ALLOWED_HOSTS = ["*"]
+
 # Placeholder; benchmark tests override this per parametrization.
 CACHES = {
     "default": {

--- a/benchmarks/test_throughput.py
+++ b/benchmarks/test_throughput.py
@@ -11,6 +11,10 @@ Parametrized tests:
   cost vs network savings tradeoff in real cache calls.
 - ``test_compressors_micro`` — pure compress/decompress in-process, no
   driver or container. Reports ratio and MB/s for each compressor.
+- ``test_drivers_request_cycle`` — same shape as ``test_drivers`` but every
+  cache op is wrapped in a real Django request cycle (URL resolve,
+  middleware, view dispatch, signals). Direct comparison reveals the
+  per-request overhead Django adds on top of the cache call itself.
 
 Each test runs the workload K_RUNS times and feeds aggregated metrics into a
 session-scoped ``results`` sink that prints a final table at session end.
@@ -27,7 +31,23 @@ from benchmarks.configs import (
     SERIALIZER_BY_ID,
     SERIALIZER_CONFIGS,
 )
-from benchmarks.runner import format_summary, run_benchmark, run_compressor_micro
+from benchmarks.runner import (
+    format_asgi_summary,
+    format_summary,
+    run_asgi_benchmark,
+    run_async_benchmark,
+    run_benchmark,
+    run_compressor_micro,
+    run_request_cycle_benchmark,
+)
+
+ASYNC_CONCURRENCY = 50
+
+# ASGI benchmark knobs — kept short by default so the suite stays runnable
+# in CI; bump these manually for hero numbers.
+ASGI_DURATION_S = 20
+ASGI_CONCURRENCY = 100
+ASGI_WORKERS = 4
 
 
 @pytest.mark.parametrize("driver", DRIVER_CONFIGS, ids=lambda c: c.id)
@@ -74,6 +94,123 @@ def test_compressors_macro(compressor, server_url, results, capsys) -> None:
     with capsys.disabled():
         print()
         print(format_summary(result))
+
+
+@pytest.mark.parametrize("driver", DRIVER_CONFIGS, ids=lambda c: c.id)
+def test_drivers_async_serial(driver, server_url, results, capsys) -> None:
+    pickle_serializer = SERIALIZER_BY_ID["pickle"]
+    location = server_url(driver.server)
+
+    result = run_async_benchmark(driver, pickle_serializer, location, concurrency=1)
+    result.driver_id = f"{driver.id}#async"
+    results.add(result)
+
+    with capsys.disabled():
+        print()
+        print(format_summary(result))
+
+
+@pytest.mark.parametrize("driver", DRIVER_CONFIGS, ids=lambda c: c.id)
+def test_drivers_async_concurrent(driver, server_url, results, capsys) -> None:
+    pickle_serializer = SERIALIZER_BY_ID["pickle"]
+    location = server_url(driver.server)
+
+    result = run_async_benchmark(
+        driver,
+        pickle_serializer,
+        location,
+        concurrency=ASYNC_CONCURRENCY,
+    )
+    result.driver_id = f"{driver.id}#async{ASYNC_CONCURRENCY}"
+    results.add(result)
+
+    with capsys.disabled():
+        print()
+        print(format_summary(result))
+
+
+@pytest.mark.parametrize("driver", DRIVER_CONFIGS, ids=lambda c: c.id)
+def test_drivers_request_cycle(driver, server_url, results, capsys) -> None:
+    pickle_serializer = SERIALIZER_BY_ID["pickle"]
+    location = server_url(driver.server)
+
+    result = run_request_cycle_benchmark(driver, pickle_serializer, location)
+    # Tag the label so the final summary distinguishes request-cycle rows
+    # from direct rows when both tests run in the same session.
+    result.driver_id = f"{driver.id}#req"
+    results.add(result)
+
+    with capsys.disabled():
+        print()
+        print(format_summary(result))
+
+
+_POOL_SIZE_SWEEP = (10, 25, 50, 100, 200, 500)
+
+
+@pytest.mark.parametrize("max_conns", _POOL_SIZE_SWEEP, ids=lambda n: f"max={n}")
+def test_pool_size_sweep(max_conns: int, server_url, asgi_results, capsys) -> None:
+    """Sweep ``max_connections`` against a pool-based driver to find the elbow.
+
+    Picks ``redis-py`` as the representative pool backend (rust-valkey
+    multiplexes and ignores the cap; django (builtin) sets its own cap via
+    the thread executor). Used to validate the default we ship with.
+    """
+
+    from benchmarks.configs import DriverConfig
+
+    base = DRIVER_BY_ID["redis-py"]
+    custom = DriverConfig(
+        id=f"redis-py#max{max_conns}",
+        backend=base.backend,
+        options={**base.options, "max_connections": max_conns},
+        server=base.server,
+    )
+    pickle_serializer = SERIALIZER_BY_ID["pickle"]
+    location = server_url(custom.server)
+
+    result = run_asgi_benchmark(
+        custom,
+        pickle_serializer,
+        location,
+        duration_s=ASGI_DURATION_S,
+        concurrency=ASGI_CONCURRENCY,
+        workers=ASGI_WORKERS,
+    )
+    asgi_results.add(result)
+
+    with capsys.disabled():
+        print()
+        print(format_asgi_summary(result))
+
+
+@pytest.mark.parametrize("driver", DRIVER_CONFIGS, ids=lambda c: c.id)
+def test_drivers_asgi(driver, server_url, asgi_results, capsys) -> None:
+    """Full-stack ASGI benchmark — granian + httpx + 6 cache ops per request.
+
+    Mirrors django-vcache's ``bench_compare.py`` shape so numbers are
+    directly comparable. To reproduce vcache's connection-leak claim
+    against Django's built-in ``RedisCache`` you need network latency
+    (``tc qdisc add dev eth0 root netem delay 1ms``); on localhost the
+    leak doesn't manifest because sync_to_async threads finish before
+    the pool can grow.
+    """
+    pickle_serializer = SERIALIZER_BY_ID["pickle"]
+    location = server_url(driver.server)
+
+    result = run_asgi_benchmark(
+        driver,
+        pickle_serializer,
+        location,
+        duration_s=ASGI_DURATION_S,
+        concurrency=ASGI_CONCURRENCY,
+        workers=ASGI_WORKERS,
+    )
+    asgi_results.add(result)
+
+    with capsys.disabled():
+        print()
+        print(format_asgi_summary(result))
 
 
 @pytest.mark.parametrize("compressor", COMPRESSOR_CONFIGS, ids=lambda c: c.id)

--- a/benchmarks/urls.py
+++ b/benchmarks/urls.py
@@ -1,0 +1,112 @@
+"""URL config + views for the request-cycle benchmark.
+
+Each view does exactly one cache operation matching one of the seven
+benchmark phases. The runner drives them via ``django.test.Client``, which
+exercises the full WSGI handler — middleware, URL resolution, request/response
+construction, ``request_started`` / ``request_finished`` signals — so the
+numbers reflect what a real Django request paying for the same cache work
+looks like, not just the cache call in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.cache import cache
+from django.http import HttpResponse
+from django.urls import path
+
+from benchmarks.runner import MGET_BATCH, WARMUP_KEYS, _build_payload, _build_payload_large
+
+_PAYLOAD: Any = _build_payload()
+
+
+def set_payload_kind(kind: str) -> None:
+    """Set the payload used by ``set`` / ``mset`` views. Called once per benchmark run."""
+    global _PAYLOAD  # noqa: PLW0603 — module-level state intentional for benchmark setup
+    _PAYLOAD = _build_payload_large() if kind == "large" else _build_payload()
+
+
+def get_view(_request: Any, i: int) -> HttpResponse:
+    cache.get(f"warm:{i % WARMUP_KEYS}")
+    return HttpResponse(b"", status=204)
+
+
+def get_miss_view(_request: Any, i: int) -> HttpResponse:
+    cache.get(f"miss:{i}")
+    return HttpResponse(b"", status=204)
+
+
+def set_view(_request: Any, i: int) -> HttpResponse:
+    cache.set(f"set:{i}", _PAYLOAD)
+    return HttpResponse(b"", status=204)
+
+
+def mget_view(_request: Any, i: int) -> HttpResponse:
+    cache.get_many([f"warm:{j}" for j in range(MGET_BATCH)])
+    return HttpResponse(b"", status=204)
+
+
+def mset_view(_request: Any, i: int) -> HttpResponse:
+    cache.set_many({f"mset:{j}": _PAYLOAD for j in range(MGET_BATCH)})
+    return HttpResponse(b"", status=204)
+
+
+def incr_view(_request: Any, i: int) -> HttpResponse:
+    cache.incr("counter")
+    return HttpResponse(b"", status=204)
+
+
+def delete_view(_request: Any, i: int) -> HttpResponse:
+    cache.delete(f"del:{i}")
+    return HttpResponse(b"", status=204)
+
+
+# ASGI-bench views. ``bench_mixed`` does six async cache ops per request,
+# matching django-vcache's ``bench_compare.py`` workload so the numbers are
+# comparable. ``bench_seed`` populates the keys ``bench_mixed`` reads.
+
+_BENCH_SMALL: dict[str, Any] = {"user": "alice", "role": "admin", "ts": 1709900000}
+_BENCH_LARGE: dict[str, Any] = {
+    "event": {
+        "id": "abc123",
+        "message": "NullPointerException in com.example.App",
+        "level": "error",
+        "platform": "java",
+        "tags": {f"tag_{i}": f"value_{i}" for i in range(30)},
+        "extra": {f"key_{i}": "x" * 50 for i in range(20)},
+    },
+}
+
+
+async def bench_seed(_request: Any) -> HttpResponse:
+    await cache.aset("bench:s1", _BENCH_SMALL, 300)
+    await cache.aset("bench:s2", _BENCH_SMALL, 300)
+    await cache.aset("bench:s3", _BENCH_SMALL, 300)
+    await cache.aset("bench:large", _BENCH_LARGE, 300)
+    await cache.aset("bench:counter", 0, 300)
+    return HttpResponse(b"seeded", status=200)
+
+
+async def bench_mixed(_request: Any) -> HttpResponse:
+    """Six async cache ops per request — matches django-vcache's workload."""
+    await cache.aget("bench:s1")  # 1. small get
+    await cache.aget_many(["bench:s1", "bench:s2", "bench:s3"])  # 2. batch get
+    await cache.aset("bench:s1", _BENCH_SMALL, 300)  # 3. small set
+    await cache.aset("bench:large", _BENCH_LARGE, 300)  # 4. large set
+    await cache.aincr("bench:counter")  # 5. atomic incr
+    await cache.aget("bench:large")  # 6. large get
+    return HttpResponse(b"", status=204)
+
+
+urlpatterns = [
+    path("bench/get/<int:i>/", get_view),
+    path("bench/get-miss/<int:i>/", get_miss_view),
+    path("bench/set/<int:i>/", set_view),
+    path("bench/mget/<int:i>/", mget_view),
+    path("bench/mset/<int:i>/", mset_view),
+    path("bench/incr/<int:i>/", incr_view),
+    path("bench/delete/<int:i>/", delete_view),
+    path("bench/seed/", bench_seed),
+    path("bench/mixed/", bench_mixed),
+]

--- a/django_cachex/client/default.py
+++ b/django_cachex/client/default.py
@@ -46,6 +46,47 @@ except ImportError:
 
 
 # =============================================================================
+# Process-wide async connection pool registry
+# =============================================================================
+# Django's ``asgiref.local.Local``-backed cache handler returns a fresh
+# ``BaseCache`` instance per asyncio task, which means our cached
+# ``KeyValueCacheClient`` (and any instance-level pool dict) is fresh per
+# task. Without a process-wide registry every async cache call creates a
+# brand-new pool — ``max_connections`` is moot because each call gets its
+# own pool. Sharing pools at the module level by event loop + config makes
+# the cap effective and brings pool-based backends in line with the
+# multiplexed rust-valkey driver.
+#
+# Outer ``WeakKeyDictionary`` keyed by the asyncio loop:
+#  - When a loop is GC'd (process shutdown, ``asyncio.run`` finishing, fork
+#    re-creating the loop in a child), its entry vanishes automatically.
+#  - On fork the child's new loop becomes the live reference; the parent's
+#    stale entries become unreachable and are dropped on the next mutation,
+#    so we don't need explicit PID-tracking.
+#
+# Inner ``dict`` is keyed by ``(pool class, url, options key, index)`` so
+# different cache configurations in the same process don't share a pool.
+
+_ASYNC_POOLS: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[tuple[Any, ...], Any]] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _options_key(options: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
+    """Make a hashable key from pool options."""
+    out: list[tuple[str, Any]] = []
+    for k in sorted(options):
+        v = options[k]
+        # Class objects, strings, ints, floats and tuples are all hashable.
+        if isinstance(v, (type, str, int, float, bool)) or v is None:
+            out.append((k, v))
+        else:
+            # Fall back to repr for unhashable / opaque values.
+            out.append((k, repr(v)))
+    return tuple(out)
+
+
+# =============================================================================
 # KeyValueCacheClient - base class (library-agnostic)
 # =============================================================================
 
@@ -93,15 +134,9 @@ class KeyValueCacheClient:
         self._servers = servers
         self._pools: dict[int, Any] = {}
 
-        # Async pools: WeakKeyDictionary keyed by event loop -> {server_index: pool}
-        # Keyed by event loop because async pools are bound to the loop they're created on.
-        # The same client instance can see multiple loops (e.g., WSGI thread that calls
-        # asyncio.run() multiple times — ContextVar copies mean the same cache instance
-        # is shared with the async context). WeakKeyDictionary ensures automatic cleanup
-        # when a loop is GC'd.
-        self._async_pools: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[int, Any]] = (
-            weakref.WeakKeyDictionary()
-        )
+        # Async pools live in the module-level ``_ASYNC_POOLS`` registry —
+        # see the comment near that constant for why instance-level caching
+        # doesn't work in Django ASGI contexts.
 
         # Set up pool class (can be overridden via argument)
         if isinstance(pool_class, str):
@@ -292,29 +327,39 @@ class KeyValueCacheClient:
     # =========================================================================
 
     def _get_async_connection_pool(self, *, write: bool) -> Any:
-        """Get an async connection pool, cached per event loop."""
+        """Get an async connection pool, cached process-wide per (loop, config).
+
+        The cache is module-level (``_ASYNC_POOLS``) rather than
+        instance-level: Django's ``asgiref.local.Local`` returns a fresh
+        ``BaseCache`` per asyncio task, so an instance-level dict would be
+        empty on every request and a brand-new pool would be created each
+        time, defeating ``max_connections`` entirely.
+        """
         loop = asyncio.get_running_loop()
         index = self._get_connection_pool_index(write=write)
-
-        # Check instance-level cache first
-        if loop in self._async_pools and index in self._async_pools[loop]:
-            return self._async_pools[loop][index]
 
         if self._async_pool_class is None:
             msg = "Async operations require _async_pool_class to be set. Use RedisCacheClient or ValkeyCacheClient."
             raise RuntimeError(msg)
 
-        # Filter out parser_class from pool options for async - it's sync-specific
+        # Filter out parser_class — it's sync-specific.
         async_pool_options = {k: v for k, v in self._pool_options.items() if k != "parser_class"}
-        pool = self._async_pool_class.from_url(
-            self._servers[index],
-            **async_pool_options,
-        )
+        # Default cap so concurrent async load can't grow the pool unbounded.
+        # Users who need more can set ``max_connections`` in OPTIONS.
+        async_pool_options.setdefault("max_connections", 50)
 
-        # Cache on instance for fast access
-        if loop not in self._async_pools:
-            self._async_pools[loop] = {}
-        self._async_pools[loop][index] = pool
+        url = self._servers[index]
+        key = (self._async_pool_class, url, _options_key(async_pool_options), index)
+
+        sub = _ASYNC_POOLS.get(loop)
+        if sub is None:
+            sub = {}
+            _ASYNC_POOLS[loop] = sub
+
+        pool = sub.get(key)
+        if pool is None:
+            pool = self._async_pool_class.from_url(url, **async_pool_options)
+            sub[key] = pool
         return pool
 
     def get_async_client(self, key: KeyT | None = None, *, write: bool = False) -> Any:

--- a/django_cachex/client/default.py
+++ b/django_cachex/client/default.py
@@ -343,7 +343,7 @@ class KeyValueCacheClient:
             raise RuntimeError(msg)
 
         # Filter out parser_class — it's sync-specific.
-        async_pool_options = {k: v for k, v in self._pool_options.items() if k != "parser_class"}
+        async_pool_options: dict[str, Any] = {k: v for k, v in self._pool_options.items() if k != "parser_class"}
         # Default cap so concurrent async load can't grow the pool unbounded.
         # Users who need more can set ``max_connections`` in OPTIONS.
         async_pool_options.setdefault("max_connections", 50)

--- a/django_cachex/client/sentinel.py
+++ b/django_cachex/client/sentinel.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from django.core.exceptions import ImproperlyConfigured
 
-from django_cachex.client.default import KeyValueCacheClient
+from django_cachex.client.default import _ASYNC_POOLS, KeyValueCacheClient, _options_key
 
 if TYPE_CHECKING:
     from redis.connection import ConnectionPool
@@ -202,13 +202,18 @@ class KeyValueSentinelCacheClient(KeyValueCacheClient):
 
     @override
     def _get_async_connection_pool(self, *, write: bool) -> Any:
-        """Get an async sentinel-managed connection pool."""
+        """Get an async sentinel-managed connection pool, shared process-wide.
+
+        Uses the same ``_ASYNC_POOLS`` registry as the non-sentinel client so
+        per-task ``KeyValueCacheClient`` instances share a single pool. See
+        ``KeyValueCacheClient._get_async_connection_pool`` for the rationale.
+        """
         loop = asyncio.get_running_loop()
         index = self._get_connection_pool_index(write=write)
 
-        # Check if we already have an async pool for this loop
-        if loop in self._async_pools and index in self._async_pools[loop]:
-            return self._async_pools[loop][index]
+        if self._async_sentinel_pool_class is None:
+            msg = "Subclasses must set _async_sentinel_pool_class"
+            raise RuntimeError(msg)
 
         service_name, is_master, clean_url = self._parse_sentinel_url(index)
         async_sentinel = self._get_async_sentinel()
@@ -219,22 +224,36 @@ class KeyValueSentinelCacheClient(KeyValueCacheClient):
             if hasattr(self, "_pool_options")
             else {}
         )
+        # Default cap so concurrent async load can't grow the pool unbounded.
+        pool_options.setdefault("max_connections", 50)
         pool_options.update(
             service_name=service_name,
             sentinel_manager=async_sentinel,
             is_master=is_master,
         )
 
-        if self._async_sentinel_pool_class is None:
-            msg = "Subclasses must set _async_sentinel_pool_class"
-            raise RuntimeError(msg)
-        pool = self._async_sentinel_pool_class.from_url(clean_url, **pool_options)
+        # Key on the sentinel-aware fields plus the URL + options. The
+        # sentinel manager is per-loop (cached above) so we include its id in
+        # the key to avoid sharing a pool across two managers in the same loop.
+        key = (
+            self._async_sentinel_pool_class,
+            clean_url,
+            service_name,
+            is_master,
+            id(async_sentinel),
+            _options_key({k: v for k, v in pool_options.items() if k != "sentinel_manager"}),
+            index,
+        )
 
-        # Cache the pool for this event loop
-        if loop not in self._async_pools:
-            self._async_pools[loop] = {}
-        self._async_pools[loop][index] = pool
+        sub = _ASYNC_POOLS.get(loop)
+        if sub is None:
+            sub = {}
+            _ASYNC_POOLS[loop] = sub
 
+        pool = sub.get(key)
+        if pool is None:
+            pool = self._async_sentinel_pool_class.from_url(clean_url, **pool_options)
+            sub[key] = pool
         return pool
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ dev = [
   "testcontainers==4.14.2",
   "ty==0.0.32",
   "types-docker==7.1.0.20260409",
+  # ASGI benchmark only — granian (real ASGI server) + httpx (load gen)
+  "granian>=2.6,<3",
+  "httpx>=0.28,<0.29",
 ]
 docs = ["mkdocs==1.6.1", "mkdocs-material==9.7.6", "mike==2.2.0"]
 

--- a/tests/cache/test_django_cachex_internals.py
+++ b/tests/cache/test_django_cachex_internals.py
@@ -17,6 +17,7 @@ from django.core.cache import caches
 from django.test import override_settings
 
 from django_cachex.client import RedisCacheClient
+from django_cachex.client.default import _ASYNC_POOLS
 
 if TYPE_CHECKING:
     from django_cachex.cache import KeyValueCache
@@ -229,10 +230,10 @@ class TestConnectionCleanup:
         pool2 = cache._cache._get_async_connection_pool(write=True)
         assert pool1 is pool2
 
-        # Should be in _async_pools for current loop
+        # Pool lives in the module-level registry under the current loop.
         loop = asyncio.get_running_loop()
-        assert loop in cache._cache._async_pools
-        assert cache._cache._async_pools[loop][0] is pool1
+        assert loop in _ASYNC_POOLS
+        assert pool1 in _ASYNC_POOLS[loop].values()
 
     def test_async_pool_different_per_loop(self, redis_container: RedisContainerInfo):
         """Test that different event loops get different async pools.
@@ -275,9 +276,9 @@ class TestConnectionCleanup:
             # Pools should be different objects
             assert pool1 is not pool2
 
-            # Each loop should have its own entry
-            assert loop1 in client._async_pools
-            assert loop2 in client._async_pools
+            # Each loop has its own entry in the module-level registry.
+            assert loop1 in _ASYNC_POOLS
+            assert loop2 in _ASYNC_POOLS
 
             # Clean up loops
             loop1.close()
@@ -308,19 +309,55 @@ class TestConnectionCleanup:
         pool = cache._cache._get_async_connection_pool(write=True)
         loop = asyncio.get_running_loop()
 
-        assert loop in cache._cache._async_pools
-        assert cache._cache._async_pools[loop][0] is pool
+        assert loop in _ASYNC_POOLS
+        assert pool in _ASYNC_POOLS[loop].values()
 
         # aclose() should NOT disconnect or remove pools
         await cache._cache.aclose()
-        assert loop in cache._cache._async_pools
-        assert cache._cache._async_pools[loop][0] is pool
+        assert loop in _ASYNC_POOLS
+        assert pool in _ASYNC_POOLS[loop].values()
+
+    @pytest.mark.asyncio
+    async def test_async_pool_shared_across_per_task_client_instances(
+        self,
+        cache: KeyValueCache,
+    ) -> None:
+        """Regression: a fresh ``KeyValueCacheClient`` reuses the existing pool.
+
+        Django's ``asgiref.local.Local``-backed cache handler returns a fresh
+        ``BaseCache`` instance per asyncio task, which means a fresh
+        ``KeyValueCacheClient`` is built on every async request. Before the
+        process-wide ``_ASYNC_POOLS`` registry, each fresh client created its
+        own pool, so ``max_connections`` had no effect across tasks and the
+        pool grew unbounded under concurrent load. This locks in the fix.
+        """
+        if cache._cache._async_pool_class is None:
+            pytest.skip("Async not supported for this client type")
+
+        # First client (the one Django gave us) opens a pool.
+        original_pool = cache._cache._get_async_connection_pool(write=True)
+
+        # Build a fresh client with the same servers + options — this is what
+        # Django's per-task Local does on every request.
+        cls = type(cache._cache)
+        fresh_client = cls(cache._cache._servers, **cache._cache._options)
+
+        # The fresh client must reuse the same pool from the module registry.
+        fresh_pool = fresh_client._get_async_connection_pool(write=True)
+        assert fresh_pool is original_pool, (
+            "Fresh per-task client created a new pool — process-wide registry not working."
+        )
+
+        # And one more independent instance, just to be sure.
+        another_client = cls(cache._cache._servers, **cache._cache._options)
+        assert another_client._get_async_connection_pool(write=True) is original_pool
 
     def test_weak_key_dictionary_cleanup_on_loop_gc(self, redis_container: RedisContainerInfo):
         """Test that async pools are cleaned up when event loop is garbage collected.
 
         This tests the WeakKeyDictionary behavior - when an event loop is GC'd,
-        its entry in _async_pools should be automatically removed.
+        its entry in the module-level _ASYNC_POOLS registry should be
+        automatically removed.
         """
         from contextlib import suppress
 
@@ -350,25 +387,23 @@ class TestConnectionCleanup:
             pool = loop.run_until_complete(create_pool())
             loop.close()
 
-            # Loop should be in _async_pools
-            assert loop in client._async_pools
+            # Loop should be in the module-level registry.
+            assert loop in _ASYNC_POOLS
 
             # Keep a weak reference to track when loop is GC'd
             loop_ref = weakref.ref(loop)
 
             # Delete the loop reference and force garbage collection
             del loop
+            del pool
             gc.collect()
 
             # The loop should have been garbage collected
             assert loop_ref() is None
 
-            # The WeakKeyDictionary should have automatically removed the entry
-            # Note: We can't check for a specific loop anymore since it's GC'd,
-            # but we can verify the pool is no longer accessible
-            # Check that no dead references remain
-            # (accessing the dict should work without errors)
-            _ = list(client._async_pools.keys())
+            # The WeakKeyDictionary should have automatically removed the entry.
+            # Iterating works without errors; the dead loop is gone.
+            _ = list(_ASYNC_POOLS.keys())
 
         with suppress(KeyError, AttributeError):
             del caches["default"]
@@ -386,9 +421,9 @@ class TestConnectionCleanup:
         await cache.aget("test_reuse_1")
         await cache.adelete("test_reuse_1")
 
-        # Should still have only one pool for the current loop
+        # Should still have at most one pool per server in the registry.
         loop = asyncio.get_running_loop()
-        assert len(cache._cache._async_pools.get(loop, {})) <= len(cache._cache._servers)
+        assert len(_ASYNC_POOLS.get(loop, {})) <= len(cache._cache._servers)
 
         # Clean up
         await cache.adelete("test_reuse_2")
@@ -414,7 +449,7 @@ class TestConnectionCleanup:
         # Both should exist
         assert 0 in cache._cache._pools
         loop = asyncio.get_running_loop()
-        assert loop in cache._cache._async_pools
+        assert loop in _ASYNC_POOLS
 
         # Clean up
         cache.delete("sync_key")

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -319,6 +331,8 @@ dev = [
     { name = "beautifulsoup4" },
     { name = "django-stubs" },
     { name = "djlint" },
+    { name = "granian" },
+    { name = "httpx" },
     { name = "lz4" },
     { name = "maturin" },
     { name = "msgpack" },
@@ -366,6 +380,8 @@ dev = [
     { name = "beautifulsoup4", specifier = "==4.14.3" },
     { name = "django-stubs", specifier = "==6.0.3" },
     { name = "djlint", specifier = "==1.36.4" },
+    { name = "granian", specifier = ">=2.6,<3" },
+    { name = "httpx", specifier = ">=0.28,<0.29" },
     { name = "lz4", specifier = "==4.4.5" },
     { name = "maturin", specifier = "==1.13.1" },
     { name = "msgpack", specifier = "==1.1.2" },
@@ -507,6 +523,46 @@ wheels = [
 ]
 
 [[package]]
+name = "granian"
+version = "2.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/0c/27aa25280b6c1f323312e83088304da8a7f3e5c1e568d3a560365ec6fa67/granian-2.7.4.tar.gz", hash = "sha256:1dc0530d7ae6b0ae43aafafe771ac0b8c38af68bbd71ab355828817faf13aac1", size = 128212, upload-time = "2026-04-23T11:55:55.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/5d/a0c3d8778cd8aa68131974d34c439a38a00a32953e71e3b549759a5e3cdb/granian-2.7.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c19ebe797d7383cbb3497c599b8201af71f9fff6b18deaf9965d106f61588ab8", size = 6322736, upload-time = "2026-04-23T11:55:00.292Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/99/211da053030574f2402c750f3e3e5dc587f5192eac4888affe6ca8894a9f/granian-2.7.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4cee0bdba9179537669c2fa0afab2ce89327a372f1b2a82f280798da321c996c", size = 6052103, upload-time = "2026-04-23T11:55:02.797Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9d/23ec1fd519a4c0db961b05d1821869ed6371cbaf8b3d3a0a85c04f89e6ca/granian-2.7.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a4bc5b54845bfb5f87537483f25c8f8e6003c3c1b4b0eadf6b93a432d0604265", size = 7000868, upload-time = "2026-04-23T11:55:04.826Z" },
+    { url = "https://files.pythonhosted.org/packages/98/35/b8798c98c90d3293d9c85580ea6021f148d5ab73ab99d1f82a0e66f73131/granian-2.7.4-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b550fb98b89465c8192b6e506993de6bfb956838e715ffb58e944aec1afdae99", size = 6257266, upload-time = "2026-04-23T11:55:06.962Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/4f/5574db17193d90a5831120a0ce2a2dc64a711110ccb9af5a3630260c3597/granian-2.7.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7100a6a6d3835fec2a207fef536a259dd42d9efdb5c46933cf6f9d55d5bfaad", size = 6849667, upload-time = "2026-04-23T11:55:08.862Z" },
+    { url = "https://files.pythonhosted.org/packages/66/a7/90b85cc6a31cbee772fc8ee731479429a64169e389444a5fdd685d44a342/granian-2.7.4-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:034ac1bfe8c19b5a7916d35a1ca426845db9ac11215f1b367566aec3b6530549", size = 6902612, upload-time = "2026-04-23T11:55:10.888Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6c/ba203ca40bd406db0412bca70281e44712f941bc6aafb59a628f4811d517/granian-2.7.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:baf1c390a25d3d9840204c39e7b801c909e99e896ae2713d898c46b563cbf962", size = 6927025, upload-time = "2026-04-23T11:55:12.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/52/77e2abfba54523943eea275ebbe733a6d186fe646304fe25f6d22b243d03/granian-2.7.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:3bb99778ae05c1118cd694717d025cc0b85f5ee81f60cbcb2a8783692798db96", size = 7146800, upload-time = "2026-04-23T11:55:14.459Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/66/7209201856b7de8d3c643ba87e11272c4d651c216d05ea3fcbdce0da4ab0/granian-2.7.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:13f0a39872afa81c6aaa8e29832371fd831373140f1f04de459ff862824f488b", size = 6999983, upload-time = "2026-04-23T11:55:16.236Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/45/bd1e521284714615996dcee48dad47d8b97ca2767a7e7cccd392f25fc176/granian-2.7.4-cp314-cp314-win_amd64.whl", hash = "sha256:97b5aeec98a9c6c0695bf8f068bd03aca83fc17c0d977a9c3a2e57bb5f10d47e", size = 3989433, upload-time = "2026-04-23T11:55:17.774Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a2/609f8f0dca7f596b5fb6e57b988b4b8f4d6579724b2720933c379d43301a/granian-2.7.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:a7b1aca6c654f0e61c9e493dd6d3ddb1698f47dc33ed04566a6635948b081b64", size = 6251034, upload-time = "2026-04-23T11:55:19.29Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f5/2eefa8ff477cce7b119ed2fe97fc1f3b2d108397d4755e83a5198149f2c8/granian-2.7.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d4e0c8cc6850dec7180a26b6805b2c4cdbac4c1c48077fd7857a3cd8ff342d9d", size = 5912772, upload-time = "2026-04-23T11:55:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/40/9a5070badaed4ceecf4082855985840c320f7232b8c1ddc93e1732c63265/granian-2.7.4-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7e6b1f6e0fe873efa3393ef28803ff699a94254f2a7dc07422cc01d9849e2136", size = 6037318, upload-time = "2026-04-23T11:55:23.855Z" },
+    { url = "https://files.pythonhosted.org/packages/95/52/1db412e63425cb12f5ca61877956583c6d12f21657b1a3e47eb3200e9c1b/granian-2.7.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dce110217825cff60f68da83280bc20471b10e004e720fa94b845e01925d8698", size = 6962778, upload-time = "2026-04-23T11:55:26.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f2/fcca39f617bf70e29ef903bb7a4d037970c637023484f2112d9ed6882516/granian-2.7.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:058f9a4ebfc7b9c2577569c6ecfd333628d0d045de272afaa65ee9933849778c", size = 6566618, upload-time = "2026-04-23T11:55:28.233Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/0da1bb552746d74275017e1ffc7fc419dd1a33345f132f6f5a90f9f41142/granian-2.7.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7c05f74fa5b5dcedc9f035a7c10b8afd90a3d941975a370f1e07c3f3095dd883", size = 6670850, upload-time = "2026-04-23T11:55:29.945Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2a/d0d9cdb10d2760e2f47bd4600c8eef02e326f8f7e253a80ce4ba384265e6/granian-2.7.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:8b992bbc667e3c74de4ad48ac8d735c7cddf3f709fc2097f7dd230ecc46fd7b3", size = 6824752, upload-time = "2026-04-23T11:55:32.066Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/79/0432f92f9df6e54394e4dd1c159c0d4814d255a2d2541fa9a5c187d19152/granian-2.7.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:df05e0f85712b3e90ddf28cb8be358664b1afa8cb8f09978141ca70052dca3a7", size = 7130809, upload-time = "2026-04-23T11:55:33.807Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/11cc0e08f59f03a3cd6a1fe46d7632a0f8690ef945a495b1303140bb7541/granian-2.7.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:dbc620f35b67cf6b03d2b6a24b9b442d1bf52961eaebadb2c3ff214d3d0c8dc4", size = 6845920, upload-time = "2026-04-23T11:55:35.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/49/bcbaaeec0f68d3d1a3dd1fdd21e4a6963d303ae18027c42b2b53f87d6b89/granian-2.7.4-cp314-cp314t-win_amd64.whl", hash = "sha256:b9df8aead4d71562753788264db23d32db34147bb73294ddd90833bef1f4cf35", size = 3981107, upload-time = "2026-04-23T11:55:37.597Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "hiredis"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -538,6 +594,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/1f/fb7375467e9adaa371cd617c2984fefe44bdce73add4c70b8dd8cab1b33a/hiredis-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e8a4b8540581dcd1b2b25827a54cfd538e0afeaa1a0e3ca87ad7126965981cc", size = 176127, upload-time = "2025-10-14T16:33:02.793Z" },
     { url = "https://files.pythonhosted.org/packages/66/14/0dc2b99209c400f3b8f24067273e9c3cb383d894e155830879108fb19e98/hiredis-3.3.0-cp314-cp314t-win32.whl", hash = "sha256:298593bb08487753b3afe6dc38bac2532e9bac8dcee8d992ef9977d539cc6776", size = 22024, upload-time = "2025-10-14T16:33:03.812Z" },
     { url = "https://files.pythonhosted.org/packages/b2/2f/8a0befeed8bbe142d5a6cf3b51e8cbe019c32a64a596b0ebcbc007a8f8f1/hiredis-3.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b442b6ab038a6f3b5109874d2514c4edf389d8d8b553f10f12654548808683bc", size = 23808, upload-time = "2025-10-14T16:33:04.965Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The headline change is a **library bugfix** — the rest of this PR is the
benchmark work that surfaced it.

### Bugfix

Django's `asgiref.local.Local`-backed cache handler returns a fresh
`KeyValueCacheClient` per asyncio task. The instance-level `_async_pools`
dict was therefore empty on every async request, and a brand-new
connection pool was created per cache call. `max_connections` was
effectively ignored, and under concurrent ASGI load the pool grew
unbounded — our ASGI bench measured **6,687 connections** for `redis-py`
on a 4-worker × 100-concurrent-client run.

The fix:

- Move the async pool cache to a module-level `WeakKeyDictionary` keyed
  by event loop, so per-task instances share one pool. Auto-cleanup when
  the loop goes away; fork-safe via the new loop being a fresh object.
- Default `max_connections=50` (matching `django-redis`) so the pool
  caps cleanly under burst load. Users can override in `OPTIONS`.
- Same fix applied to the sentinel client (same bug pattern).

After the fix, the same workload reports **111 connections**. Throughput
is the same or slightly better.

A new `test_async_pool_shared_across_per_task_client_instances` test in
`TestConnectionCleanup` locks in the regression. Existing pool-lifecycle
tests were updated to reference the module-level registry.

### Benchmark expansion

Four new dimensions on top of the existing direct-sync workload, plus
tighter connection sampling:

- `test_drivers_request_cycle` — wraps each cache op in a real Django
  request via `Client()`.
- `test_drivers_async_serial` / `test_drivers_async_concurrent` —
  native async, one-at-a-time vs `asyncio.gather` of 50 in flight.
- `test_drivers_asgi` — full-stack benchmark with `granian` ASGI server +
  `httpx` load + a `bench_mixed` view that does six async cache ops per
  request, matching `django-vcache`'s `bench_compare.py` methodology.
- `test_pool_size_sweep` — parametrize `max_connections` to find the
  perf elbow (the sweep is what informed the `50` default).

Adds Django's official built-in `RedisCache` to the matrix as
`django (builtin)` for direct comparison. Adds `granian` and `httpx`
to the dev dependency group for the ASGI bench.

## Test plan

- [x] `tests/cache/test_django_cachex_internals.py::TestConnectionCleanup` — 21 passed
- [x] Async + internals: 425 passed, 0 failed
- [x] Full ASGI matrix re-run with the fix: connections drop ~60–70× across pool-based drivers, throughput unchanged
- [x] Pool-size sweep: confirms 50 is comfortably above the elbow for 100-concurrent / 4-worker workload