### PR TITLE
test: tighten weak admin/timeout asserts; fix: _decompress raises + admin tolerates undecodable values

### DIFF
--- a/django_cachex/admin/helpers.py
+++ b/django_cachex/admin/helpers.py
@@ -283,8 +283,15 @@ def get_size(cache: Any, key: str, key_type: str | None = None) -> int | None:
             return client.strlen(full_key)
         except NotSupportedError, AttributeError:
             pass
-        # Fallback: compute Python object size (e.g. LocMemCache)
-        value = cache.get(key)
+        # Fallback: compute Python object size (e.g. LocMemCache). Decode
+        # failures for stale data must not break the size column — return None
+        # so the row still renders and the user can delete the broken key.
+        from django_cachex.exceptions import CompressorError, SerializerError
+
+        try:
+            value = cache.get(key)
+        except CompressorError, SerializerError:
+            return None
         return _deep_getsizeof(value) if value is not None else None
 
     try:

--- a/django_cachex/admin/views/key_detail.py
+++ b/django_cachex/admin/views/key_detail.py
@@ -22,6 +22,7 @@ from django_cachex.admin.views.base import (
     key_list_url,
     show_help,
 )
+from django_cachex.exceptions import CompressorError, SerializerError
 from django_cachex.types import KeyType
 
 if TYPE_CHECKING:
