### PR TITLE
refactor(sync): route stream I/O through transport's high-level API

### DIFF
--- a/django_cachex/cache/sync.py
+++ b/django_cachex/cache/sync.py
@@ -12,7 +12,7 @@ Configuration::
 
     CACHES = {
         "redis": {
-            "BACKEND": "django_cachex.cache.RedisCache",
+            "BACKEND": "django_cachex.cache.RedisCache",  # or RustValkeyCache, etc.
             "LOCATION": "redis://127.0.0.1:6379/0",
         },
         "default": {
@@ -26,7 +26,8 @@ Configuration::
         },
     }
 
-``TRANSPORT`` is the alias of a Redis/Valkey cache used for stream I/O.
+``TRANSPORT`` is the alias of any cachex ``KeyValueCache`` subclass — pure-Python
+or Rust-driver-backed — used for stream I/O.
 ``STREAM_KEY`` is the Redis Stream key shared by all pods (default ``cache:sync``).
 ``MAXLEN`` caps stream length via approximate trimming (default 10000).
 ``BLOCK_TIMEOUT`` is the XREAD BLOCK timeout in milliseconds (default 1000).
@@ -34,6 +35,13 @@ Configuration::
 warm the local cache (default 0 = no replay). Values up to ``MAXLEN`` are
 useful — e.g. ``1000`` replays the last 1000 mutations so a restarting pod
 doesn't start with an empty cache.
+
+**Wire format:** stream fields go through the *transport* cache's high-level
+``xadd``/``xread``/``xrevrange`` methods, which apply its configured serializer
+and compressor end-to-end. So if the transport is configured with
+``OPTIONS={"serializer": "msgpack", "compressor": "zstd"}``, stream entries
+are msgpack-then-zstd. All pods sharing one ``STREAM_KEY`` must use the same
+transport ``BACKEND`` + ``OPTIONS`` so their serializers agree.
 """
 
 from __future__ import annotations
@@ -64,31 +72,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _field(fields: dict, name: str) -> str:
-    """Extract a string field from raw Redis stream entry (may be bytes or str)."""
-    val = fields.get(name.encode(), fields.get(name, b""))
-    return val.decode() if isinstance(val, bytes) else str(val) if val else ""
-
-
-def _field_bytes(fields: dict, name: str) -> bytes:
-    """Extract a bytes field from raw Redis stream entry."""
-    val = fields.get(name.encode(), fields.get(name, b""))
-    return val if isinstance(val, bytes) else val.encode() if val else b""
-
-
 class SyncCache(LocMemCache):
     """Stream-synchronized in-memory cache.
 
-    Extends Django's ``LocMemCache`` with cross-pod synchronization.
-    All reads are local dict lookups (inherited from ``LocMemCache``).
-    Writes update the local dict and publish to a Redis Stream. A daemon
-    thread consumes the stream and applies remote changes. All supported
-    operations are **eventually consistent** (last-writer-wins).
+    Extends Django's ``LocMemCache`` with cross-pod synchronization. All reads
+    are local dict lookups (inherited from ``LocMemCache``). Writes update
+    the local dict and publish to a Redis Stream via the transport cache's
+    high-level ``xadd``. A daemon thread consumes the stream via ``xread``
+    and applies remote changes. All supported operations are
+    **eventually consistent** (last-writer-wins).
 
     **Unsupported operations**: ``add``, ``incr``, and ``decr`` raise
-    ``NotSupportedError``. These operations have semantics (atomic
-    check-and-set, atomic increment) that cannot be provided with
-    eventual consistency. Use the transport cache directly for these.
+    ``NotSupportedError``. These have semantics (atomic check-and-set,
+    atomic increment) that cannot be provided with eventual consistency.
+    Use the transport cache directly for these.
 
     **Fail-safe**: The consumer thread is automatically restarted if it dies.
     Use ``info()["sync"]`` to monitor consumer health, last read age, and
@@ -98,8 +95,6 @@ class SyncCache(LocMemCache):
     _cachex_support: str = "cachex"
 
     # Type declarations for attributes and methods inherited from LocMemCache.
-    # LocMemCache sets these dynamically from module-level globals and defines
-    # private helpers without type stubs, so type checkers can't infer them.
     if TYPE_CHECKING:
         from collections import OrderedDict
         from threading import Lock
