### PR TITLE
ci: build wheels for Linux ARM64, macOS arm64, Windows amd64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,28 @@ jobs:
           path: wheelhouse/*
 
   build-rust-wheels:
-    name: Build Rust wheels (cibuildwheel, django-cachex-rust)
-    runs-on: ubuntu-latest
+    name: Build Rust wheels (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x86_64
+            cibw_archs: x86_64
+            cibw_build: cp314-manylinux_x86_64 cp314t-manylinux_x86_64
+          - os: ubuntu-24.04-arm
+            label: linux-aarch64
+            cibw_archs: aarch64
+            cibw_build: cp314-manylinux_aarch64 cp314t-manylinux_aarch64
+          - os: macos-14
+            label: macos-arm64
+            cibw_archs: arm64
+            cibw_build: cp314-macosx_arm64 cp314t-macosx_arm64
+          - os: windows-latest
+            label: windows-amd64
+            cibw_archs: AMD64
+            cibw_build: cp314-win_amd64 cp314t-win_amd64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
 
@@ -166,16 +186,18 @@ jobs:
         with:
           package-dir: crates/django-cachex-rust
         env:
-          CIBW_BUILD: cp314-manylinux_x86_64 cp314t-manylinux_x86_64
+          CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_ENABLE: cpython-freethreading
-          CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          # Linux builds run inside manylinux containers — install Rust there.
+          # macOS and Windows runners have rustup preinstalled.
           CIBW_BEFORE_ALL_LINUX: |
             curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
           CIBW_ENVIRONMENT_LINUX: PATH="$HOME/.cargo/bin:$PATH"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-rust-linux-x86_64
+          name: wheels-rust-${{ matrix.label }}
           path: wheelhouse/*.whl
 
   test-wheel:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,28 @@ jobs:
           path: dist/*
 
   build-rust-wheels:
-    name: Build Rust wheels (cibuildwheel, django-cachex-rust)
-    runs-on: ubuntu-latest
+    name: Build Rust wheels (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x86_64
+            cibw_archs: x86_64
+            cibw_build: cp314-manylinux_x86_64 cp314t-manylinux_x86_64
+          - os: ubuntu-24.04-arm
+            label: linux-aarch64
+            cibw_archs: aarch64
+            cibw_build: cp314-manylinux_aarch64 cp314t-manylinux_aarch64
+          - os: macos-14
+            label: macos-arm64
+            cibw_archs: arm64
+            cibw_build: cp314-macosx_arm64 cp314t-macosx_arm64
+          - os: windows-latest
+            label: windows-amd64
+            cibw_archs: AMD64
+            cibw_build: cp314-win_amd64 cp314t-win_amd64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,14 +66,16 @@ jobs:
         with:
           package-dir: crates/django-cachex-rust
         env:
-          CIBW_BUILD: cp314-manylinux_x86_64 cp314t-manylinux_x86_64
+          CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_ENABLE: cpython-freethreading
-          CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BEFORE_ALL_LINUX: |
             curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
           CIBW_ENVIRONMENT_LINUX: PATH="$HOME/.cargo/bin:$PATH"
 
+      # sdist is a single artifact — only build it once on the Linux x86_64 leg.
       - name: Build Rust sdist
+        if: matrix.label == 'linux-x86_64'
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
@@ -61,7 +83,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist-rust
+          name: dist-rust-${{ matrix.label }}
           path: wheelhouse/*
 
   publish-pure:
@@ -92,8 +114,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: dist-rust
+          pattern: dist-rust-*
           path: dist
+          merge-multiple: true
 
       - name: Publish django-cachex-rust to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Expand the rust wheel build matrix beyond Linux x86_64. Adds prebuilt wheels for macOS Apple Silicon, Windows x86_64, and Linux ARM64 — covering modern dev and prod targets.

| Runner | Wheel ABIs |
|---|---|
| ubuntu-latest | cp314-manylinux_x86_64, cp314t-manylinux_x86_64 |
| ubuntu-24.04-arm (native) | cp314-manylinux_aarch64, cp314t-manylinux_aarch64 |
| macos-14 (Apple Silicon) | cp314-macosx_arm64, cp314t-macosx_arm64 |
| windows-latest | cp314-win_amd64, cp314t-win_amd64 |

## What changed

- `ci.yml` and `publish.yml` `build-rust-wheels` jobs now run a 4-entry matrix.
- Sdist (single artifact) is built only on the linux-x86_64 leg of `publish.yml` to avoid duplicates.
- Per-platform artifact upload names; `publish-rust` glob-merges them.
- No code changes — Rust crate (PyO3 + tokio + redis-rs + rustls/ring) is already cross-platform.

## Skipped (low ROI)

- macOS x86_64 (Intel Macs rare in 2026)
- Windows ARM64 (rare; can revisit if asked)

## Test plan

- [ ] CI: `build-rust-wheels` matrix all green
- [ ] CI: existing `test-wheel` / `smoke-test-wheel-freethreaded` / `smoke-test-pure-only` still pass (they test the linux-x86_64 wheel — unchanged)

## Notes

- Free-threaded (cp314t) wheels for macOS/Windows are less battle-tested than Linux. If issues surface, easiest knob is to drop the `t` ABI from the macOS/Windows entries in the matrix.
- Build time grows from ~10 min (Linux only) to ~25-30 min (4 parallel platforms). Only matters at release time.