### PR TITLE
refactor: collapse serializer/compressor boilerplate into base classes (#86)

### DIFF
--- a/benchmarks/configs.py
+++ b/benchmarks/configs.py
@@ -106,7 +106,7 @@ COMPRESSOR_CONFIGS: tuple[CompressorConfig, ...] = (
     CompressorConfig(id="gzip", dotted_path="django_cachex.compressors.gzip.GzipCompressor"),
     CompressorConfig(id="lzma", dotted_path="django_cachex.compressors.lzma.LzmaCompressor"),
     CompressorConfig(id="lz4", dotted_path="django_cachex.compressors.lz4.Lz4Compressor"),
-    CompressorConfig(id="zstd", dotted_path="django_cachex.compressors.zstd.ZStdCompressor"),
+    CompressorConfig(id="zstd", dotted_path="django_cachex.compressors.zstd.ZstdCompressor"),
 )
 
 

--- a/django_cachex/compressors/__init__.py
+++ b/django_cachex/compressors/__init__.py
@@ -1,4 +1,3 @@
-# Compressors module
 from django_cachex.compressors.base import BaseCompressor
 
 __all__ = ["BaseCompressor"]

--- a/django_cachex/compressors/base.py
+++ b/django_cachex/compressors/base.py
@@ -2,21 +2,20 @@
 # Copyright (c) 2011-2016 Andrey Antukh <niwi@niwi.nz>
 # Copyright (c) 2011 Sean Bleier
 # Licensed under BSD-3-Clause
-#
-# django-redis was used as inspiration for this project.
 
-from typing import Any
+from django_cachex.exceptions import CompressorError
 
 
 class BaseCompressor:
     """Base class for cache value compressors.
 
-    Compression is skipped for values of ``min_length`` bytes or fewer.
+    Subclasses implement ``_compress`` and ``_decompress``. Compression is
+    skipped for values up to ``min_length`` bytes (boundary inclusive).
     """
 
     min_length: int = 256
 
-    def __init__(self, *, min_length: int | None = None, **kwargs: Any) -> None:
+    def __init__(self, *, min_length: int | None = None) -> None:
         if min_length is not None:
             self.min_length = min_length
 
@@ -25,8 +24,14 @@ class BaseCompressor:
             return self._compress(data)
         return data
 
+    def decompress(self, data: bytes) -> bytes:
+        try:
+            return self._decompress(data)
+        except Exception as e:
+            raise CompressorError from e
+
     def _compress(self, data: bytes) -> bytes:
         raise NotImplementedError
 
-    def decompress(self, data: bytes) -> bytes:
+    def _decompress(self, data: bytes) -> bytes:
         raise NotImplementedError

--- a/django_cachex/compressors/gzip.py
+++ b/django_cachex/compressors/gzip.py
@@ -2,22 +2,24 @@
 # Copyright (c) 2011-2016 Andrey Antukh <niwi@niwi.nz>
 # Copyright (c) 2011 Sean Bleier
 # Licensed under BSD-3-Clause
-#
-# django-redis was used as inspiration for this project. The code similarity
-# is somewhat coincidental given the minimal nature of wrapping gzip.
 
 import gzip
 
 from django_cachex.compressors.base import BaseCompressor
-from django_cachex.exceptions import CompressorError
 
 
 class GzipCompressor(BaseCompressor):
-    def _compress(self, data: bytes) -> bytes:
-        return gzip.compress(data)
+    """gzip compressor with configurable compression level."""
 
-    def decompress(self, data: bytes) -> bytes:
-        try:
-            return gzip.decompress(data)
-        except Exception as e:
-            raise CompressorError from e
+    level: int = 9
+
+    def __init__(self, *, level: int | None = None, min_length: int | None = None) -> None:
+        super().__init__(min_length=min_length)
+        if level is not None:
+            self.level = level
+
+    def _compress(self, data: bytes) -> bytes:
+        return gzip.compress(data, compresslevel=self.level)
+
+    def _decompress(self, data: bytes) -> bytes:
+        return gzip.decompress(data)

--- a/django_cachex/compressors/lz4.py
+++ b/django_cachex/compressors/lz4.py
@@ -1,15 +1,20 @@
 from lz4 import frame as lz4_frame
 
 from django_cachex.compressors.base import BaseCompressor
-from django_cachex.exceptions import CompressorError
 
 
 class Lz4Compressor(BaseCompressor):
-    def _compress(self, data: bytes) -> bytes:
-        return lz4_frame.compress(data)
+    """LZ4 compressor with configurable compression level."""
 
-    def decompress(self, data: bytes) -> bytes:
-        try:
-            return lz4_frame.decompress(data)
-        except Exception as e:
-            raise CompressorError from e
+    level: int = 0
+
+    def __init__(self, *, level: int | None = None, min_length: int | None = None) -> None:
+        super().__init__(min_length=min_length)
+        if level is not None:
+            self.level = level
+
+    def _compress(self, data: bytes) -> bytes:
+        return lz4_frame.compress(data, compression_level=self.level)
+
+    def _decompress(self, data: bytes) -> bytes:
+        return lz4_frame.decompress(data)

--- a/django_cachex/compressors/lzma.py
+++ b/django_cachex/compressors/lzma.py
@@ -1,25 +1,20 @@
 import lzma
-from typing import Any
 
 from django_cachex.compressors.base import BaseCompressor
-from django_cachex.exceptions import CompressorError
 
 
 class LzmaCompressor(BaseCompressor):
-    """LZMA compressor with configurable preset level."""
+    """LZMA compressor with configurable compression level (``preset`` in lzma terms)."""
 
-    preset: int = 4
+    level: int = 4
 
-    def __init__(self, *, preset: int | None = None, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-        if preset is not None:
-            self.preset = preset
+    def __init__(self, *, level: int | None = None, min_length: int | None = None) -> None:
+        super().__init__(min_length=min_length)
+        if level is not None:
+            self.level = level
 
     def _compress(self, data: bytes) -> bytes:
-        return lzma.compress(data, preset=self.preset)
+        return lzma.compress(data, preset=self.level)
 
-    def decompress(self, data: bytes) -> bytes:
-        try:
-            return lzma.decompress(data)
-        except Exception as e:
-            raise CompressorError from e
+    def _decompress(self, data: bytes) -> bytes:
+        return lzma.decompress(data)

--- a/django_cachex/compressors/zlib.py
+++ b/django_cachex/compressors/zlib.py
@@ -1,25 +1,20 @@
 import zlib
-from typing import Any
 
 from django_cachex.compressors.base import BaseCompressor
-from django_cachex.exceptions import CompressorError
 
 
 class ZlibCompressor(BaseCompressor):
-    """Zlib compressor with configurable compression level."""
+    """zlib compressor with configurable compression level."""
 
     level: int = 6
 
-    def __init__(self, *, level: int | None = None, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
+    def __init__(self, *, level: int | None = None, min_length: int | None = None) -> None:
+        super().__init__(min_length=min_length)
         if level is not None:
             self.level = level
 
     def _compress(self, data: bytes) -> bytes:
         return zlib.compress(data, self.level)
 
-    def decompress(self, data: bytes) -> bytes:
-        try:
-            return zlib.decompress(data)
-        except Exception as e:
-            raise CompressorError from e
+    def _decompress(self, data: bytes) -> bytes:
+        return zlib.decompress(data)

--- a/django_cachex/compressors/zstd.py
+++ b/django_cachex/compressors/zstd.py
@@ -1,15 +1,20 @@
 from compression import zstd
 
 from django_cachex.compressors.base import BaseCompressor
-from django_cachex.exceptions import CompressorError
 
 
-class ZStdCompressor(BaseCompressor):
+class ZstdCompressor(BaseCompressor):
+    """Zstandard compressor with configurable compression level."""
+
+    level: int = 3
+
+    def __init__(self, *, level: int | None = None, min_length: int | None = None) -> None:
+        super().__init__(min_length=min_length)
+        if level is not None:
+            self.level = level
+
     def _compress(self, data: bytes) -> bytes:
-        return zstd.compress(data)
+        return zstd.compress(data, level=self.level)
 
-    def decompress(self, data: bytes) -> bytes:
-        try:
-            return zstd.decompress(data)
-        except Exception as e:
-            raise CompressorError from e
+    def _decompress(self, data: bytes) -> bytes:
+        return zstd.decompress(data)

--- a/django_cachex/serializers/__init__.py
+++ b/django_cachex/serializers/__init__.py
@@ -1,4 +1,3 @@
-# Serializers module
 from django_cachex.serializers.base import BaseSerializer
 
 __all__ = ["BaseSerializer"]

--- a/django_cachex/serializers/base.py
+++ b/django_cachex/serializers/base.py
@@ -2,23 +2,35 @@
 # Copyright (c) 2011-2016 Andrey Antukh <niwi@niwi.nz>
 # Copyright (c) 2011 Sean Bleier
 # Licensed under BSD-3-Clause
-#
-# django-redis was used as inspiration for this project.
 
 from typing import Any
+
+from django_cachex.exceptions import SerializerError
 
 
 class BaseSerializer:
     """Base class for cache value serializers.
 
-    Duck-type compatible with Django's RedisSerializer (dumps/loads interface).
+    Subclasses implement ``_dumps`` and ``_loads``. Plain ints pass through
+    ``loads`` unchanged so Redis ``INCR`` results don't need re-decoding.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        pass
-
-    def dumps(self, obj: Any) -> bytes | int:
-        raise NotImplementedError
+    def dumps(self, obj: Any) -> bytes:
+        try:
+            return self._dumps(obj)
+        except Exception as e:
+            raise SerializerError from e
 
     def loads(self, data: bytes | int) -> Any:
+        if isinstance(data, int):
+            return data
+        try:
+            return self._loads(data)
+        except Exception as e:
+            raise SerializerError from e
+
+    def _dumps(self, obj: Any) -> bytes:
+        raise NotImplementedError
+
+    def _loads(self, data: bytes) -> Any:
         raise NotImplementedError

--- a/django_cachex/serializers/json.py
+++ b/django_cachex/serializers/json.py
@@ -2,33 +2,22 @@
 # Copyright (c) 2011-2016 Andrey Antukh <niwi@niwi.nz>
 # Copyright (c) 2011 Sean Bleier
 # Licensed under BSD-3-Clause
-#
-# django-redis was used as inspiration for this project.
 
 import json
 from typing import Any
 
 from django.core.serializers.json import DjangoJSONEncoder
 
-from django_cachex.exceptions import SerializerError
 from django_cachex.serializers.base import BaseSerializer
 
 
 class JSONSerializer(BaseSerializer):
-    """JSON-based serializer using Django's DjangoJSONEncoder."""
+    """JSON serializer using ``DjangoJSONEncoder`` (handles datetime, UUID, etc.)."""
 
     encoder_class = DjangoJSONEncoder
 
-    def dumps(self, obj: Any) -> bytes | int:
-        try:
-            return json.dumps(obj, cls=self.encoder_class).encode()
-        except (TypeError, ValueError, OverflowError) as e:
-            raise SerializerError from e
+    def _dumps(self, obj: Any) -> bytes:
+        return json.dumps(obj, cls=self.encoder_class).encode()
 
-    def loads(self, data: bytes | int) -> Any:
-        try:
-            if isinstance(data, int):
-                return data
-            return json.loads(data.decode())
-        except (json.JSONDecodeError, UnicodeDecodeError) as e:
-            raise SerializerError from e
+    def _loads(self, data: bytes) -> Any:
+        return json.loads(data.decode())

--- a/django_cachex/serializers/msgpack.py
+++ b/django_cachex/serializers/msgpack.py
@@ -2,31 +2,19 @@
 # Copyright (c) 2011-2016 Andrey Antukh <niwi@niwi.nz>
 # Copyright (c) 2011 Sean Bleier
 # Licensed under BSD-3-Clause
-#
-# django-redis was used as inspiration for this project. The code similarity
-# is somewhat coincidental given the minimal nature of wrapping msgpack.
 
 from typing import Any
 
 import msgpack
 
-from django_cachex.exceptions import SerializerError
 from django_cachex.serializers.base import BaseSerializer
 
 
 class MessagePackSerializer(BaseSerializer):
     """MessagePack-based serializer for efficient binary serialization."""
 
-    def dumps(self, obj: Any) -> bytes | int:
-        try:
-            return msgpack.dumps(obj)
-        except Exception as e:
-            raise SerializerError from e
+    def _dumps(self, obj: Any) -> bytes:
+        return msgpack.dumps(obj)
 
-    def loads(self, data: bytes | int) -> Any:
-        try:
-            if isinstance(data, int):
-                return data
-            return msgpack.loads(data, raw=False, strict_map_key=False)
-        except Exception as e:
-            raise SerializerError from e
+    def _loads(self, data: bytes) -> Any:
+        return msgpack.loads(data, raw=False, strict_map_key=False)

--- a/django_cachex/serializers/orjson.py
+++ b/django_cachex/serializers/orjson.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import orjson
 
-from django_cachex.exceptions import SerializerError
 from django_cachex.serializers.base import BaseSerializer
 
 
@@ -10,19 +9,11 @@ class OrjsonSerializer(BaseSerializer):
     """JSON serializer backed by orjson (Rust).
 
     Natively serializes datetime, date, UUID, dataclasses, and enums.
-    Decimal and other arbitrary types raise SerializerError unless caller pre-converts.
+    Other arbitrary types raise ``SerializerError`` on dumps.
     """
 
-    def dumps(self, obj: Any) -> bytes | int:
-        try:
-            return orjson.dumps(obj)
-        except Exception as e:
-            raise SerializerError from e
+    def _dumps(self, obj: Any) -> bytes:
+        return orjson.dumps(obj)
 
-    def loads(self, data: bytes | int) -> Any:
-        try:
-            if isinstance(data, int):
-                return data
-            return orjson.loads(data)
-        except Exception as e:
-            raise SerializerError from e
+    def _loads(self, data: bytes) -> Any:
+        return orjson.loads(data)

--- a/django_cachex/serializers/ormsgpack.py
+++ b/django_cachex/serializers/ormsgpack.py
@@ -2,23 +2,14 @@ from typing import Any
 
 import ormsgpack
 
-from django_cachex.exceptions import SerializerError
 from django_cachex.serializers.base import BaseSerializer
 
 
 class OrMessagePackSerializer(BaseSerializer):
     """MessagePack serializer backed by ormsgpack (Rust)."""
 
-    def dumps(self, obj: Any) -> bytes | int:
-        try:
-            return ormsgpack.packb(obj)
-        except Exception as e:
-            raise SerializerError from e
+    def _dumps(self, obj: Any) -> bytes:
+        return ormsgpack.packb(obj)
 
-    def loads(self, data: bytes | int) -> Any:
-        try:
-            if isinstance(data, int):
-                return data
-            return ormsgpack.unpackb(data)
-        except Exception as e:
-            raise SerializerError from e
+    def _loads(self, data: bytes) -> Any:
+        return ormsgpack.unpackb(data)

--- a/django_cachex/serializers/pickle.py
+++ b/django_cachex/serializers/pickle.py
@@ -1,34 +1,17 @@
 import pickle
 from typing import Any
 
-from django.core.exceptions import ImproperlyConfigured
-
-from django_cachex.exceptions import SerializerError
 from django_cachex.serializers.base import BaseSerializer
 
 
 class PickleSerializer(BaseSerializer):
     """Pickle-based serializer matching Django's RedisSerializer interface."""
 
-    def __init__(self, *, protocol: int | None = None, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
+    def __init__(self, *, protocol: int | None = None) -> None:
+        self.protocol = protocol if protocol is not None else pickle.DEFAULT_PROTOCOL
 
-        if protocol is None:
-            protocol = pickle.DEFAULT_PROTOCOL
-
-        if protocol > pickle.HIGHEST_PROTOCOL:
-            msg = f"protocol can't be higher than pickle.HIGHEST_PROTOCOL: {pickle.HIGHEST_PROTOCOL}"
-            raise ImproperlyConfigured(msg)
-
-        self.protocol = protocol
-
-    def dumps(self, obj: Any) -> bytes | int:
+    def _dumps(self, obj: Any) -> bytes:
         return pickle.dumps(obj, self.protocol)
 
-    def loads(self, data: bytes | int) -> Any:
-        try:
-            if isinstance(data, int):
-                return data
-            return pickle.loads(data)  # noqa: S301
-        except Exception as e:
-            raise SerializerError from e
+    def _loads(self, data: bytes) -> Any:
+        return pickle.loads(data)  # noqa: S301

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -9,6 +9,9 @@
 - **`SyncCache` wire format changed.** Stream entries now flow through the transport's serializer + compressor pipeline instead of raw pickle. Pods running the new code cannot read entries written by older pods on the same stream — coordinate the rollout (drain or rotate `STREAM_KEY`).
 - **`hmset` removed.** Use `hset(key, mapping=...)` or `hset(key, items=...)` (flat key-value list, matching redis-py/valkey-py).
 - **`django_cachex.unfold` removed.** The django-unfold theme variant of the admin is gone, along with the `[unfold]` extra and `examples/unfold/`. Plain `django_cachex.admin` remains. Unfold support may return as a thin theme override once the core admin app stabilises.
+- **`ZStdCompressor` renamed to `ZstdCompressor`** (`django_cachex.compressors.zstd.ZstdCompressor`). Update `OPTIONS["compressor"]` strings.
+- **`LzmaCompressor` constructor `preset=` renamed to `level=`** for consistency with the other compressors. All compressors now accept `level=` (mapped to the underlying library's native parameter).
+- **`PickleSerializer` no longer raises `ImproperlyConfigured` for `protocol > pickle.HIGHEST_PROTOCOL`**; pickle's own `ValueError` propagates at first dumps call (wrapped as `SerializerError`).
 
 ### New features
 
@@ -22,6 +25,8 @@
 - **PyPI wheels via cibuildwheel.** Manylinux x86_64 wheels for cp314 and cp314t.
 - **Async pool sharing.** A single async connection pool is shared across per-task `Cache` instances (#83), avoiding the thundering-herd reconnect on cold start.
 - **Pipeline parity.** Stream ops, CAS ops, missing key ops (`persist`/`pttl`/`expire_at`/etc.), context manager, `zpopmin`/`zpopmax` default `count=1` aligned with the cache API.
+- **Compressors gain a uniform `level=` parameter** (gzip, lz4, zstd join zlib/lzma in exposing it). Defaults match each library's own default.
+- **Serializer/compressor wrappers consolidated.** Subclasses now implement `_dumps`/`_loads` (serializers) or `_compress`/`_decompress` (compressors); the base classes wrap the boilerplate (`SerializerError` / `CompressorError` translation, int-passthrough on loads).
 
 ### Fixes
 

--- a/docs/user-guide/compression.md
+++ b/docs/user-guide/compression.md
@@ -10,7 +10,7 @@ CACHES = {
         "BACKEND": "django_cachex.cache.ValkeyCache",
         "LOCATION": "valkey://127.0.0.1:6379/1",
         "OPTIONS": {
-            "compressor": "django_cachex.compressors.zstd.ZStdCompressor",
+            "compressor": "django_cachex.compressors.zstd.ZstdCompressor",
         }
     }
 }
@@ -24,7 +24,7 @@ CACHES = {
 | `django_cachex.compressors.gzip.GzipCompressor` | — (stdlib) |
 | `django_cachex.compressors.lzma.LzmaCompressor` | — (stdlib) |
 | `django_cachex.compressors.lz4.Lz4Compressor` | `lz4` |
-| `django_cachex.compressors.zstd.ZStdCompressor` | `zstd` (Python < 3.14) |
+| `django_cachex.compressors.zstd.ZstdCompressor` | `zstd` (Python < 3.14) |
 
 Install optional dependencies:
 
@@ -86,7 +86,7 @@ Specify a list of compressors to safely migrate between formats. The first is us
 ```python
 "OPTIONS": {
     "compressor": [
-        "django_cachex.compressors.zstd.ZStdCompressor",  # Write with new format
+        "django_cachex.compressors.zstd.ZstdCompressor",  # Write with new format
         "django_cachex.compressors.gzip.GzipCompressor",  # Read old format
     ],
 }

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -124,11 +124,11 @@ Available serializers:
 ```python
 "OPTIONS": {
     # Single compressor
-    "compressor": "django_cachex.compressors.zstd.ZStdCompressor",
+    "compressor": "django_cachex.compressors.zstd.ZstdCompressor",
 
     # Or with fallback for migration
     "compressor": [
-        "django_cachex.compressors.zstd.ZStdCompressor",  # Write
+        "django_cachex.compressors.zstd.ZstdCompressor",  # Write
         "django_cachex.compressors.zlib.ZlibCompressor",  # Fallback read
     ],
 }
@@ -142,7 +142,7 @@ Available compressors:
 | `django_cachex.compressors.gzip.GzipCompressor` | gzip compression |
 | `django_cachex.compressors.lz4.Lz4Compressor` | LZ4 (requires lz4) |
 | `django_cachex.compressors.lzma.LzmaCompressor` | LZMA |
-| `django_cachex.compressors.zstd.ZStdCompressor` | Zstandard (requires zstd) |
+| `django_cachex.compressors.zstd.ZstdCompressor` | Zstandard (requires zstd) |
 
 Compression is only applied to values larger than `min_length` bytes (default: 256).
 
@@ -351,7 +351,7 @@ CACHES = {
             "serializer": "django_cachex.serializers.pickle.PickleSerializer",
 
             # Compression
-            "compressor": "django_cachex.compressors.zstd.ZStdCompressor",
+            "compressor": "django_cachex.compressors.zstd.ZstdCompressor",
 
             # Connection pool
             "max_connections": 50,

--- a/tests/cache/test_compressors.py
+++ b/tests/cache/test_compressors.py
@@ -6,7 +6,7 @@ from django_cachex.compressors.gzip import GzipCompressor
 from django_cachex.compressors.lz4 import Lz4Compressor
 from django_cachex.compressors.lzma import LzmaCompressor
 from django_cachex.compressors.zlib import ZlibCompressor
-from django_cachex.compressors.zstd import ZStdCompressor
+from django_cachex.compressors.zstd import ZstdCompressor
 from django_cachex.exceptions import CompressorError
 
 ALL_COMPRESSORS = [
@@ -14,7 +14,7 @@ ALL_COMPRESSORS = [
     Lz4Compressor,
     LzmaCompressor,
     ZlibCompressor,
-    ZStdCompressor,
+    ZstdCompressor,
 ]
 
 
@@ -90,3 +90,15 @@ class TestDecompressErrors:
     def test_invalid_data_raises_error(self, compressor):
         with pytest.raises(CompressorError):
             compressor.decompress(b"this is not compressed data!!")
+
+
+class TestCompressionLevel:
+    """Each compressor accepts a `level=` constructor arg."""
+
+    def test_custom_level(self, compressor):
+        cls = type(compressor)
+        custom = cls(level=1)
+        assert custom.level == 1
+        # Roundtrip still works at custom level.
+        data = b"abcdefghij" * 100
+        assert custom.decompress(custom.compress(data)) == data

--- a/tests/cache/test_serializers.py
+++ b/tests/cache/test_serializers.py
@@ -1,7 +1,6 @@
 import pickle
 
 import pytest
-from django.core.exceptions import ImproperlyConfigured
 
 from django_cachex.exceptions import SerializerError
 from django_cachex.serializers.json import JSONSerializer
@@ -37,16 +36,15 @@ class TestPickleSerializer:
         serializer = PickleSerializer()
         assert serializer.protocol == pickle.DEFAULT_PROTOCOL
 
-    def test_protocol_too_high(self):
-        with pytest.raises(
-            ImproperlyConfigured,
-            match=f"protocol can't be higher than pickle.HIGHEST_PROTOCOL: {pickle.HIGHEST_PROTOCOL}",
-        ):
-            PickleSerializer(protocol=pickle.HIGHEST_PROTOCOL + 1)
-
     def test_protocol_explicit(self):
         serializer = PickleSerializer(protocol=4)
         assert serializer.protocol == 4
+
+    def test_protocol_too_high_raises_on_dumps(self):
+        # We no longer pre-validate; pickle itself raises at dumps time.
+        serializer = PickleSerializer(protocol=pickle.HIGHEST_PROTOCOL + 1)
+        with pytest.raises(SerializerError):
+            serializer.dumps({"x": 1})
 
 
 class TestMessagePackSerializer:

--- a/tests/fixtures/cache.py
+++ b/tests/fixtures/cache.py
@@ -18,7 +18,7 @@ COMPRESSORS = {
     "lz4": "django_cachex.compressors.lz4.Lz4Compressor",
     "lzma": "django_cachex.compressors.lzma.LzmaCompressor",
     "zlib": "django_cachex.compressors.zlib.ZlibCompressor",
-    "zstd": "django_cachex.compressors.zstd.ZStdCompressor",
+    "zstd": "django_cachex.compressors.zstd.ZstdCompressor",
 }
 
 # Available serializers (None means default pickle)


### PR DESCRIPTION
## Summary

Folds the duplicated wrapping logic across the seven compressors and five serializers into their respective base classes, plus drops the AI-style mannerisms and inconsistencies flagged in #86.

### Compressors
- New `_decompress` hook on `BaseCompressor`; the `try/except → CompressorError` wrapper lives in the base, not in every subclass.
- Uniform `level=` constructor param across **gzip, lz4, lzma, zlib, zstd** (mapped to each lib's native parameter name). `LzmaCompressor.preset` is renamed to `level` for consistency.
- `ZStdCompressor` → `ZstdCompressor` (fixtures, benchmarks, and docs updated).
- Dropped `**kwargs: Any` swallow on base + subclasses; trimmed AI-style preamble comments; added missing class docstrings on lz4/zstd.

### Serializers
- New `_dumps`/`_loads` hooks on `BaseSerializer`; the int-passthrough + `try/except → SerializerError` wrapping lives in the base, not in every subclass.
- Narrowed `dumps` return type to `bytes` (no concrete serializer ever returned `int`). `loads(bytes | int)` kept since that's the documented + tested public contract.
- Dropped `PickleSerializer.protocol` pre-validation and `**kwargs`; pickle raises naturally and the base wraps as `SerializerError`.
- Trimmed AI-style preambles.

### Breaking changes (changelog updated)
- `ZStdCompressor` → `ZstdCompressor` — update `OPTIONS["compressor"]` strings.
- `LzmaCompressor(preset=...)` → `LzmaCompressor(level=...)`.
- `PickleSerializer` no longer raises `ImproperlyConfigured` for too-high protocol; pickle's own `ValueError` propagates at first dumps call (wrapped as `SerializerError`).

Net -26 LoC.

## Test plan
- [x] Full cache suite — 7529 passed, 245 skipped
- [x] `ruff check` / `ruff format --check`
- [x] `mypy django_cachex/`
- [x] `ty check django_cachex/`
- [x] Targeted: `tests/cache/test_serializers.py`, `tests/cache/test_compressors.py`, `tests/cache/test_serializer_fallback.py`, `tests/cache/test_compressor_fallback.py`

Closes parts of #86 (Serializers + Compressors review areas).