### PR TITLE
test: tighten remaining substring-match admin assertions

### DIFF
--- a/tests/admin/test_views.py
+++ b/tests/admin/test_views.py
@@ -465,8 +465,7 @@ class TestKeyListView:
         response = admin_client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        assert "by cache" in content.lower()
-        # Both cache names should appear as filter options
+        # Both cache names appear as filter options — that's enough to prove the filter rendered.
         assert "?cache=default" in content
         assert "?cache=local" in content
 
@@ -604,8 +603,8 @@ class TestKeyDetailView:
         response = admin_client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        # Should show stream type
-        assert "stream" in content.lower()
+        # change_form.html renders <span class="type-badge type-stream">stream</span>
+        assert 'type-stream">stream</span>' in content
 
     def test_key_detail_requires_staff(self, db, test_cache):
         """Key detail view should redirect anonymous users."""
@@ -653,8 +652,8 @@ class TestKeyDetailView:
         response = admin_client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        # Should show "Raw Key" label or the key with prefix
-        assert "Raw" in content or "rawkey:test" in content
+        # Detail view shows the raw (prefixed) key in the page body.
+        assert "rawkey:test" in content
 
     def test_key_detail_shows_cache_name(
         self,
@@ -683,8 +682,8 @@ class TestKeyDetailView:
         response = admin_client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        # Should show list type
-        assert "list" in content.lower()
+        # change_form.html renders <span class="type-badge type-list">list</span>
+        assert 'type-list">list</span>' in content
         # Should show item count
         assert "3" in content
 
@@ -700,8 +699,8 @@ class TestKeyDetailView:
         response = admin_client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        # Should show TTL field
-        assert "TTL" in content or "ttl" in content.lower()
+        # change_form.html renders the TTL update form with id="id_ttl"
+        assert 'id="id_ttl"' in content
 
     def test_key_detail_shows_no_expiry(
         self,
@@ -715,8 +714,9 @@ class TestKeyDetailView:
         response = admin_client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        # Should indicate no expiry
-        assert "No expiry" in content or "expiry" in content.lower() or "-1" in content
+        # When the key has no expiry, the TTL input renders an empty value with the
+        # "no expiry" placeholder.
+        assert 'placeholder="no expiry"' in content
 
     def test_string_value_save_form_structure(
         self,
@@ -1919,8 +1919,8 @@ class TestKeyDetailCreateMode:
 
         assert response.status_code == 200
         content = response.content.decode()
-        # Should show value textarea
-        assert "id_value" in content or "textarea" in content.lower()
+        # The string-value form has a textarea with id="id_value".
+        assert 'id="id_value"' in content
 
     def test_create_mode_operation_creates_key(
         self,
@@ -2029,8 +2029,9 @@ class TestCacheDetailView:
         response = admin_client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        # Should have link to keys list
-        assert "Keys" in content or "List" in content
+        # change_form.html renders <a href="...?cache=default">List Keys</a>
+        assert "?cache=default" in content
+        assert "List Keys" in content
 
     def test_cache_detail_shows_slowlog_section(self, admin_client: Client, test_cache):
         """Cache detail view should show slow log section."""
@@ -2038,8 +2039,9 @@ class TestCacheDetailView:
         response = admin_client.get(url)
         assert response.status_code == 200
         content = response.content.decode()
-        # Should have slow log section
-        assert "Slow Log" in content or "slow" in content.lower()
+        # change_form.html renders <h2>Slow Log</h2> when slowlog_data is truthy
+        # (always — get_slowlog returns a dict even when empty).
+        assert "<h2>Slow Log</h2>" in content
 
     def test_cache_detail_count_parameter(self, admin_client: Client, test_cache):
         """Cache detail view should accept count parameter for slowlog."""


### PR DESCRIPTION
Continuation of #93. PR #93 tightened three substring-match sites; this finishes the sweep of the worst remaining ones. All of these would have passed on virtually any HTML output (e.g. `"list" in content.lower()` matches any CSS class containing the substring "list").

## Changes

Each assertion is replaced with a check against the specific markup the template actually emits. Where a test had multiple alternatives joined by `or`, kept the strong one and dropped the weak fallback.

| Before | After | Rationale |
|---|---|---|
| `"by cache" in content.lower()` | dropped (redundant — `?cache=default` / `?cache=local` follow on next lines) | Stronger asserts already prove the filter rendered |
| `"stream" in content.lower()` | `'type-stream">stream</span>' in content` | The `type-badge` span emitted by `change_form.html` |
| `"Raw" in content or "rawkey:test" in content` | `"rawkey:test" in content` | Kept the strong half |
| `"list" in content.lower()` | `'type-list">list</span>' in content` | Same `type-badge` markup |
| `"TTL" in content or "ttl" in content.lower()` | `'id="id_ttl"' in content` | The TTL form input id from `change_form.html` |
| `"No expiry" in content or "expiry" in content.lower() or "-1" in content` | `'placeholder="no expiry"' in content` | Template emits this placeholder when ttl is None |
| `"id_value" in content or "textarea" in content.lower()` | `'id="id_value"' in content` | Slightly tightened from the strong half |
| `"Keys" in content or "List" in content` (cache_detail keys link) | `"?cache=default" in content` + `"List Keys" in content` | Same pattern as #93's cache-list test |
| `"Slow Log" in content or "slow" in content.lower()` | `'<h2>Slow Log</h2>' in content` | `get_slowlog` always returns a dict so the section always renders |

## Out of scope

Action-button alternatives like `"Update" in content or "Save" in content` (test_views.py:883, 903, 1867, 1881, 1895, 1909) are left as-is. Those legitimately accommodate template-evolution flexibility for UI button labels — tightening would require freezing exact wording, which is the wrong tradeoff for those tests.

## Followup

The redundant per-test docstring sweep (138 `[D5]` candidates in `test_views.py` alone, plus more across `tests/cache/`) will be a separate PR. Large, mechanical, easier to review on its own.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `pytest tests/admin/test_views.py` — 140 passed

Refs: #86