@@ -116,13 +111,11 @@ class SyncCache(LocMemCache):
     def __init__(self, server: str, params: dict[str, Any]) -> None:
         options = params.get("OPTIONS", {})
 
-        # Transport cache alias (required)
         self._transport_alias: str = options.get("TRANSPORT", "")
         if not self._transport_alias:
-            msg = "SyncCache requires OPTIONS['TRANSPORT'] with a cache alias for Redis/Valkey stream transport."
+            msg = "SyncCache requires OPTIONS['TRANSPORT'] with a cache alias for stream transport."
             raise ImproperlyConfigured(msg)
 
-        # Stream configuration
         self._stream_key: str = options.get("STREAM_KEY", "cache:sync")
         self._maxlen: int = options.get("MAXLEN", 10000)
         self._block_timeout: int = options.get("BLOCK_TIMEOUT", 1000)
@@ -130,7 +123,7 @@ class SyncCache(LocMemCache):
 
         # LocMemCache uses ``name`` (the LOCATION value) to key its module-level
         # globals. We use _STORAGE_KEY or stream_key so each stream has isolated
-        # storage.  Tests can override _STORAGE_KEY to simulate separate pods
+        # storage. Tests can override _STORAGE_KEY to simulate separate pods
         # within the same process.
         storage_key = options.get("_STORAGE_KEY", self._stream_key)
         self._storage_key: str = storage_key
@@ -166,10 +159,6 @@ class SyncCache(LocMemCache):
 
         return caches[self._transport_alias]
 
-    def _get_raw_client(self) -> Any:
-        """Get raw Redis/Valkey client for stream operations."""
-        return self._transport.get_client(write=True)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
-
     # -- Consumer-side local storage helper --
 
     def _local_set(self, key: str, pickled: bytes, exp_time: float | None) -> None:
@@ -191,18 +180,18 @@ class SyncCache(LocMemCache):
         self,
         op: str,
         key: str = "",
-        val: bytes = b"",
+        val: Any = None,
         exp: float | None = None,
         keys: str = "",
     ) -> None:
-        """Publish a cache mutation to the Redis Stream (non-blocking, best-effort).
+        """Publish a cache mutation to the stream (non-blocking, best-effort).
 
-        Submits the XADD call to a single-worker ThreadPoolExecutor so the
-        calling thread returns immediately without waiting for the network
-        round-trip. The single worker serializes publishes, preserving stream
-        order.
+        ``val`` is the original Python value — the transport cache's serializer
+        and compressor handle wire encoding. The single-worker executor
+        preserves stream order while keeping the calling thread off the
+        network round-trip.
         """
-        fields: dict[str, str | bytes] = {
+        fields: dict[str, Any] = {
             "op": op,
             "pod": self._pod_id,
             "key": key,
@@ -213,11 +202,10 @@ class SyncCache(LocMemCache):
             fields["keys"] = keys
         self._publish_executor.submit(self._do_xadd, fields)
 
-    def _do_xadd(self, fields: dict[str, str | bytes]) -> None:
-        """Execute a single XADD. Runs in the publish executor thread."""
+    def _do_xadd(self, fields: dict[str, Any]) -> None:
+        """Execute a single XADD via the transport's high-level API."""
         try:
