### PR TITLE
chore: production-readiness audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/django-cachex.svg)](https://pypi.org/project/django-cachex/)
 [![CI](https://github.com/oliverhaas/django-cachex/actions/workflows/ci.yml/badge.svg)](https://github.com/oliverhaas/django-cachex/actions/workflows/ci.yml)
 
-Cache extensions for django, including full featured Valkey and Redis cache backend for Django and a built-in admin interface.
+Valkey and Redis cache backend for Django, with a Django admin UI for cache inspection.
 
 ## Installation
 
@@ -25,24 +25,20 @@ CACHES = {
 }
 ```
 
-## Features
+## What's in the box
 
-- **Full-featured cache backends** for Valkey and Redis with async support, extended data structures, distributed locking, Lua scripting, and more
-- **Built-in admin interface** for browsing, searching, and managing cache keys directly from Django admin
-- **Drop-in replacement** for Django's built-in Redis backend
-
-## Cache Backends
-
-- **Unified Valkey and Redis support** - Single package for both backends
-- **Async support** - Async versions of all extended methods
-- **Mixing sync & async support** - Async cache still works in sync code
-- **Extended data structures** - Hashes, lists, sets, sorted sets
-- **TTL and pattern operations** - `ttl()`, `expire()`, `keys()`, `delete_pattern()`
-- **Lua script support** - Register and execute Lua scripts with automatic key prefixing
-- **Distributed locking** - `cache.lock()` for cross-process synchronization
-- **Sentinel and Cluster** - High availability and horizontal scaling
-- **Pluggable serializers** - Pickle, JSON, MsgPack with fallback support
-- **Pluggable compressors** - Zlib, Gzip, LZ4, LZMA, Zstandard with fallback support
+- One package for both Valkey and Redis, default and Sentinel and Cluster.
+- Sync and async are first-class. The async cache also works from sync code.
+- Hash, list, set, sorted set, and stream operations on the cache object.
+- TTL and pattern helpers (`ttl()`, `expire()`, `keys()`, `delete_pattern()`).
+- Distributed locks: `cache.lock()`.
+- Lua scripting with automatic key prefixing and value encoding/decoding.
+- Pluggable serializers (Pickle, JSON, MsgPack, ormsgpack, orjson) and compressors (Zlib, Gzip, LZ4, LZMA, Zstandard), each with fallback chains for safe migrations.
+- Cache stampede prevention (TTL-based XFetch).
+- Two composite backends: `SyncCache` (cross-pod stream-synchronized in-memory cache) and `TieredCache` (L1/L2 with TTL propagation).
+- Django `LocMemCache` and `DatabaseCache` extensions with the same data-structure ops and admin support.
+- Optional Rust I/O driver (PyO3 + tokio + redis-rs) under the same `KeyValueCache` API. Free-threaded CPython (3.14t) supported.
+- Django admin UI for browsing keys, inspecting values, editing, and flushing — see below.
 
 ## Cache Admin
 
@@ -85,7 +81,7 @@ Full documentation at [oliverhaas.github.io/django-cachex](https://oliverhaas.gi
 
 ## Acknowledgments
 
-This project was started from [django-redis](https://github.com/jazzband/django-redis) and Django's official [Redis cache backend](https://docs.djangoproject.com/en/stable/topics/cache/#redis). Some utility code for serializers and compressors is derived from django-redis, licensed under BSD-3-Clause. The admin functionality was inspired by [django-redisboard](https://github.com/ionelmc/django-redisboard). All of the above I used in production, noticed some flaws over the years, and for one reason or another a new package ended up the best way for progress for me here.
+This project started from [django-redis](https://github.com/jazzband/django-redis) and Django's official [Redis cache backend](https://docs.djangoproject.com/en/stable/topics/cache/#redis). Some serializer and compressor utility code is derived from django-redis, licensed under BSD-3-Clause. The admin UI was inspired by [django-redisboard](https://github.com/ionelmc/django-redisboard).
 
 The Rust I/O driver and async bridge are heavily inspired by — and in places directly adapted from — [django-vcache](https://gitlab.com/glitchtip/django-vcache) (MIT, by David Burke / GlitchTip). The fork-safe tokio runtime, the `RustAwaitable` deferred-loop-binding pattern, and the multiplexed-connection design all originate there.
 

--- a/django_cachex/admin/queryset.py
+++ b/django_cachex/admin/queryset.py
@@ -529,7 +529,7 @@ class KeyAdminMixin:
                 with contextlib.suppress(Exception):
                     ttl = cache.ttl(user_key)
                     key_obj.ttl = ttl  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
-                    if ttl >= 0:
+                    if ttl is not None and ttl >= 0:
                         key_obj.ttl_expires_at = timezone.now() + timedelta(seconds=ttl)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
                 with contextlib.suppress(Exception):
                     key_type = cache.type(user_key)

--- a/django_cachex/admin/views/key_detail.py
+++ b/django_cachex/admin/views/key_detail.py
@@ -526,7 +526,7 @@ def _key_detail_view(  # noqa: C901, PLR0911, PLR0912, PLR0915
             key_type = cache.type(key)
         with contextlib.suppress(Exception):
             ttl = cache.ttl(key)
-            if ttl >= 0:
+            if ttl is not None and ttl >= 0:
                 ttl_expires_at = timezone.now() + timedelta(seconds=ttl)
         # Get type-specific data for non-string types
         if key_type and key_type != KeyType.STRING:

--- a/django_cachex/cache/cluster.py
+++ b/django_cachex/cache/cluster.py
@@ -37,7 +37,7 @@ try:
     class RedisClusterCache(KeyValueClusterCache):
         """Django cache backend for Redis Cluster mode.
 
-        Provides automatic sharding across multiple Redis nodes using hash slots.
+        Keys are sharded across nodes by hash slot.
         """
 
         _class = RedisClusterCacheClient
@@ -60,7 +60,7 @@ try:
     class ValkeyClusterCache(KeyValueClusterCache):
         """Django cache backend for Valkey Cluster mode.
 
-        Provides automatic sharding across multiple Valkey nodes using hash slots.
+        Keys are sharded across nodes by hash slot.
         """
 
         _class = ValkeyClusterCacheClient

--- a/django_cachex/cache/sentinel.py
+++ b/django_cachex/cache/sentinel.py
@@ -25,8 +25,8 @@ if _REDIS_AVAILABLE:
     class RedisSentinelCache(KeyValueSentinelCache):
         """Django cache backend for Redis Sentinel high availability.
 
-        Provides automatic failover and service discovery via Redis Sentinel.
-        LOCATION should use the Sentinel service name as the hostname.
+        Failover and service discovery happen through Redis Sentinel; the
+        ``LOCATION`` hostname is the Sentinel service name.
         """
 
         _class = RedisSentinelCacheClient
@@ -49,8 +49,8 @@ if _VALKEY_AVAILABLE:
     class ValkeySentinelCache(KeyValueSentinelCache):
         """Django cache backend for Valkey Sentinel high availability.
 
-        Provides automatic failover and service discovery via Valkey Sentinel.
-        LOCATION should use the Sentinel service name as the hostname.
+        Failover and service discovery happen through Valkey Sentinel; the
+        ``LOCATION`` hostname is the Sentinel service name.
         """
 
         _class = ValkeySentinelCacheClient

--- a/django_cachex/cache/sync.py
+++ b/django_cachex/cache/sync.py
@@ -143,6 +143,7 @@ class SyncCache(LocMemCache):
         # Non-blocking publish: single-worker executor serializes XADD calls
         # without blocking the calling thread on network I/O.
         self._publish_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="sync-pub")
+        self._publish_executor_shutdown = False
 
         # Admin display: show stream key and transport alias as location
         self._cachex_location = f"stream:{self._stream_key} [transport: {self._transport_alias}]"
@@ -246,8 +247,9 @@ class SyncCache(LocMemCache):
 
     def _start_consumer(self) -> None:
         # Recreate executor if it was shut down (e.g. after shutdown() + reuse)
-        if self._publish_executor._shutdown:
+        if self._publish_executor_shutdown:
             self._publish_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="sync-pub")
+            self._publish_executor_shutdown = False
         if self._replay_count > 0:
             self._replay_stream(self._replay_count)
         self._stop_event.clear()
@@ -408,6 +410,7 @@ class SyncCache(LocMemCache):
             self._initialized = False
             self._stop_event.clear()
         self._publish_executor.shutdown(wait=True, cancel_futures=False)
+        self._publish_executor_shutdown = True
 
     # -- Standard Django cache interface (LocMemCache + stream sync) --
 
@@ -555,7 +558,7 @@ class SyncCache(LocMemCache):
         made_key = self.make_and_validate_key(key, version=version)
         with self._lock:
             if made_key not in self._cache or self._has_expired(made_key):
-                return 0
+                return -2
             exp = self._expire_info.get(made_key)
             if exp is None:
                 return None
@@ -567,7 +570,7 @@ class SyncCache(LocMemCache):
         made_key = self.make_and_validate_key(key, version=version)
         with self._lock:
             if made_key not in self._cache or self._has_expired(made_key):
-                return 0
+                return -2
             exp = self._expire_info.get(made_key)
             if exp is None:
                 return None

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,8 +2,8 @@
 
 ## Requirements
 
-- Python 3.12+
-- Django 5.2+
+- Python 3.14+ (free-threaded supported)
+- Django 6.0+
 - valkey-py 6.1+ or redis-py 6+
 - Valkey server 7+ or Redis server 6+
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,30 +1,32 @@
 # django-cachex
 
-Full featured Valkey and Redis cache backend for Django with a built-in admin interface.
+Valkey and Redis cache backend for Django, with a Django admin UI for cache inspection.
 
 [![PyPI version](https://img.shields.io/pypi/v/django-cachex.svg?style=flat)](https://pypi.org/project/django-cachex/)
 [![Python versions](https://img.shields.io/pypi/pyversions/django-cachex.svg)](https://pypi.org/project/django-cachex/)
 [![Django versions](https://img.shields.io/pypi/frameworkversions/django/django-cachex.svg)](https://pypi.org/project/django-cachex/)
 
-## Why django-cachex?
+## What's in the box
 
-**Drop-in replacement** for Django's built-in Redis cache backend with extended features:
+A drop-in replacement for Django's built-in Redis cache, plus:
 
-- **Built-in admin interface** - Browse, search, edit, and delete cache keys from Django admin
-- **Unified Valkey and Redis support** - Single package for both backends
-- **Extended data structures** - Hashes, lists, sets, sorted sets
-- **Sync and async support** - All extended methods available in both sync and async
-- **TTL and pattern operations** - `ttl()`, `expire()`, `keys()`, `delete_pattern()`
-- **Lua script support** - Register and execute Lua scripts with automatic key prefixing
-- **Distributed locking** - `cache.lock()` for cross-process synchronization
-- **Sentinel and Cluster** - High availability and horizontal scaling
-- **Pluggable serializers** - Pickle, JSON, MsgPack with fallback support
-- **Pluggable compressors** - Zlib, Gzip, LZ4, LZMA, Zstandard with fallback support
+- One package for both Valkey and Redis, default and Sentinel and Cluster.
+- Sync and async are first-class. The async cache also works from sync code.
+- Hash, list, set, sorted set, and stream operations on the cache object.
+- TTL and pattern helpers (`ttl()`, `expire()`, `keys()`, `delete_pattern()`).
+- Distributed locks: `cache.lock()`.
+- Lua scripting with automatic key prefixing and value encoding/decoding.
+- Pluggable serializers (Pickle, JSON, MsgPack, ormsgpack, orjson) and compressors (Zlib, Gzip, LZ4, LZMA, Zstandard), each with fallback chains for safe migrations.
+- Cache stampede prevention (TTL-based XFetch).
+- Two composite backends: `SyncCache` (cross-pod stream-synchronized in-memory cache) and `TieredCache` (L1/L2 with TTL propagation).
+- Django `LocMemCache` and `DatabaseCache` extensions with the same data-structure ops and admin support.
+- Optional Rust I/O driver (PyO3 + tokio + redis-rs) under the same `KeyValueCache` API. Free-threaded CPython (3.14t) supported.
+- Django admin UI for browsing keys, inspecting values, editing, and flushing.
 
 ## Requirements
 
-- Python 3.12+
-- Django 5.2+
+- Python 3.14+ (free-threaded supported)
+- Django 6.0+
 - valkey-py 6.1+ or redis-py 6.0+
 
 ## Quick Start

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -53,7 +53,7 @@ Hash operations for field-value data structures:
 
 | Method | Description |
 |--------|-------------|
-| `hset(key, field, value)` | Set a hash field value |
+| `hset(key, field=None, value=None, mapping=None, items=None)` | Set hash field(s); pass `field`/`value`, a `mapping` dict, or a flat `items` list |
 | `hdel(key, *fields)` | Delete hash field(s) |
 | `hexists(key, field)` | Check if hash field exists |
 | `hget(key, field)` | Get a hash field value |
@@ -63,7 +63,6 @@ Hash operations for field-value data structures:
 | `hincrbyfloat(key, field, amount=1.0)` | Increment hash field by float |
 | `hlen(key)` | Get number of fields in hash |
 | `hmget(key, *fields)` | Get multiple hash field values |
-| `hmset(key, mapping)` | Set multiple hash fields |
 | `hsetnx(key, field, value)` | Set hash field only if it doesn't exist |
 | `hvals(key)` | Get all values in a hash |
 
@@ -220,14 +219,14 @@ Extended methods (data structures, TTL, patterns) have async versions on the cac
 # Sync (on cache object directly)
 cache.hset("hash", "field", "value")
 
-# Async (on cache client -- note: client methods use raw/prefixed keys)
+# Async (on cache client; note that client methods take raw/prefixed keys)
 key = cache.make_and_validate_key("hash")
 await cache._cache.ahset(key, "field", "value")
 ```
 
 - `attl`, `apttl`, `aexpire`, `apexpire`, `aexpireat`, `apexpireat`, `apersist`
 - `akeys`, `aiter_keys`, `adelete_pattern`
-- `ahset`, `ahdel`, `ahexists`, `ahget`, `ahgetall`, `ahincrby`, `ahincrbyfloat`, `ahkeys`, `ahlen`, `ahmget`, `ahmset`, `ahsetnx`, `ahvals`
+- `ahset`, `ahdel`, `ahexists`, `ahget`, `ahgetall`, `ahincrby`, `ahincrbyfloat`, `ahkeys`, `ahlen`, `ahmget`, `ahsetnx`, `ahvals`
 - `asadd`, `asrem`, `asmembers`, `asismember`, `asmismember`, `ascard`, `aspop`, `asrandmember`, `asmove`, `asdiff`, `asdiffstore`, `asinter`, `asinterstore`, `asunion`, `asunionstore`
 - `azadd`, `azcard`, `azcount`, `azincrby`, `azrange`, `azrevrange`, `azrangebyscore`, `azrevrangebyscore`, `azrank`, `azrevrank`, `azrem`, `azremrangebyrank`, `azremrangebyscore`, `azscore`, `azmscore`, `azpopmin`, `azpopmax`
 - `allen`, `alpush`, `arpush`, `alpop`, `arpop`, `alindex`, `alrange`, `alset`, `altrim`, `alrem`, `alpos`, `almove`, `alinsert`, `ablpop`, `abrpop`, `ablmove`

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- **Python 3.14+ required.** Dropped support for 3.12 and 3.13. The package now ships on cp314 and cp314t (free-threaded) wheels.
+- **Django 6.0+ required.** Dropped support for Django 5.2.
+- **`SyncCache` wire format changed.** Stream entries now flow through the transport's serializer + compressor pipeline instead of raw pickle. Pods running the new code cannot read entries written by older pods on the same stream — coordinate the rollout (drain or rotate `STREAM_KEY`).
+- **`hmset` removed.** Use `hset(key, mapping=...)` or `hset(key, items=...)` (flat key-value list, matching redis-py/valkey-py).
+
+### New features
+
+- **Rust I/O driver.** Optional native driver built on PyO3 + tokio + redis-rs. Set `"client_class"` to one of `RustRedisCache`, `RustValkeyCache`, `RustRedisClusterCache`, `RustValkeyClusterCache`, `RustRedisSentinelCache`, `RustValkeySentinelCache`. Sync and async share one tokio runtime; async dodges the threadpool round-trip.
+- **`SyncCache` backend.** Stream-synchronized in-memory cache: reads are local, writes broadcast over a Redis Stream, a daemon thread on each pod consumes the stream and applies remote changes. Read-heavy, write-light, eventually consistent.
+- **`TieredCache` backend.** Composes two existing `CACHES` entries as L1 (fast, e.g. LocMem) and L2 (durable, e.g. Redis), with TTL propagation and pull-through reads.
+- **Cache-stampede prevention.** TTL-based XFetch via `OPTIONS["stampede_prevention"]` (or `stampede_prevention=` per call). Configurable buffer/beta/delta.
+- **`LocMemCache` and `DatabaseCache` extensions.** Drop-in replacements for the Django builtins, adding data-structure ops, TTL helpers, and admin support. Compound read-modify-write ops on `LocMemCache` are serialized via a per-backend `RLock` (#62).
+- **`orjson` and `ormsgpack` serializer extras.**
+- **Free-threaded CPython (3.14t) support.** A cp314t wheel is built; `_driver` works with the GIL disabled. The Rust driver also runs on the free-threaded build.
+- **PyPI wheels via cibuildwheel.** Manylinux x86_64 wheels for cp314 and cp314t.
+- **Async pool sharing.** A single async connection pool is shared across per-task `Cache` instances (#83), avoiding the thundering-herd reconnect on cold start.
+- **Pipeline parity.** Stream ops, CAS ops, missing key ops (`persist`/`pttl`/`expire_at`/etc.), context manager, `zpopmin`/`zpopmax` default `count=1` aligned with the cache API.
+
+### Fixes
+
+- `LocMemCache.lpush`/`sadd`/`hset`/`hincrby`/`zadd`/etc. no longer lose updates under concurrent threads (#62).
+- `delete_pattern` batches deletes to bound peak memory on broad patterns.
+- `clear()` is now prefix/version-scoped instead of `FLUSHDB`. The old behavior is available as `flush_db()`.
+- Compressor `decompress` methods catch all exceptions and re-raise as `CompressorError`.
+- Several cluster correctness fixes (script loading on replicas, set_many `timeout=0`).
+
+---
+
 ## 0.3.0 (February 2026)
 
 - **`expiretime()` and `set(get=True)` support**: New cache methods for retrieving absolute expiry timestamps and atomic get-and-set operations.

--- a/docs/user-guide/admin.md
+++ b/docs/user-guide/admin.md
@@ -61,9 +61,9 @@ Different cache backends have different levels of support:
 
 | Badge | Level | Description |
 |-------|-------|-------------|
-| **cachex** | Full Support | django-cachex backends (`ValkeyCache`, `RedisCache`, etc.) -- all features including key listing, pattern search, TTL inspection, and data type operations. |
-| **wrapped** | Wrapped Support | Django builtin backends (`LocMemCache`, `DatabaseCache`, etc.) -- most features available through wrapper compatibility. |
-| **limited** | Limited Support | Custom or unknown backends -- basic operations may work but key listing and advanced features may not be available. |
+| **cachex** | Full Support | django-cachex backends (`ValkeyCache`, `RedisCache`, etc.). All features: key listing, pattern search, TTL inspection, and data type operations. |
+| **wrapped** | Wrapped Support | Django builtin backends (`LocMemCache`, `DatabaseCache`, etc.). Most features work through wrapper compatibility. |
+| **limited** | Limited Support | Custom or unknown backends. Basic operations may work; key listing and advanced features may not be available. |
 
 ### Using Redis/Valkey?
 

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -25,13 +25,13 @@ from django.core.cache import cache
 
 cache.set("foo", "value", timeout=25)
 cache.ttl("foo")      # Returns 25
-cache.ttl("missing")  # Returns 0 (key doesn't exist)
+cache.ttl("missing")  # Returns -2 (key doesn't exist)
 ```
 
 Returns:
 
-- `0` - Key doesn't exist or already expired
-- `None` - Key exists but has no expiration
+- `-2` - Key doesn't exist or already expired
+- `None` - Key exists but has no expiration (set with `timeout=None`)
 - `int` - Seconds until expiration
 
 ### Get TTL in Milliseconds
@@ -163,7 +163,7 @@ from django.core.cache import cache
 cache.hset("user:1", "name", "Alice")
 
 # Set multiple fields at once
-cache.hmset("user:1", {"email": "alice@example.com", "age": 30})
+cache.hset("user:1", mapping={"email": "alice@example.com", "age": 30})
 
 # Get a single field
 name = cache.hget("user:1", "name")  # "Alice"

--- a/docs/user-guide/async.md
+++ b/docs/user-guide/async.md
@@ -1,10 +1,10 @@
 # Async Support
 
-django-cachex implements Django's async cache methods (`aget`, `aset`, `adelete`, etc.) using native async clients from `redis.asyncio` and `valkey.asyncio`, providing true async operations without thread pool overhead.
+django-cachex implements Django's async cache methods (`aget`, `aset`, `adelete`, etc.) using native async clients from `redis.asyncio` and `valkey.asyncio`. There is no threadpool round-trip.
 
 ## Overview
 
-A single cache backend supports both sync and async operations simultaneously -- `cache.get()` and `await cache.aget()` work on the same backend with no separate configuration needed.
+A single cache backend serves both sync and async callers. `cache.get()` and `await cache.aget()` operate on the same backend with no separate configuration.
 
 ## Basic Usage
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -21,6 +21,10 @@ CACHES = {
 
 ## Backend Classes
 
+All backends live in `django_cachex.cache`.
+
+### Valkey / Redis (Python driver)
+
 | Backend | Description |
 |---------|-------------|
 | `ValkeyCache` | Standard Valkey connection |
@@ -30,7 +34,32 @@ CACHES = {
 | `ValkeyClusterCache` | Valkey Cluster sharding |
 | `RedisClusterCache` | Redis Cluster sharding |
 
-All backends are in `django_cachex.cache`.
+### Valkey / Redis (Rust driver)
+
+Same wire-level features, dispatched through the bundled `_driver` Rust extension (PyO3 + tokio + redis-rs). Async paths skip the threadpool round-trip and a single tokio runtime serves sync and async callers.
+
+| Backend | Description |
+|---------|-------------|
+| `RustValkeyCache` | Standard Valkey connection |
+| `RustRedisCache` | Standard Redis connection |
+| `RustValkeySentinelCache` | Valkey Sentinel high availability |
+| `RustRedisSentinelCache` | Redis Sentinel high availability |
+| `RustValkeyClusterCache` | Valkey Cluster sharding |
+| `RustRedisClusterCache` | Redis Cluster sharding |
+
+### Local backends
+
+| Backend | Description |
+|---------|-------------|
+| `LocMemCache` | Drop-in replacement for Django's `LocMemCache` with data-structure ops, TTL helpers, and admin support |
+| `DatabaseCache` | Drop-in replacement for Django's `DatabaseCache` with the same extensions |
+
+### Composite backends
+
+| Backend | Description |
+|---------|-------------|
+| `SyncCache` | In-memory store synchronized across pods via a Redis Stream consumer |
+| `TieredCache` | Composes two existing `CACHES` entries as L1/L2 with TTL propagation |
 
 !!! note "Valkey and Redis Compatibility"
     Valkey and Redis are likely still fully compatible, so either backend works with either server. Valkey is recommended as it remains fully open source.
@@ -142,6 +171,35 @@ Compression is only applied to values larger than `min_length` bytes (default: 2
     "parser_class": "valkey.connection.LibvalkeyParser",
     # For Redis with hiredis
     # "parser_class": "redis.connection.HiredisParser",
+}
+```
+
+### Cache stampede prevention
+
+Probabilistic early recompute (XFetch) to avoid thundering-herd recompute when a hot key expires:
+
+```python
+"OPTIONS": {
+    # Enable with defaults (buffer=60s, beta=1.0, delta=1.0)
+    "stampede_prevention": True,
+
+    # Or tune individually
+    "stampede_prevention": {
+        "buffer": 30,   # extra TTL added to writes; recompute window inside this buffer
+        "beta": 1.0,    # higher = more aggressive early recompute
+        "delta": 1.0,   # estimated recompute cost (seconds)
+    },
+}
+```
+
+Per-call overrides accept the same shapes via the `stampede_prevention=` keyword on `get`/`set`/`add`/`get_or_set`/`get_many`/`set_many`.
+
+### Custom client class
+
+```python
+"OPTIONS": {
+    # Use the Rust driver client
+    "client_class": "django_cachex.client.rust.RustValkeyCacheClient",
 }
 ```
 

--- a/tests/cache/test_cache_sync.py
+++ b/tests/cache/test_cache_sync.py
@@ -301,8 +301,8 @@ class TestSyncExpiry:
         sync_cache.set("persist_key", "val", timeout=None)
         assert sync_cache.ttl("persist_key") is None
 
-    def test_ttl_returns_zero_for_missing(self, sync_cache: BaseCache):
-        assert sync_cache.ttl("no_key") == 0
+    def test_ttl_returns_minus_two_for_missing(self, sync_cache: BaseCache):
+        assert sync_cache.ttl("no_key") == -2
 
     def test_has_key_false_for_expired(self, sync_cache: BaseCache):
         sync_cache.set("exp_hk", "val", timeout=1)


### PR DESCRIPTION
## Summary

Pre-publish sweep — docs accuracy, a few code-correctness nits, and prose cleanup. No public API changes.

### Docs
- Python 3.12+ → 3.14+ and Django 5.2+ → 6.0+ in `index.md` and `installation.md` (match `pyproject`).
- Drop `hmset` references in `advanced.md` and `api.md`; replaced with `hset(mapping=...)`.
- Fix `ttl()` return-value table in `advanced.md`: missing keys return `-2`, not `0`.
- Add **Unreleased** changelog entry: breaking changes (Python 3.14+, Django 6.0+, SyncCache wire format, `hmset` removal) and the headline features since v0.3.0 (Rust driver, SyncCache, TieredCache, stampede prevention, LocMem/Database extensions, free-threaded support).
- Expand `configuration.md` backend table with Rust variants, LocMem/Database/Sync/Tiered. Document `stampede_prevention` and `client_class` OPTIONS.

### Code
- `SyncCache.ttl()`/`pttl()` return `-2` for missing keys (was `0`); aligns with the project-wide contract. Test updated.
- `SyncCache`: track publish-executor shutdown via a boolean we own instead of probing `ThreadPoolExecutor._shutdown` (private CPython attribute).
- `admin/views/key_detail.py` and `admin/queryset.py`: explicit `ttl is not None` guard before `ttl >= 0` (previously a `TypeError` silently swallowed by `contextlib.suppress`, leaving `ttl_expires_at` unset).

### Prose
- Rewrite README and `docs/index` "What's in the box" sections; drop the bold-template bullet shape and the acknowledgments ramble.
- Replace fake ` -- ` em-dashes in `admin.md`, `async.md`, `api.md`.
- Drop "Provides automatic…" docstring openers on cluster/sentinel cache classes.

### Withdrawn from initial audit
- Parenthesized `except (A, B):` — the project's own `ruff format` (with `target-version = "py314"`) actively *removes* these parens since PEP 758 makes them optional. Leaving the unparenthesized form as the canonical project style.

## Test plan

- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy django_cachex/` clean
- [x] `uv run ty check django_cachex/` clean
- [x] `uv run pytest -n auto` — 8016 passed, 245 skipped (no regressions)
- [ ] Spot-check the rendered changelog entry in mkdocs preview before tagging the next release