@@ -535,19 +536,35 @@ def _key_detail_view(  # noqa: C901, PLR0911, PLR0912, PLR0915
         # In create mode, use the type from query param
         key_type = create_type
 
-    # Get value for string keys (cache.get() only works for strings)
+    # Get value for string keys (cache.get() only works for strings).
+    # Decode failures (compressor / serializer mismatch on stale data) must NOT
+    # crash the page — the user still needs to be able to delete the broken key.
     raw_value = None
     value_is_editable = True
+    value_decode_error: str | None = None
     string_sha1 = None
     if key_exists and (not key_type or key_type == KeyType.STRING):
-        raw_value = cache.get(key)
-        if hasattr(cache, "eval_script"):
-            with contextlib.suppress(Exception):
-                from django_cachex.admin.cas import get_string_sha1
+        try:
+            raw_value = cache.get(key)
+        except (CompressorError, SerializerError) as exc:
+            value_decode_error = str(exc) or exc.__class__.__name__
+            value_is_editable = False
+            messages.warning(
+                request,
+                f"Value cannot be decoded ({exc.__class__.__name__}: {exc}). "
+                "The key was likely written with a different compressor or serializer. "
+                "You can still delete the key.",
+            )
+        else:
+            if hasattr(cache, "eval_script"):
+                with contextlib.suppress(Exception):
+                    from django_cachex.admin.cas import get_string_sha1
 
-                string_sha1 = get_string_sha1(cache, key)
+                    string_sha1 = get_string_sha1(cache, key)
 
-    if raw_value is not None:
+    if value_decode_error is not None:
+        value_display = f"<value cannot be decoded: {value_decode_error}>"
+    elif raw_value is not None:
         # Format value for display - JSON-serializable values are editable
         value_display, value_is_editable = format_value_for_display(raw_value)
     else:

--- a/django_cachex/client/default.py
+++ b/django_cachex/client/default.py
@@ -205,13 +205,24 @@ class KeyValueCacheClient:
         return [create_compressor(config)]
 
     def _decompress(self, value: bytes) -> bytes:
-        """Decompress with fallback support for multiple compressors."""
+        """Decompress with fallback support for multiple compressors.
+
+        Returns ``value`` unchanged when no compressors are configured. Raises
+        ``CompressorError`` if every configured compressor fails — symmetric
+        with ``_deserialize``. To accept uncompressed payloads alongside
+        compressed ones (e.g. mid-migration), keep the previously-used
+        compressor at the end of the fallback chain.
+        """
+        if not self._compressors:
+            return value
+        last_error: CompressorError | None = None
         for compressor in self._compressors:
             try:
                 return compressor.decompress(value)
-            except CompressorError:
-                continue
-        return value
+            except CompressorError as e:
+                last_error = e
+        # Every configured compressor failed.
+        raise last_error if last_error is not None else CompressorError("decompression failed")
 
     def _deserialize(self, value: bytes) -> Any:
         """Deserialize with fallback support for multiple serializers."""

--- a/tests/admin/test_views.py
+++ b/tests/admin/test_views.py
@@ -172,8 +172,9 @@ class TestIndexView:
         response = admin_client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        # Should have link to key browser (List Keys link)
-        assert "List Keys" in content or "key" in content.lower()
+        # The keys_link column emits an <a> pointing at the key changelist filtered by cache name.
+        assert "?cache=default" in content
+        assert "List Keys" in content
 
     def test_index_search_filters_caches(self, admin_client: Client, test_cache):
         """Search should filter cache list by name."""
@@ -325,8 +326,8 @@ class TestKeyListView:
         response = admin_client.get(url + "&q=ttl:*")
         assert response.status_code == 200
         content = response.content.decode()
-        # Should show TTL value or "No expiry" - looking for table header
-        assert "TTL" in content or "ttl" in content.lower()
+        # ttl_display emits <code title="{seconds}s">{timeuntil}</code> for keys with a TTL.
+        assert '<code title="' in content
 
     def test_key_list_shows_size_column(
         self,
@@ -416,8 +417,8 @@ class TestKeyListView:
         response = admin_client.get(url + "&q=paginate:*")
         assert response.status_code == 200
         content = response.content.decode()
-        # Should show pagination controls
-        assert "paginator" in content or "page" in content.lower()
+        # Django's standard paginator wraps the controls in <p class="paginator">.
+        assert 'class="paginator"' in content
 
     def test_key_list_results_count(
         self,
@@ -2061,25 +2062,22 @@ class TestCacheAdmin:
         # Should return 200 (changelist_view is the cache list now)
         assert response.status_code == 200
 
-    def test_has_add_permission_returns_false(self, admin_client: Client, test_cache):
-        """CacheAdmin should not allow adding new cache entries."""
+    def test_has_add_permission_returns_false(self, admin_user, test_cache):
+        """CacheAdmin should not allow adding new cache entries — even for a superuser."""
         from django.contrib.admin import site
         from django.test import RequestFactory
 
         from django_cachex.admin.models import Cache
 
-        # Get the registered admin instance
         cache_admin = site._registry[Cache]
 
-        factory = RequestFactory()
-        request = factory.get("/admin/")
-        request.user = admin_client.session.get("_auth_user_id")
+        request = RequestFactory().get("/admin/")
+        request.user = admin_user
 
-        # has_add_permission should return False
         assert cache_admin.has_add_permission(request) is False
 
-    def test_has_delete_permission_returns_false(self, admin_client: Client, test_cache):
-        """CacheAdmin should not allow deleting cache entries."""
+    def test_has_delete_permission_returns_false(self, admin_user, test_cache):
+        """CacheAdmin should not allow deleting cache entries — even for a superuser."""
         from django.contrib.admin import site
         from django.test import RequestFactory
 
@@ -2087,9 +2085,8 @@ class TestCacheAdmin:
 
         cache_admin = site._registry[Cache]
 
-        factory = RequestFactory()
-        request = factory.get("/admin/")
-        request.user = admin_client.session.get("_auth_user_id")
+        request = RequestFactory().get("/admin/")
+        request.user = admin_user
 
         assert cache_admin.has_delete_permission(request) is False
 

--- a/tests/admin/test_views.py
+++ b/tests/admin/test_views.py
@@ -2461,3 +2461,78 @@ class TestPermissionViewAccess:
         assert admin_client.get(_cache_detail_url("default")).status_code == 200
         assert admin_client.get(_key_list_url("default")).status_code == 200
         assert admin_client.get(_key_add_url("default")).status_code == 200
+
+
+class TestUndecodableValueResilience:
+    """Admin must not crash on keys whose stored value can't be decoded.
+
+    A compressor or serializer change after data was already cached, or any
+    other source of stale-but-undecodable bytes, must still let an operator
+    open the key detail page and delete the broken key.
+    """
+
+    BROKEN_KEY = "broken:undecodable"
+
+    @staticmethod
+    def _inject_broken_value(test_cache: KeyValueCache) -> None:
+        """Write garbage bytes directly to Redis under the cache's key prefix.
+
+        Bypasses the cache's serializer/compressor pipeline so reading via
+        cache.get() will raise SerializerError (or CompressorError, depending
+        on what's configured).
+        """
+        client = test_cache.get_client(write=True)
+        full_key = test_cache.make_key(TestUndecodableValueResilience.BROKEN_KEY)
+        # Bytes that aren't valid pickle and aren't valid for any compressor
+        # in the default chain. The client's _decompress / _deserialize must
+        # raise on read.
+        client.set(full_key, b"\x00not-valid-pickle-or-compressed-data")
+
+    def test_key_detail_loads_for_broken_value(self, admin_client, test_cache):
+        """Key detail view returns 200 (not 500) for an undecodable value."""
+        self._inject_broken_value(test_cache)
+
+        response = admin_client.get(_key_detail_url("default", self.BROKEN_KEY))
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        # The view should communicate the decode failure rather than crashing.
+        assert "cannot be decoded" in content
+
+    def test_key_detail_shows_warning_message_for_broken_value(self, admin_client, test_cache):
+        """User sees a warning explaining why the value isn't shown."""
+        self._inject_broken_value(test_cache)
+
+        response = admin_client.get(_key_detail_url("default", self.BROKEN_KEY))
+
+        # Django messages framework renders into the page.
+        content = response.content.decode()
+        assert "different compressor or serializer" in content
+
+    def test_delete_works_for_broken_value(self, admin_client, test_cache):
+        """Operators can still delete a broken key from the admin."""
+        self._inject_broken_value(test_cache)
+
+        # Sanity: key exists in Redis (raw client doesn't decode).
+        client = test_cache.get_client(write=True)
+        full_key = test_cache.make_key(self.BROKEN_KEY)
+        assert client.exists(full_key) == 1
+
+        response = admin_client.post(
+            _key_detail_url("default", self.BROKEN_KEY),
+            {"action": "delete"},
+        )
+
+        # 302 redirect to key list = success (matches the success branch in key_detail.py).
+        assert response.status_code == 302
+        assert client.exists(full_key) == 0
+
+    def test_key_list_renders_with_broken_value(self, admin_client, test_cache):
+        """The key list shouldn't crash either; size column degrades gracefully."""
+        self._inject_broken_value(test_cache)
+
+        response = admin_client.get(_key_list_url("default"))
+
+        assert response.status_code == 200
+        # Broken key still appears in the list — operator needs to see it to delete it.
+        assert self.BROKEN_KEY in response.content.decode()

--- a/tests/cache/test_cache_timeouts.py
+++ b/tests/cache/test_cache_timeouts.py
@@ -65,11 +65,12 @@ class TestSetWithTimeout:
         cache.set("preserve_me", "changed", timeout=-1, nx=True)
         assert cache.get("preserve_me") == "original"
 
-    def test_very_small_timeout(self, cache: KeyValueCache):
+    def test_subsecond_float_timeout_is_accepted(self, cache: KeyValueCache):
+        # Sub-second float timeouts must be accepted by the backend (not raise or
+        # be rejected). Whether the key has already expired by the time we read
+        # is a race we don't assert on here — test_zero_timeout_immediate_expiration
+        # covers the rounded-to-zero case.
         cache.set("tiny_ttl", "value", timeout=0.00001)
-        # Either already expired or still present (race condition)
-        result = cache.get("tiny_ttl")
-        assert result in (None, "value")
 
 
 class TestTTLOperations:

--- a/tests/cache/test_compressor_fallback.py
+++ b/tests/cache/test_compressor_fallback.py
@@ -145,9 +145,17 @@ class TestDecompressFallback:
         # gzip will fail, zlib should succeed
         assert client._decompress(zlib_data) == data
 
-    def test_decompress_returns_raw_when_all_fail(self):
-        """Test that _decompress returns raw bytes when all compressors fail."""
+    def test_decompress_raises_when_all_compressors_fail(self):
+        """When every configured compressor fails, _decompress raises CompressorError.
+
+        Symmetric with _deserialize, which also raises on all-fail. Callers
+        that want to tolerate raw payloads should keep the previously-used
+        compressor at the end of the fallback chain (or omit compressors).
+        """
+        import pytest
+
         from django_cachex.client import RedisCacheClient
+        from django_cachex.exceptions import CompressorError
 
         client = RedisCacheClient(
             servers=["redis://localhost:6379"],
@@ -156,13 +164,17 @@ class TestDecompressFallback:
             ],
         )
 
-        # Plain data that isn't gzip
+        # Plain data that isn't gzip — the only configured compressor fails.
         data = b"Plain uncompressed data"
-        assert client._decompress(data) == data
+        with pytest.raises(CompressorError):
+            client._decompress(data)
 
-    def test_decompress_continues_on_failure(self):
-        """Test that _decompress continues to next compressor on failure."""
+    def test_decompress_raises_after_full_chain_fails(self):
+        """_decompress walks the full chain before raising; raises when none succeed."""
+        import pytest
+
         from django_cachex.client import RedisCacheClient
+        from django_cachex.exceptions import CompressorError
 
         client = RedisCacheClient(
             servers=["redis://localhost:6379"],
@@ -172,13 +184,13 @@ class TestDecompressFallback:
             ],
         )
 
-        # Data that looks like it could be gzip but isn't valid
+        # Looks like gzip (magic bytes) but isn't valid; zlib also fails.
         fake_gzip = b"\x1f\x8bNot actually valid gzip data"
-        # Both gzip and zlib fail, returns raw data
-        assert client._decompress(fake_gzip) == fake_gzip
+        with pytest.raises(CompressorError):
+            client._decompress(fake_gzip)
 
     def test_decompress_with_no_compressors_returns_raw(self):
-        """Test that _decompress returns raw data when no compressors configured."""
+        """When no compressors are configured, _decompress is a no-op pass-through."""
         from django_cachex.client import RedisCacheClient
 
         client = RedisCacheClient(


### PR DESCRIPTION
Second batch from #86. Started as test-correctness fixes; expanded to include the `_decompress` symmetry fix + admin-resilience hardening at user request.

## Test correctness (commit `ced5369`)

### `test_very_small_timeout` could not fail
At `tests/cache/test_cache_timeouts.py:72` the test asserted `result in (None, "value")` after a sub-millisecond timeout, accepting both possible outcomes. Renamed to `test_subsecond_float_timeout_is_accepted` and reduced to "set() must accept the float without raising". `test_zero_timeout_immediate_expiration` already covers the rounded-to-zero semantics.

### `test_has_add_permission` / `test_has_delete_permission` asserted on a string, not a User
At `tests/admin/test_views.py:2076` and `:2092`, `request.user = admin_client.session.get("_auth_user_id")` assigned the auth user ID (a string). The tests only passed because the methods return `False` unconditionally. Switched to the `admin_user` fixture so the assertion meaningfully says "even a superuser cannot add/delete via this admin".

### Three admin substring-match tests passed on virtually any HTML

| Line | Before | After |
|---|---|---|
| 176 | `"List Keys" in content or "key" in content.lower()` | `"?cache=default" in content` (the actual link URL) plus `"List Keys" in content` |
| 329 | `"TTL" in content or "ttl" in content.lower()` | `'<code title="' in content` (markup `ttl_display()` emits) |
| 420 | `"paginator" in content or "page" in content.lower()` | `'class="paginator"' in content` (Django's standard paginator) |

## `_decompress` symmetry + admin resilience (commit `df84db3`)

### Behaviour change
`_decompress` previously returned raw bytes when every configured compressor failed, then `_deserialize` produced a confusing `SerializerError`. Now `_decompress` raises `CompressorError` directly — symmetric with `_deserialize`'s all-fail behaviour. The migration path (keep the previous compressor at the end of the fallback chain) is unchanged. The no-compressor pass-through case is also unchanged.

Two existing tests in `test_compressor_fallback.py` documented the old behaviour; renamed and updated:
- `test_decompress_returns_raw_when_all_fail` → `test_decompress_raises_when_all_compressors_fail`
- `test_decompress_continues_on_failure` → `test_decompress_raises_after_full_chain_fails`
- `test_decompress_with_no_compressors_returns_raw` kept (no-compressor case is intentionally a pass-through)

### Admin resilience
A behaviour change like this cannot ship without making sure operators can still **delete a broken key** through the admin. Two read-side spots in `django_cachex/admin/` decoded values; both now catch `(CompressorError, SerializerError)` and fail soft:
- `admin/views/key_detail.py` (line 543) — wraps the string-key `cache.get(key)`. On decode failure: shows a Django `messages.warning` explaining the situation, sets `value_is_editable = False`, and renders a sentinel display value. The page still loads (200) and the delete form still works.
- `admin/helpers.py` (`_string_size` LocMemCache fallback) — returns `None` for the size column instead of bubbling the exception.

Added `TestUndecodableValueResilience` covering the four guarantees:
1. Key detail view returns 200 (not 500) for an undecodable value
2. Warning message appears on the page
3. Delete works for the broken key
4. Key list still renders and shows the broken key

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy` clean
- [x] `ty check` clean
- [x] `pytest tests/admin/ tests/cache/test_cache_timeouts.py tests/cache/test_compressor_fallback.py` — passing
- [x] `pytest tests/cache/` (excl. cluster/sentinel/replica Docker) — 7488 passed
- [x] New `TestUndecodableValueResilience` (4 tests) — passing

Refs: #86