-            client = self._get_raw_client()
-            client.xadd(
+            self._transport.xadd(  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
                 self._stream_key,
                 fields,
                 maxlen=self._maxlen,
@@ -279,15 +267,13 @@ class SyncCache(LocMemCache):
         left off (no duplicates).
         """
         try:
-            client = self._get_raw_client()
-            entries = client.xrevrange(self._stream_key, count=count)
+            entries = self._transport.xrevrange(self._stream_key, count=count)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
             if not entries:
                 return
-            # Apply in forward order (oldest first)
             with self._lock:
                 for entry_id, fields in reversed(entries):
                     self._apply_message(fields)
-                    self._last_id = entry_id.decode() if isinstance(entry_id, bytes) else str(entry_id)
+                    self._last_id = entry_id
             logger.info(
                 "SyncCache: Replayed %d entries from stream %s",
                 len(entries),
@@ -299,22 +285,20 @@ class SyncCache(LocMemCache):
     def _consumer_loop(self) -> None:
         while not self._stop_event.is_set():
             try:
-                client = self._get_raw_client()
-                result = client.xread(
+                result = self._transport.xread(  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
                     streams={self._stream_key: self._last_id},
                     count=100,
                     block=self._block_timeout,
                 )
-                if result is None:
+                if not result:
                     continue
                 self._last_read_time = time.time()
-                # result is list of [stream_key, [(entry_id, fields), ...]]
-                for _stream_key, entries in result:
+                for entries in result.values():
                     with self._lock:
                         for entry_id, fields in entries:
                             # Advance cursor BEFORE processing so a bad
                             # message is skipped, not retried forever.
-                            self._last_id = entry_id.decode() if isinstance(entry_id, bytes) else str(entry_id)
+                            self._last_id = entry_id
                             try:
                                 self._apply_message(fields)
                             except Exception:  # noqa: BLE001
@@ -331,10 +315,10 @@ class SyncCache(LocMemCache):
                     )
                     self._stop_event.wait(1.0)
 
-    def _apply_message(self, fields: dict) -> None:
-        """Apply a single stream message to local cache. Caller holds self._lock."""
-        op = _field(fields, "op")
-        pod = _field(fields, "pod")
+    def _apply_message(self, fields: dict[str, Any]) -> None:
+        """Apply a single stream message to local cache. Caller holds ``self._lock``."""
+        op = fields.get("op", "")
+        pod = fields.get("pod", "")
 
         # Skip self-messages (already applied locally by the writer)
         if pod == self._pod_id:
@@ -344,28 +328,29 @@ class SyncCache(LocMemCache):
         if handler:
             handler(self, fields)
 
-    def _handle_set(self, fields: dict) -> None:
-        key = _field(fields, "key")
-        val_bytes = _field_bytes(fields, "val")
-        exp_str = _field(fields, "exp")
+    def _handle_set(self, fields: dict[str, Any]) -> None:
+        key = fields["key"]
+        value = fields.get("val")
+        exp_str = fields.get("exp", "")
         exp_time = float(exp_str) if exp_str else None
-        self._local_set(key, val_bytes, exp_time)
+        pickled = pickle.dumps(value, self.pickle_protocol)
+        self._local_set(key, pickled, exp_time)
 
-    def _handle_delete(self, fields: dict) -> None:
-        self._delete(_field(fields, "key"))
+    def _handle_delete(self, fields: dict[str, Any]) -> None:
+        self._delete(fields["key"])
 
-    def _handle_delete_many(self, fields: dict) -> None:
-        for key in _field(fields, "keys").split("\x00"):
+    def _handle_delete_many(self, fields: dict[str, Any]) -> None:
+        for key in fields.get("keys", "").split("\x00"):
             if key:
                 self._delete(key)
 
-    def _handle_clear(self, fields: dict) -> None:
+    def _handle_clear(self, fields: dict[str, Any]) -> None:
         self._cache.clear()
         self._expire_info.clear()
 
-    def _handle_touch(self, fields: dict) -> None:
-        key = _field(fields, "key")
-        exp_str = _field(fields, "exp")
+    def _handle_touch(self, fields: dict[str, Any]) -> None:
+        key = fields["key"]
+        exp_str = fields.get("exp", "")
         exp_time = float(exp_str) if exp_str else None
         if key in self._cache:
             self._expire_info[key] = exp_time
@@ -397,21 +382,19 @@ class SyncCache(LocMemCache):
         deadline = time.time() + timeout
         while time.time() < deadline:
             try:
-                client = self._get_raw_client()
-                result = client.xread(
+                result = self._transport.xread(  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
                     streams={self._stream_key: read_from},
                     count=100,
                     block=50,
                 )
-                if result is None:
+                if not result:
                     return
-                for _stream_key, entries in result:
+                for entries in result.values():
                     with self._lock:
                         for entry_id, fields in entries:
                             self._apply_message(fields)
-                            eid = entry_id.decode() if isinstance(entry_id, bytes) else str(entry_id)
-                            read_from = eid
-                            self._last_id = eid
+                            read_from = entry_id
+                            self._last_id = entry_id
             except Exception:  # noqa: BLE001
                 return
 
@@ -446,7 +429,7 @@ class SyncCache(LocMemCache):
         with self._lock:
             self._set(made_key, pickled, timeout)
         exp_time = self._expire_info.get(made_key)
-        self._publish("set", key=made_key, val=pickled, exp=exp_time)
+        self._publish("set", key=made_key, val=value, exp=exp_time)
         return True
 
     def add(self, key: KeyT, value: Any, timeout: float | None = DEFAULT_TIMEOUT, version: int | None = None) -> bool:

--- a/tests/cache/test_cache_sync.py
+++ b/tests/cache/test_cache_sync.py
@@ -28,13 +28,14 @@ def _build_sync_config(
     host: str,
     port: int,
     client_library: str = "redis",
+    driver: str = "py",
     stream_key: str | None = None,
     max_entries: int = 1000,
 ) -> dict:
     """Build CACHES config with redis transport + SyncCache."""
     options = _get_client_library_options(client_library)
     location = f"redis://{host}:{port}?db=13"
-    backend_class = BACKENDS[("default", client_library, "py")]
+    backend_class = BACKENDS[("default", client_library, driver)]
     sk = stream_key or f"test:sync:{uuid.uuid4().hex[:8]}"
 
     return {
@@ -64,12 +65,17 @@ def _cleanup_globals(stream_key: str) -> None:
 
 
 @pytest.fixture
-def sync_cache(redis_container: RedisContainerInfo) -> Iterator[BaseCache]:
-    """Single SyncCache instance for basic operations."""
+def sync_cache(redis_container: RedisContainerInfo, driver: str) -> Iterator[BaseCache]:
+    """Single SyncCache instance for basic operations.
+
+    Parametrized over the transport driver (``py`` and ``rust``) via the
+    shared ``driver`` fixture.
+    """
     config = _build_sync_config(
         redis_container.host,
         redis_container.port,
         client_library=redis_container.client_library,
+        driver=driver,
     )
     stream_key = config["default"]["OPTIONS"]["STREAM_KEY"]
 
@@ -82,16 +88,17 @@ def sync_cache(redis_container: RedisContainerInfo) -> Iterator[BaseCache]:
 
 
 @pytest.fixture
-def sync_pair(redis_container: RedisContainerInfo) -> Iterator[tuple[SyncCache, SyncCache]]:
+def sync_pair(redis_container: RedisContainerInfo, driver: str) -> Iterator[tuple[SyncCache, SyncCache]]:
     """Two SyncCache instances sharing one stream (simulates two pods).
 
     Uses separate cache aliases with the same STREAM_KEY but different
     _STORAGE_KEY values so each pod has its own local dict (simulating
-    separate processes sharing one Redis Stream).
+    separate processes sharing one Redis Stream). Parametrized over the
+    transport driver.
     """
     options = _get_client_library_options(redis_container.client_library)
     location = f"redis://{redis_container.host}:{redis_container.port}?db=13"
-    backend_class = BACKENDS[("default", redis_container.client_library, "py")]
+    backend_class = BACKENDS[("default", redis_container.client_library, driver)]
     stream_key = f"test:sync-pair:{uuid.uuid4().hex[:8]}"
     storage_key_1 = f"{stream_key}:pod1"
     storage_key_2 = f"{stream_key}:pod2"
@@ -149,11 +156,12 @@ class TestSyncConfig:
         with pytest.raises(ImproperlyConfigured, match="TRANSPORT"):
             SyncCache("", {"OPTIONS": {}})
 
-    def test_default_stream_key(self, redis_container: RedisContainerInfo):
+    def test_default_stream_key(self, redis_container: RedisContainerInfo, driver: str):
         config = _build_sync_config(
             redis_container.host,
             redis_container.port,
             client_library=redis_container.client_library,
+            driver=driver,
         )
         # Remove STREAM_KEY to test default
         del config["default"]["OPTIONS"]["STREAM_KEY"]
@@ -428,11 +436,12 @@ class TestSyncCrossInstance:
 
 
 class TestSyncCull:
-    def test_cull_evicts_when_full(self, redis_container: RedisContainerInfo):
+    def test_cull_evicts_when_full(self, redis_container: RedisContainerInfo, driver: str):
         config = _build_sync_config(
             redis_container.host,
             redis_container.port,
             client_library=redis_container.client_library,
+            driver=driver,
             max_entries=10,
         )
         stream_key = config["default"]["OPTIONS"]["STREAM_KEY"]
@@ -521,7 +530,7 @@ class TestSyncAdmin:
 
 
 class TestSyncReplay:
-    def test_replay_warms_cache_on_startup(self, redis_container: RedisContainerInfo):
+    def test_replay_warms_cache_on_startup(self, redis_container: RedisContainerInfo, driver: str):
         """A new SyncCache with REPLAY > 0 picks up entries from the stream."""
         stream_key = f"test:replay:{uuid.uuid4().hex[:8]}"
         storage_key_1 = f"{stream_key}:producer"
@@ -529,7 +538,7 @@ class TestSyncReplay:
 
         options = _get_client_library_options(redis_container.client_library)
         location = f"redis://{redis_container.host}:{redis_container.port}?db=13"
-        backend_class = BACKENDS[("default", redis_container.client_library, "py")]
+        backend_class = BACKENDS[("default", redis_container.client_library, driver)]
 
         config = {
             "transport": {
@@ -579,7 +588,7 @@ class TestSyncReplay:
         _cleanup_globals(storage_key_1)
         _cleanup_globals(storage_key_2)
 
-    def test_replay_zero_starts_empty(self, redis_container: RedisContainerInfo):
+    def test_replay_zero_starts_empty(self, redis_container: RedisContainerInfo, driver: str):
         """With REPLAY=0 (default), a new pod starts with an empty cache."""
         stream_key = f"test:noreplay:{uuid.uuid4().hex[:8]}"
         storage_key_1 = f"{stream_key}:producer"
@@ -587,7 +596,7 @@ class TestSyncReplay:
 
         options = _get_client_library_options(redis_container.client_library)
         location = f"redis://{redis_container.host}:{redis_container.port}?db=13"
-        backend_class = BACKENDS[("default", redis_container.client_library, "py")]
+        backend_class = BACKENDS[("default", redis_container.client_library, driver)]
 
         config = {
             "transport": {
@@ -634,11 +643,12 @@ class TestSyncReplay:
 
 
 class TestSyncShutdown:
-    def test_shutdown_stops_consumer(self, redis_container: RedisContainerInfo):
+    def test_shutdown_stops_consumer(self, redis_container: RedisContainerInfo, driver: str):
         config = _build_sync_config(
             redis_container.host,
             redis_container.port,
             client_library=redis_container.client_library,
+            driver=driver,
         )
         stream_key = config["default"]["OPTIONS"]["STREAM_KEY"]
 


### PR DESCRIPTION
## Summary

Part of #69 (the SyncCache portion).

`SyncCache` previously reached into the **raw** redis-py client via `self._transport.get_client().xadd/xread/xrevrange`, which only works against a redis-py-shaped client. With the Rust driver landed, the same operations should be portable across drivers.

This PR switches stream I/O to the transport's high-level `cache.xadd/xread/xrevrange` methods — uniform across `KeyValueCache` (py) and `RustKeyValueCacheClient` (rust). `SyncCache` now works with any cachex transport: `ValkeyCache`, `RustValkeyCache`, sentinel/cluster variants, all of them.

## Wire format change (intentional)

The stream wire format now honours the transport's serializer + compressor config end-to-end:

- **Before**: `val` always pre-pickled raw bytes, never compressed, regardless of transport config.
- **After**: `val` goes through the transport's full encode pipeline. If the transport is configured with `OPTIONS={\"serializer\": \"msgpack\", \"compressor\": \"zstd\"}`, the stream entry is msgpack-then-zstd.

Consumer-side `_handle_set` re-pickles for the local LocMemCache backing store (which still expects pickle bytes).

### Migration note (release notes)

Pods running the previous `SyncCache` and pods running this version **cannot interpret each other's stream entries** — different decode paths, different formats. Mixed deployments will fail to sync. Coordinated rollout required: drain the stream and restart all pods together.

## Cleanup

Drops the bytes-handling helpers (`_field`, `_field_bytes`, `_get_raw_client`) since the high-level methods return decoded fields directly. Net -7 lines, much simpler control flow.

## Tests

Tests now parametrize over both `py` and `rust` drivers via the shared `driver` fixture. 99 sync tests pass per driver (50 × 2 + a few config-only).

## Test plan

- [x] All 99 SyncCache tests pass on both `py` and `rust` drivers
- [x] Full cache test suite: 5068 passed, 166 skipped, 0 regressions
- [x] All pre-commit hooks green (ruff, mypy, ty)