### PR TITLE
fix(benchmarks): narrow bare-except blocks so broken metrics fail visibly

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -11,6 +11,7 @@ import asyncio
 import gc
 import time
 import tracemalloc
+import warnings
 from dataclasses import dataclass, field
 from statistics import mean, median
 from typing import TYPE_CHECKING, Any
@@ -171,7 +172,7 @@ def _build_payload() -> dict[str, Any]:
 
 
 def _build_payload_large() -> list[dict[str, Any]]:
-    # ~15 KiB pickled — queryset-shaped, well above the 256 B compression
+    # ~14 KiB pickled — queryset-shaped, well above the 256 B compression
     # threshold. Used for compressor benchmarks where a small payload would
     # bypass compression entirely.
     return [
@@ -326,9 +327,12 @@ def _open_info_client(location: str):
 
 
 def _server_used_memory(info_client) -> int | None:
+    import redis
+
     try:
         info = info_client.info("memory")
-    except Exception:
+    except (redis.RedisError, OSError) as exc:
+        warnings.warn(f"server INFO memory sample failed: {exc!r}", stacklevel=2)
         return None
     if not isinstance(info, dict):
         return None
@@ -337,9 +341,12 @@ def _server_used_memory(info_client) -> int | None:
 
 
 def _server_connections(info_client) -> int | None:
+    import redis
+
     try:
         info = info_client.info("clients")
-    except Exception:
+    except (redis.RedisError, OSError) as exc:
+        warnings.warn(f"server INFO clients sample failed: {exc!r}", stacklevel=2)
         return None
     if not isinstance(info, dict):
         return None
@@ -641,7 +648,8 @@ def _total_rss_kb(parent_pid: int) -> float:
             check=False,
             timeout=2,
         )
-    except Exception:
+    except (subprocess.SubprocessError, OSError) as exc:
+        warnings.warn(f"ps RSS sample failed: {exc!r}", stacklevel=2)
         return total
     for raw in result.stdout.strip().splitlines():
         stripped = raw.strip()
@@ -774,7 +782,10 @@ def run_asgi_benchmark(  # noqa: C901, PLR0915 — orchestrates many phases in o
                         local_lat.append((time.perf_counter() - start) * 1000)
                         if resp.status_code >= 400:
                             e += 1
-                    except Exception:
+                    except httpx.HTTPError:
+                        # Transport / protocol / status errors are part of what we measure.
+                        # Programming bugs (NameError, TypeError, etc.) intentionally propagate
+                        # so they crash the run instead of being counted as request errors.
                         e += 1
                     t += 1
                 return t, e, local_lat


### PR DESCRIPTION
Audit follow-up from #86 (theme 2: real bugs / footguns).

## Problem

`benchmarks/runner.py` had four `except Exception:` blocks that silently zeroed metrics on any failure. Concretely:

- `_server_used_memory` — broken `INFO memory` → `None` → `or 0` → metric column reads 0
- `_server_connections` — same shape
- `_total_rss_kb` `ps` subprocess — `ps` failure → 0
- `_client_loop` httpx request loop — any error (including `NameError`/`TypeError` programming bugs) → counted as a request error

Result: published numbers in `benchmarks/README.md` could be wrong without anyone noticing. Audit reviewer flagged this as "editorial bias risk" — broken metrics sit alongside real ones in the same table.

## Fix

Each except is narrowed to its expected exception family. Programming bugs and other unexpected exceptions now propagate and crash the run instead of being silently swallowed.

| Spot | Before | After |
|---|---|---|
| `_server_used_memory` | `except Exception:` | `except (redis.RedisError, OSError) as exc:` + `warnings.warn(...)` then return `None` |
| `_server_connections` | same | same |
| `_total_rss_kb` ps subprocess | `except Exception:` | `except (subprocess.SubprocessError, OSError) as exc:` + `warnings.warn(...)` then return current total |
| `_client_loop` httpx | `except Exception:` | `except httpx.HTTPError:` (transport / protocol / status errors still counted as request errors; programming bugs now surface) |

`warnings.warn` deduplicates by call-site, so a persistent failure (e.g. INFO returning errors every sample) emits one warning per call site, not N.

## Bonus

While verifying the audit's payload-size claim, found the `_build_payload_large` doc comment was off — claimed `~15 KiB` but actual pickled size is **13.71 KiB**. Matches the README's `~14 KiB`. Fixed the comment to `~14 KiB` for consistency.

## Smoke test

Pointed the INFO helpers at an unreachable Redis endpoint:

```
_server_used_memory: None
_server_connections: None
warnings emitted: 2
  - server INFO memory sample failed: network:ConnectionError
  - server INFO clients sample failed: network:ConnectionError
_total_rss_kb(0): 0.0
```

Both helpers warn AND return `None` instead of silently swallowing.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy benchmarks/runner.py` clean (pre-existing `conftest.py` mypy errors are unrelated to this change — confirmed by stash-and-re-run on origin/main)
- [x] `ty check` clean for `runner.py`
- [x] Smoke test confirms warnings fire + None return on connection failure

Refs: #86
