### PR TITLE
test: remove 338 redundant per-test docstrings (D5 sweep)

### DIFF
--- a/tests/admin/test_cas.py
+++ b/tests/admin/test_cas.py
@@ -129,7 +129,6 @@ class TestCASStringUpdate:
         assert result == -1
 
     def test_complex_value(self, test_cache: KeyValueCache):
-        """Test CAS with a complex JSON-serializable value."""
         original = {"key": "value", "nested": [1, 2, 3]}
         test_cache.set("cas_complex", original)
         sha1 = get_string_sha1(test_cache, "cas_complex")

--- a/tests/admin/test_views.py
+++ b/tests/admin/test_views.py
@@ -63,7 +63,6 @@ class TestIndexView:
         assert response.status_code == 200
 
     def test_index_shows_configured_caches(self, admin_client: Client, test_cache):
-        """Index view should list all configured caches."""
         url = _cache_list_url()
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -79,13 +78,11 @@ class TestIndexView:
         assert response.status_code == 302
 
     def test_index_help_button(self, admin_client: Client, test_cache):
-        """Help button should show help message."""
         url = _cache_list_url()
         response = admin_client.get(url + "?help=1")
         assert response.status_code == 200
 
     def test_index_page_title(self, admin_client: Client, test_cache):
-        """Index view should have correct page title."""
         url = _cache_list_url()
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -140,7 +137,6 @@ class TestIndexView:
         )
 
     def test_index_shows_location_column(self, admin_client: Client, test_cache):
-        """Index view should show cache location in the cache table."""
         from bs4 import BeautifulSoup
 
         url = _cache_list_url()
@@ -167,7 +163,6 @@ class TestIndexView:
         ), f"Cache location not found in cache table: {table_text[:200]}"
 
     def test_index_cache_links_to_keys(self, admin_client: Client, test_cache):
-        """Cache list should have links to key browser."""
         url = _cache_list_url()
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -177,7 +172,6 @@ class TestIndexView:
         assert "List Keys" in content
 
     def test_index_search_filters_caches(self, admin_client: Client, test_cache):
-        """Search should filter cache list by name."""
         url = _cache_list_url()
         # Search for "default" - should show default, hide others
         response = admin_client.get(url + "?q=default")
@@ -206,7 +200,6 @@ class TestKeyListView:
         assert response.status_code == 302
 
     def test_key_list_page_title(self, admin_client: Client, test_cache):
-        """Key search view should have correct page title."""
         url = _key_list_url("default")
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -215,7 +208,6 @@ class TestKeyListView:
         assert b"default" in response.content
 
     def test_key_list_has_help_and_add_links(self, admin_client: Client, test_cache):
-        """Key search view should have help and add key links."""
         url = _key_list_url("default")
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -230,7 +222,6 @@ class TestKeyListView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Bulk delete action should delete selected keys."""
         test_cache.set("bulk:delete:1", "value1")
         test_cache.set("bulk:delete:2", "value2")
         test_cache.set("bulk:keep", "value3")
@@ -259,7 +250,6 @@ class TestKeyListView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key search should show string keys."""
         test_cache.set("test:key1", "value1")
         test_cache.set("test:key2", "value2")
 
@@ -274,7 +264,6 @@ class TestKeyListView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key search with empty pattern should list all keys."""
         test_cache.set("mykey", "myvalue")
 
         url = _key_list_url("default")
@@ -319,7 +308,6 @@ class TestKeyListView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key search should show TTL column."""
         test_cache.set("ttl:column:test", "value", timeout=300)
 
         url = _key_list_url("default")
@@ -365,7 +353,6 @@ class TestKeyListView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key search should support wildcard patterns."""
         test_cache.set("wild:card:one", "value1")
         test_cache.set("wild:card:two", "value2")
         test_cache.set("other:key", "value3")
@@ -408,7 +395,6 @@ class TestKeyListView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key search should paginate results."""
         # Create enough keys to trigger pagination (default is usually 100)
         for i in range(150):
             test_cache.set(f"paginate:key:{i:03d}", f"value{i}")
@@ -425,7 +411,6 @@ class TestKeyListView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key search should show results count."""
         test_cache.set("count:key:1", "value1")
         test_cache.set("count:key:2", "value2")
         test_cache.set("count:key:3", "value3")
@@ -460,7 +445,6 @@ class TestKeyListView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Cache filter should render when multiple caches are configured."""
         url = _key_list_url("default")
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -474,7 +458,6 @@ class TestKeyListView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Selecting a different cache in the filter should switch the view."""
         from django.core.cache import caches
 
         caches["local"].set("localonly:key", "localvalue")
@@ -507,7 +490,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Detail view should work for string keys."""
         test_cache.set("string:test", "hello world")
 
         url = _key_detail_url("default", "string:test")
@@ -533,7 +515,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Detail view should work for Redis list keys."""
         test_cache.lpush("list:test", "item1", "item2", "item3")
 
         url = _key_detail_url("default", "list:test")
@@ -547,7 +528,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Detail view should work for Redis set keys."""
         test_cache.sadd("set:test", "member1", "member2", "member3")
 
         url = _key_detail_url("default", "set:test")
@@ -560,7 +540,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Detail view should work for Redis hash keys."""
         test_cache.hset("hash:test", "field1", "value1")
         test_cache.hset("hash:test", "field2", "value2")
 
@@ -574,7 +553,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Detail view should work for Redis sorted set keys."""
         test_cache.zadd("zset:test", {"member1": 1.0, "member2": 2.0})
 
         url = _key_detail_url("default", "zset:test")
@@ -595,7 +573,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Detail view should work for Redis stream keys."""
         test_cache.xadd("stream:detail:test", {"field1": "value1"})
         test_cache.xadd("stream:detail:test", {"field2": "value2"})
 
@@ -618,7 +595,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key detail view should have correct page title."""
         test_cache.set("title:test", "value")
 
         url = _key_detail_url("default", "title:test")
@@ -645,7 +621,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key detail should show the raw Redis key."""
         test_cache.set("rawkey:test", "value")
 
         url = _key_detail_url("default", "rawkey:test")
@@ -660,7 +635,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key detail should show the cache name."""
         test_cache.set("cache:name:test", "value")
 
         url = _key_detail_url("default", "cache:name:test")
@@ -675,7 +649,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key detail should show type badge for the key."""
         test_cache.rpush("type:badge:test", "item1", "item2", "item3")
 
         url = _key_detail_url("default", "type:badge:test")
@@ -692,7 +665,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key detail should show TTL for expiring keys."""
         test_cache.set("ttl:detail:test", "value", timeout=300)
 
         url = _key_detail_url("default", "ttl:detail:test")
@@ -707,7 +679,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Key detail should show 'No expiry' for persistent keys."""
         test_cache.set("noexpiry:test", "value", timeout=None)
 
         url = _key_detail_url("default", "noexpiry:test")
@@ -723,7 +694,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """String key detail view should have properly structured save form."""
         test_cache.set("form:structure:test", "original value")
 
         url = _key_detail_url("default", "form:structure:test")
@@ -742,7 +712,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Save button on string key detail should update the value."""
         test_cache.set("save:button:test", "original value")
 
         url = _key_detail_url("default", "save:button:test")
@@ -763,7 +732,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """TTL input for keys should have its own form with set_ttl action."""
         test_cache.set("ttl:form:test", "value", timeout=300)
 
         url = _key_detail_url("default", "ttl:form:test")
@@ -824,7 +792,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Updating TTL on list key should set the expiry."""
         test_cache.rpush("list:ttl:test", "item1", "item2")
 
         url = _key_detail_url("default", "list:ttl:test")
@@ -846,7 +813,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Submitting empty TTL on list key should persist (no expiry)."""
         test_cache.rpush("list:persist:test", "item1")
         # Set an initial TTL
         test_cache.expire("list:persist:test", 300)
@@ -869,7 +835,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """JSON-serializable string should show JSON indicator and be editable."""
         test_cache.set("json:string:test", "hello world")
 
         url = _key_detail_url("default", "json:string:test")
@@ -887,7 +852,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """JSON-serializable dict should show JSON indicator and be editable."""
         test_cache.set("json:dict:test", {"name": "Alice", "age": 30})
 
         url = _key_detail_url("default", "json:dict:test")
@@ -907,7 +871,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """JSON-serializable list value should be editable."""
         test_cache.set("json:list:value:test", [1, 2, 3, "four"])
 
         url = _key_detail_url("default", "json:list:value:test")
@@ -925,7 +888,6 @@ class TestKeyDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """JSON indicator should be shown for dict values."""
         test_cache.set("json:indicator:test", {"type": "example"})
 
         url = _key_detail_url("default", "json:indicator:test")
@@ -941,7 +903,6 @@ class TestKeyAddView:
     """Tests for the add key view."""
 
     def test_add_key_get(self, admin_client: Client, test_cache):
-        """Add key view GET should return form."""
         url = _key_add_url("default")
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -954,7 +915,6 @@ class TestKeyAddView:
         assert response.status_code == 302
 
     def test_add_key_page_title(self, admin_client: Client, test_cache):
-        """Add key view should have correct page title."""
         url = _key_add_url("default")
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -973,7 +933,6 @@ class TestKeyAddView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Add key with timeout should create expiring key."""
         # Create string key via key_detail update action
         url = _key_detail_create_url("default", "timeout:test:key", "string")
         response = admin_client.post(
@@ -1029,7 +988,6 @@ class TestKeyAddView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Add key view should parse JSON values."""
         # Create string key via key_detail update action
         url = _key_detail_create_url("default", "new:json:key", "string")
         response = admin_client.post(
@@ -1169,7 +1127,6 @@ class TestKeyOperations:
     """Tests for key operations (delete, edit, TTL)."""
 
     def test_delete_key(self, admin_client: Client, test_cache: KeyValueCache):
-        """Delete action should remove key."""
         test_cache.set("delete:me", "goodbye")
 
         url = _key_detail_url("default", "delete:me")
@@ -1184,7 +1141,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Edit action should update key value."""
         test_cache.set("edit:me", "old value")
 
         url = _key_detail_url("default", "edit:me")
@@ -1202,7 +1158,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """LREM action should remove item from list."""
         test_cache.rpush("lrem:test", "item1", "item2", "item3", "item2")
 
         url = _key_detail_url("default", "lrem:test")
@@ -1221,7 +1176,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """LTRIM action should trim list to specified range."""
         test_cache.rpush("ltrim:test", "a", "b", "c", "d", "e")
 
         url = _key_detail_url("default", "ltrim:test")
@@ -1240,7 +1194,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """HSET action should update hash field value inline."""
         test_cache.hset("hash:edit", "name", "old_value")
 
         url = _key_detail_url("default", "hash:edit")
@@ -1281,7 +1234,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """LPOP action should pop from left of list."""
         test_cache.rpush("lpop:test", "a", "b", "c")
 
         url = _key_detail_url("default", "lpop:test")
@@ -1297,7 +1249,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """LPOP action with count should pop multiple elements from left."""
         test_cache.rpush("lpop:count:test", "a", "b", "c", "d", "e")
 
         url = _key_detail_url("default", "lpop:count:test")
@@ -1316,7 +1267,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """RPOP action should pop from right of list."""
         test_cache.rpush("rpop:test", "a", "b", "c")
 
         url = _key_detail_url("default", "rpop:test")
@@ -1332,7 +1282,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """RPOP action with count should pop multiple elements from right."""
         test_cache.rpush("rpop:count:test", "a", "b", "c", "d", "e")
 
         url = _key_detail_url("default", "rpop:count:test")
@@ -1351,7 +1300,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """LPUSH action should push to left of list."""
         test_cache.rpush("lpush:test", "b", "c")
 
         url = _key_detail_url("default", "lpush:test")
@@ -1370,7 +1318,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """RPUSH action should push to right of list."""
         test_cache.rpush("rpush:test", "a", "b")
 
         url = _key_detail_url("default", "rpush:test")
@@ -1389,7 +1336,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """SADD action should add member to set."""
         test_cache.sadd("sadd:test", "a", "b")
 
         url = _key_detail_url("default", "sadd:test")
@@ -1408,7 +1354,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """SREM action should remove member from set."""
         test_cache.sadd("srem:test", "a", "b", "c")
 
         url = _key_detail_url("default", "srem:test")
@@ -1427,7 +1372,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """SPOP action should pop random member from set."""
         test_cache.sadd("spop:test", "only_member")
 
         url = _key_detail_url("default", "spop:test")
@@ -1443,7 +1387,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """SPOP action with count should pop multiple random members."""
         test_cache.sadd("spop:count:test", "a", "b", "c", "d", "e")
 
         url = _key_detail_url("default", "spop:count:test")
@@ -1605,7 +1548,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """ZREM action should remove member from sorted set."""
         test_cache.zadd("zrem:test", {"a": 1.0, "b": 2.0, "c": 3.0})
 
         url = _key_detail_url("default", "zrem:test")
@@ -1624,7 +1566,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """ZPOPMIN action should pop member with lowest score."""
         test_cache.zadd("zpopmin:test", {"a": 1.0, "b": 2.0, "c": 3.0})
 
         url = _key_detail_url("default", "zpopmin:test")
@@ -1640,7 +1581,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """ZPOPMAX action should pop member with highest score."""
         test_cache.zadd("zpopmax:test", {"a": 1.0, "b": 2.0, "c": 3.0})
 
         url = _key_detail_url("default", "zpopmax:test")
@@ -1656,7 +1596,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """ZADD action should update score for existing member."""
         test_cache.zadd("zscore:test", {"a": 1.0, "b": 2.0})
 
         url = _key_detail_url("default", "zscore:test")
@@ -1675,7 +1614,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Set TTL action should set expiration time."""
         test_cache.set("ttl:test", "value")
 
         url = _key_detail_url("default", "ttl:test")
@@ -1694,7 +1632,6 @@ class TestKeyOperations:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Persist action should remove TTL."""
         test_cache.set("persist:test", "value", timeout=300)
 
         url = _key_detail_url("default", "persist:test")
@@ -1791,7 +1728,6 @@ class TestFlushCache:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Flush action should clear all keys."""
         test_cache.set("flush:key1", "value1")
         test_cache.set("flush:key2", "value2")
 
@@ -1829,7 +1765,6 @@ class TestKeyDetailCreateMode:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Create mode should show informational message about key not existing."""
         url = _key_detail_create_url("default", "newkey:message", "list")
         response = admin_client.get(url)
 
@@ -1843,7 +1778,6 @@ class TestKeyDetailCreateMode:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Create mode should show Operations section for adding data."""
         url = _key_detail_create_url("default", "newkey:ops", "list")
         response = admin_client.get(url)
 
@@ -1857,7 +1791,6 @@ class TestKeyDetailCreateMode:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Create mode for list should show push operations."""
         url = _key_detail_create_url("default", "newkey:list:push", "list")
         response = admin_client.get(url)
 
@@ -1871,7 +1804,6 @@ class TestKeyDetailCreateMode:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Create mode for set should show add member operation."""
         url = _key_detail_create_url("default", "newkey:set:add", "set")
         response = admin_client.get(url)
 
@@ -1885,7 +1817,6 @@ class TestKeyDetailCreateMode:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Create mode for hash should show set field operation."""
         url = _key_detail_create_url("default", "newkey:hash:set", "hash")
         response = admin_client.get(url)
 
@@ -1899,7 +1830,6 @@ class TestKeyDetailCreateMode:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Create mode for zset should show add member operation."""
         url = _key_detail_create_url("default", "newkey:zset:add", "zset")
         response = admin_client.get(url)
 
@@ -1913,7 +1843,6 @@ class TestKeyDetailCreateMode:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Create mode for string should show value editor."""
         url = _key_detail_create_url("default", "newkey:string:edit", "string")
         response = admin_client.get(url)
 
@@ -1927,7 +1856,6 @@ class TestKeyDetailCreateMode:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Performing operation in create mode should create the key."""
         # Make sure key doesn't exist
         assert test_cache.get("createkey:list") is None
 
@@ -2001,7 +1929,6 @@ class TestCacheDetailView:
         assert response.status_code == 302
 
     def test_cache_detail_shows_cache_name(self, admin_client: Client, test_cache):
-        """Cache detail view should show cache name."""
         url = _cache_detail_url("default")
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -2012,7 +1939,6 @@ class TestCacheDetailView:
         admin_client: Client,
         test_cache: KeyValueCache,
     ):
-        """Cache detail view should display cache configuration."""
         url = _cache_detail_url("default")
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -2024,7 +1950,6 @@ class TestCacheDetailView:
         assert b"Configuration" in response.content
 
     def test_cache_detail_has_keys_link(self, admin_client: Client, test_cache):
-        """Cache detail view should have link to keys list."""
         url = _cache_detail_url("default")
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -2034,7 +1959,6 @@ class TestCacheDetailView:
         assert "List Keys" in content
 
     def test_cache_detail_shows_slowlog_section(self, admin_client: Client, test_cache):
-        """Cache detail view should show slow log section."""
         url = _cache_detail_url("default")
         response = admin_client.get(url)
         assert response.status_code == 200
@@ -2044,7 +1968,6 @@ class TestCacheDetailView:
         assert "<h2>Slow Log</h2>" in content
 
     def test_cache_detail_count_parameter(self, admin_client: Client, test_cache):
-        """Cache detail view should accept count parameter for slowlog."""
         url = _cache_detail_url("default")
         # Test with different count values
         for count in [10, 25, 50]:
@@ -2093,7 +2016,6 @@ class TestCacheAdmin:
         assert cache_admin.has_delete_permission(request) is False
 
     def test_non_staff_has_no_permissions(self, db, test_cache):
-        """Non-staff users should not have view/change/module permissions."""
         from django.contrib.admin import site
         from django.contrib.auth.models import User
         from django.test import RequestFactory
@@ -2117,7 +2039,6 @@ class TestCacheAdmin:
         assert cache_admin.has_module_permission(request) is False
 
     def test_superuser_has_all_permissions(self, admin_user, test_cache):
-        """Superusers should have view/change/module permissions."""
         from django.contrib.admin import site
         from django.test import RequestFactory
 
@@ -2157,7 +2078,6 @@ class TestCacheAdmin:
         assert cache_admin.has_change_permission(request) is False
 
     def test_staff_with_view_perm_can_view(self, db, test_cache):
-        """Staff user with view_cache permission can view caches."""
         from django.contrib.admin import site
         from django.contrib.auth.models import Permission, User
         from django.test import RequestFactory
@@ -2187,7 +2107,6 @@ class TestCacheAdmin:
         assert cache_admin.has_change_permission(request) is False
 
     def test_staff_with_change_perm_can_change(self, db, test_cache):
-        """Staff user with change_cache permission can flush caches."""
         from django.contrib.admin import site
         from django.contrib.auth.models import Permission, User
         from django.test import RequestFactory
@@ -2221,7 +2140,6 @@ class TestKeyAdminPermissions:
     """Test KeyAdmin permission methods with Django's permission system."""
 
     def test_module_permission_true(self, admin_user, test_cache):
-        """KeyAdmin should be visible in sidebar."""
         from django.contrib.admin import site
         from django.test import RequestFactory
 
@@ -2236,7 +2154,6 @@ class TestKeyAdminPermissions:
         assert key_admin.has_module_permission(request) is True
 
     def test_superuser_has_all_key_permissions(self, admin_user, test_cache):
-        """Superusers should have all key permissions."""
         from django.contrib.admin import site
         from django.test import RequestFactory
 
@@ -2279,7 +2196,6 @@ class TestKeyAdminPermissions:
         assert key_admin.has_delete_permission(request) is False
 
     def test_staff_with_view_key_perm(self, db, test_cache):
-        """Staff user with view_key permission can view keys."""
         from django.contrib.admin import site
         from django.contrib.auth.models import Permission, User
         from django.test import RequestFactory
@@ -2374,7 +2290,6 @@ class TestPermissionViewAccess:
         assert response.status_code == 403
 
     def test_staff_with_view_perm_can_access_cache_list(self, db, test_cache):
-        """Staff user with view_cache can access cache list."""
         from django.contrib.auth.models import Permission, User
 
         staff_user = User.objects.create_user(
@@ -2458,7 +2373,6 @@ class TestPermissionViewAccess:
         assert test_cache.get("test_key") == "value"
 
     def test_superuser_can_access_all_views(self, admin_client, test_cache):
-        """Superuser can access all views (unchanged behavior)."""
         assert admin_client.get(_cache_list_url()).status_code == 200
         assert admin_client.get(_cache_detail_url("default")).status_code == 200
         assert admin_client.get(_key_list_url("default")).status_code == 200
@@ -2502,7 +2416,6 @@ class TestUndecodableValueResilience:
         assert "cannot be decoded" in content
 
     def test_key_detail_shows_warning_message_for_broken_value(self, admin_client, test_cache):
-        """User sees a warning explaining why the value isn't shown."""
         self._inject_broken_value(test_cache)
 
         response = admin_client.get(_key_detail_url("default", self.BROKEN_KEY))
@@ -2512,7 +2425,6 @@ class TestUndecodableValueResilience:
         assert "different compressor or serializer" in content
 
     def test_delete_works_for_broken_value(self, admin_client, test_cache):
-        """Operators can still delete a broken key from the admin."""
         self._inject_broken_value(test_cache)
 
         # Sanity: key exists in Redis (raw client doesn't decode).

--- a/tests/cache/test_cache_async.py
+++ b/tests/cache/test_cache_async.py
@@ -13,7 +13,6 @@ class TestAsyncAdd:
 
     @pytest.mark.asyncio
     async def test_aadd_succeeds_for_new_key(self, cache: KeyValueCache):
-        """Test aadd creates new key."""
         cache.delete("async_add_new")
         result = await cache.aadd("async_add_new", "new_value")
         assert result is True
@@ -21,7 +20,6 @@ class TestAsyncAdd:
 
     @pytest.mark.asyncio
     async def test_aadd_fails_for_existing_key(self, cache: KeyValueCache):
-        """Test aadd does not overwrite existing key."""
         cache.set("async_add_existing", "original")
         result = await cache.aadd("async_add_existing", "new_value")
         assert result is False
@@ -29,7 +27,6 @@ class TestAsyncAdd:
 
     @pytest.mark.asyncio
     async def test_aadd_with_timeout(self, cache: KeyValueCache):
-        """Test aadd with explicit timeout."""
         cache.delete("async_add_timeout")
         result = await cache.aadd("async_add_timeout", "timed_value", timeout=60)
         assert result is True
@@ -42,14 +39,12 @@ class TestAsyncSet:
 
     @pytest.mark.asyncio
     async def test_aset_and_get(self, cache: KeyValueCache):
-        """Test aset stores value that can be retrieved."""
         await cache.aset("async_set_key", "async_set_value")
         result = cache.get("async_set_key")
         assert result == "async_set_value"
 
     @pytest.mark.asyncio
     async def test_aset_with_timeout(self, cache: KeyValueCache):
-        """Test aset with explicit timeout."""
         await cache.aset("async_timeout_key", "timeout_value", timeout=60)
         result = cache.get("async_timeout_key")
         assert result == "timeout_value"
@@ -59,7 +54,6 @@ class TestAsyncSet:
 
     @pytest.mark.asyncio
     async def test_aset_overwrites_existing(self, cache: KeyValueCache):
-        """Test aset overwrites existing value."""
         cache.set("async_overwrite", "original")
         await cache.aset("async_overwrite", "updated")
         result = cache.get("async_overwrite")
@@ -67,7 +61,6 @@ class TestAsyncSet:
 
     @pytest.mark.asyncio
     async def test_aset_complex_value(self, cache: KeyValueCache):
-        """Test aset with complex data types."""
         data = {"items": [1, 2, 3], "nested": {"key": "value"}}
         await cache.aset("async_complex_set", data)
         result = cache.get("async_complex_set")
@@ -75,7 +68,6 @@ class TestAsyncSet:
 
     @pytest.mark.asyncio
     async def test_aset_with_version(self, cache: KeyValueCache):
-        """Test aset respects version parameter."""
         await cache.aset("versioned_set", "v1_data", version=1)
         await cache.aset("versioned_set", "v2_data", version=2)
 
@@ -91,7 +83,6 @@ class TestAsyncDelete:
 
     @pytest.mark.asyncio
     async def test_adelete_existing_key(self, cache: KeyValueCache):
-        """Test adelete removes an existing key."""
         cache.set("async_delete_key", "to_delete")
         assert cache.get("async_delete_key") == "to_delete"
 
@@ -101,14 +92,12 @@ class TestAsyncDelete:
 
     @pytest.mark.asyncio
     async def test_adelete_nonexistent_key(self, cache: KeyValueCache):
-        """Test adelete returns False for nonexistent key."""
         cache.delete("nonexistent_async_key")
         result = await cache.adelete("nonexistent_async_key")
         assert result is False
 
     @pytest.mark.asyncio
     async def test_adelete_with_version(self, cache: KeyValueCache):
-        """Test adelete respects version parameter."""
         cache.set("versioned_delete", "v1_data", version=1)
         cache.set("versioned_delete", "v2_data", version=2)
 
@@ -123,7 +112,6 @@ class TestAsyncTouch:
 
     @pytest.mark.asyncio
     async def test_atouch_updates_timeout(self, cache: KeyValueCache):
-        """Test atouch updates the timeout."""
         cache.set("async_touch_key", "value", timeout=10)
         result = await cache.atouch("async_touch_key", timeout=60)
         assert result is True
@@ -132,7 +120,6 @@ class TestAsyncTouch:
 
     @pytest.mark.asyncio
     async def test_atouch_nonexistent_key(self, cache: KeyValueCache):
-        """Test atouch returns False for nonexistent key."""
         cache.delete("async_touch_missing")
         result = await cache.atouch("async_touch_missing", timeout=60)
         assert result is False
@@ -143,14 +130,12 @@ class TestAsyncHasKey:
 
     @pytest.mark.asyncio
     async def test_ahas_key_exists(self, cache: KeyValueCache):
-        """Test ahas_key returns True for existing key."""
         cache.set("async_has_key", "value")
         result = await cache.ahas_key("async_has_key")
         assert result is True
 
     @pytest.mark.asyncio
     async def test_ahas_key_missing(self, cache: KeyValueCache):
-        """Test ahas_key returns False for missing key."""
         cache.delete("async_missing_key")
         result = await cache.ahas_key("async_missing_key")
         assert result is False
@@ -161,7 +146,6 @@ class TestAsyncIncr:
 
     @pytest.mark.asyncio
     async def test_aincr_increments(self, cache: KeyValueCache):
-        """Test aincr increments value."""
         cache.set("async_counter", 10)
         result = await cache.aincr("async_counter")
         assert result == 11
@@ -169,21 +153,18 @@ class TestAsyncIncr:
 
     @pytest.mark.asyncio
     async def test_aincr_by_amount(self, cache: KeyValueCache):
-        """Test aincr increments by specified amount."""
         cache.set("async_counter2", 5)
         result = await cache.aincr("async_counter2", 10)
         assert result == 15
 
     @pytest.mark.asyncio
     async def test_aincr_missing_key_creates_it(self, cache: KeyValueCache):
-        """Test aincr creates a missing key with the delta value."""
         cache.delete("async_missing_counter")
         result = await cache.aincr("async_missing_counter")
         assert result == 1
 
     @pytest.mark.asyncio
     async def test_adecr_decrements(self, cache: KeyValueCache):
-        """Test adecr decrements value."""
         cache.set("async_decr", 10)
         result = await cache.adecr("async_decr")
         assert result == 9
@@ -194,7 +175,6 @@ class TestAsyncGetMany:
 
     @pytest.mark.asyncio
     async def test_aget_many_retrieves_multiple(self, cache: KeyValueCache):
-        """Test aget_many retrieves multiple values."""
         cache.set("async_many_a", "value_a")
         cache.set("async_many_b", "value_b")
         cache.set("async_many_c", "value_c")
@@ -221,7 +201,6 @@ class TestAsyncSetMany:
 
     @pytest.mark.asyncio
     async def test_aset_many_stores_multiple(self, cache: KeyValueCache):
-        """Test aset_many stores multiple values."""
         await cache.aset_many(
             {
                 "async_set_many_x": 1,
@@ -240,7 +219,6 @@ class TestAsyncDeleteMany:
 
     @pytest.mark.asyncio
     async def test_adelete_many_removes_multiple(self, cache: KeyValueCache):
-        """Test adelete_many removes multiple keys."""
         cache.set_many({"async_del_1": 1, "async_del_2": 2, "async_del_3": 3})
 
         result = await cache.adelete_many(["async_del_1", "async_del_2"])
@@ -256,7 +234,6 @@ class TestAsyncClear:
 
     @pytest.mark.asyncio
     async def test_aclear_removes_all(self, cache: KeyValueCache):
-        """Test aclear removes all keys."""
         cache.set("async_clear_key", "value")
         assert cache.get("async_clear_key") == "value"
 
@@ -270,28 +247,24 @@ class TestAsyncGet:
 
     @pytest.mark.asyncio
     async def test_aget_existing_key(self, cache: KeyValueCache):
-        """Test aget retrieves an existing value."""
         cache.set("async_key", "async_value")
         result = await cache.aget("async_key")
         assert result == "async_value"
 
     @pytest.mark.asyncio
     async def test_aget_missing_key_returns_default(self, cache: KeyValueCache):
-        """Test aget returns default for missing key."""
         cache.delete("missing_async_key")
         result = await cache.aget("missing_async_key")
         assert result is None
 
     @pytest.mark.asyncio
     async def test_aget_missing_key_with_custom_default(self, cache: KeyValueCache):
-        """Test aget returns custom default for missing key."""
         cache.delete("missing_async_key2")
         result = await cache.aget("missing_async_key2", default="fallback")
         assert result == "fallback"
 
     @pytest.mark.asyncio
     async def test_aget_complex_value(self, cache: KeyValueCache):
-        """Test aget with complex data types."""
         data = {"user": "alice", "scores": [10, 20, 30], "active": True}
         cache.set("async_complex", data)
         result = await cache.aget("async_complex")
@@ -299,7 +272,6 @@ class TestAsyncGet:
 
     @pytest.mark.asyncio
     async def test_aget_with_version(self, cache: KeyValueCache):
-        """Test aget respects version parameter."""
         cache.set("versioned_key", "v1_value", version=1)
         cache.set("versioned_key", "v2_value", version=2)
 

--- a/tests/cache/test_cache_basic.py
+++ b/tests/cache/test_cache_basic.py
@@ -65,7 +65,6 @@ class TestSetWithGet:
         assert ttl is not None and ttl > 0
 
     def test_set_get_preserves_none_vs_missing(self, cache: KeyValueCache):
-        """Successive set-get calls chain correctly."""
         cache.delete("get_chain")
         old1 = cache.set("get_chain", "a", get=True)
         assert old1 is None

--- a/tests/cache/test_cache_keys.py
+++ b/tests/cache/test_cache_keys.py
@@ -105,7 +105,6 @@ class TestRenameOperations:
         assert cache.get("{slot6}:dest") == "existing_value"
 
     def test_rename_version_src_dst(self, cache: KeyValueCache):
-        """rename with different source and destination versions."""
         cache.set("{vs}:rsrc", "value", version=1)
 
         cache.rename("{vs}:rsrc", "{vs}:rdst", version_src=1, version_dst=2)
@@ -113,7 +112,6 @@ class TestRenameOperations:
         assert cache.get("{vs}:rdst", version=2) == "value"
 
     def test_renamenx_version_src_dst(self, cache: KeyValueCache):
-        """renamenx with different source and destination versions."""
         cache.set("{vs}:rnxsrc", "value", version=1)
 
         result = cache.renamenx("{vs}:rnxsrc", "{vs}:rnxdst", version_src=1, version_dst=2)
@@ -137,7 +135,6 @@ class TestDeletePatternOperations:
         assert bool(res) is False
 
     def test_delete_pattern_with_custom_count(self, cache: KeyValueCache):
-        """Test delete_pattern with custom itersize."""
         for key in ["foo-aa", "foo-ab", "foo-bb", "foo-bc"]:
             cache.set(key, "foo")
 
@@ -155,7 +152,6 @@ class TestDeletePatternOperations:
         cache: KeyValueCache,
         settings: SettingsWrapper,
     ):
-        """Test delete_pattern uses settings for default itersize."""
         for key in ["foo-aa", "foo-ab", "foo-bb", "foo-bc"]:
             cache.set(key, "foo")
 

--- a/tests/cache/test_cache_keys_async.py
+++ b/tests/cache/test_cache_keys_async.py
@@ -119,7 +119,6 @@ class TestAsyncVersionSrcDst:
 
     @pytest.mark.asyncio
     async def test_arename_version_src_dst(self, cache: KeyValueCache):
-        """arename with different source and destination versions."""
         cache.set("{vs}:arsrc", "value", version=1)
 
         await cache.arename("{vs}:arsrc", "{vs}:ardst", version_src=1, version_dst=2)
@@ -128,7 +127,6 @@ class TestAsyncVersionSrcDst:
 
     @pytest.mark.asyncio
     async def test_arenamenx_version_src_dst(self, cache: KeyValueCache):
-        """arenamenx with different source and destination versions."""
         cache.set("{vs}:arnxsrc", "value", version=1)
 
         result = await cache.arenamenx("{vs}:arnxsrc", "{vs}:arnxdst", version_src=1, version_dst=2)

--- a/tests/cache/test_cache_lists.py
+++ b/tests/cache/test_cache_lists.py
@@ -146,7 +146,6 @@ class TestListOperations:
         assert length == -1
 
     def test_list_with_complex_values(self, cache: KeyValueCache):
-        """Test that lists work with complex serialized values."""
         cache.rpush("mylist15", {"name": "Alice"}, {"name": "Bob"})
 
         result = cache.lrange("mylist15", 0, -1)
@@ -156,7 +155,6 @@ class TestListOperations:
         assert popped == {"name": "Alice"}
 
     def test_list_version_support(self, cache: KeyValueCache):
-        """Test that version parameter works correctly."""
         cache.rpush("mylist", "v1_a", "v1_b", version=1)
         cache.rpush("mylist", "v2_a", version=2)
 
@@ -167,7 +165,6 @@ class TestListOperations:
         assert cache.lrange("mylist", 0, -1, version=2) == ["v2_a"]
 
     def test_lpos_basic(self, cache: KeyValueCache):
-        """Test finding element position in list."""
         cache.rpush("mylist_lpos", "a", "b", "c", "b", "d")
 
         # Find first occurrence
@@ -177,7 +174,6 @@ class TestListOperations:
         assert cache.lpos("mylist_lpos", "z") is None
 
     def test_lpos_with_rank(self, cache: KeyValueCache):
-        """Test lpos with rank parameter."""
         cache.rpush("mylist_lpos2", "a", "b", "c", "b", "d", "b")
 
         # Find second occurrence (rank=2)
@@ -187,7 +183,6 @@ class TestListOperations:
         assert cache.lpos("mylist_lpos2", "b", rank=-1) == 5
 
     def test_lpos_with_count(self, cache: KeyValueCache):
-        """Test lpos with count parameter returns multiple indices."""
         cache.rpush("mylist_lpos3", "a", "b", "c", "b", "d", "b")
 
         # Find all occurrences
@@ -199,7 +194,6 @@ class TestListOperations:
         assert result == [1, 3]
 
     def test_lmove_basic(self, cache: KeyValueCache):
-        """Test moving element between lists."""
         # Use hash tags {list} to ensure keys are on same cluster slot
         cache.rpush("{list}src", "a", "b", "c")
         cache.rpush("{list}dst", "x", "y")
@@ -212,7 +206,6 @@ class TestListOperations:
         assert cache.lrange("{list}dst", 0, -1) == ["x", "y", "a"]
 
     def test_lmove_directions(self, cache: KeyValueCache):
-        """Test different lmove directions."""
         # Use hash tags {list} to ensure keys are on same cluster slot
         cache.rpush("{list}src2", "1", "2", "3")
         cache.rpush("{list}dst2", "a")
@@ -224,7 +217,6 @@ class TestListOperations:
         assert cache.lrange("{list}dst2", 0, -1) == ["3", "a"]
 
     def test_lmove_empty_source(self, cache: KeyValueCache):
-        """Test lmove on empty source list."""
         # Use hash tags {list} to ensure keys are on same cluster slot
         cache.rpush("{list}dst3", "x")
 
@@ -233,7 +225,6 @@ class TestListOperations:
         assert cache.lrange("{list}dst3", 0, -1) == ["x"]
 
     def test_blpop_immediate(self, cache: KeyValueCache):
-        """Test blpop returns immediately when data exists."""
         cache.rpush("blpop_list", "a", "b", "c")
 
         result = cache.blpop("blpop_list", timeout=1)
@@ -249,7 +240,6 @@ class TestListOperations:
         assert result is None
 
     def test_blpop_multiple_keys(self, cache: KeyValueCache):
-        """Test blpop with multiple keys returns first available."""
         # Use hash tags to ensure keys are on same cluster slot
         cache.rpush("{blpop}list2", "x", "y")
 
@@ -260,7 +250,6 @@ class TestListOperations:
         assert value == "x"
 
     def test_brpop_immediate(self, cache: KeyValueCache):
-        """Test brpop returns immediately when data exists."""
         cache.rpush("brpop_list", "a", "b", "c")
 
         result = cache.brpop("brpop_list", timeout=1)
@@ -276,7 +265,6 @@ class TestListOperations:
         assert result is None
 
     def test_blmove_immediate(self, cache: KeyValueCache):
-        """Test blmove returns immediately when data exists."""
         # Use hash tags to ensure keys are on same cluster slot
         cache.rpush("{blmove}src", "a", "b", "c")
         cache.rpush("{blmove}dst", "x")
@@ -295,7 +283,6 @@ class TestListOperations:
         assert result is None
 
     def test_blpop_with_complex_values(self, cache: KeyValueCache):
-        """Test blpop works with serialized complex values."""
         cache.rpush("blpop_complex", {"name": "Alice"}, {"name": "Bob"})
 
         result = cache.blpop("blpop_complex", timeout=1)
@@ -308,7 +295,6 @@ class TestVersionSrcDst:
     """Tests for version_src/version_dst on lmove and blmove."""
 
     def test_lmove_version_src_dst(self, cache: KeyValueCache):
-        """lmove with different source and destination versions."""
         cache.rpush("{vs}:lsrc", "a", "b", version=1)
         cache.rpush("{vs}:ldst", "x", version=2)
 
@@ -318,7 +304,6 @@ class TestVersionSrcDst:
         assert cache.lrange("{vs}:ldst", 0, -1, version=2) == ["x", "a"]
 
     def test_blmove_version_src_dst(self, cache: KeyValueCache):
-        """blmove with different source and destination versions."""
         cache.rpush("{vs}:blsrc", "a", "b", version=1)
         cache.rpush("{vs}:bldst", "x", version=2)
 

--- a/tests/cache/test_cache_lists_async.py
+++ b/tests/cache/test_cache_lists_async.py
@@ -264,7 +264,6 @@ class TestAsyncVersionSrcDst:
 
     @pytest.mark.asyncio
     async def test_almove_version_src_dst(self, cache: KeyValueCache):
-        """almove with different source and destination versions."""
         cache.rpush("{vs}:alsrc", "a", "b", version=1)
         cache.rpush("{vs}:aldst", "x", version=2)
 
@@ -275,7 +274,6 @@ class TestAsyncVersionSrcDst:
 
     @pytest.mark.asyncio
     async def test_ablmove_version_src_dst(self, cache: KeyValueCache):
-        """ablmove with different source and destination versions."""
         cache.rpush("{vs}:ablsrc", "a", "b", version=1)
         cache.rpush("{vs}:abldst", "x", version=2)
 

--- a/tests/cache/test_cache_pipeline.py
+++ b/tests/cache/test_cache_pipeline.py
@@ -13,14 +13,12 @@ class TestPipelineBasic:
     """Test basic pipeline functionality."""
 
     def test_pipeline_returns_pipeline_object(self, cache: KeyValueCache):
-        """Test that pipeline() returns a Pipeline object."""
         from django_cachex.client.pipeline import Pipeline
 
         pipe = cache.pipeline()
         assert isinstance(pipe, Pipeline)
 
     def test_pipeline_manual_execute(self, cache: KeyValueCache):
-        """Test pipeline with manual execute."""
         cache.set("manual_key", "manual_value")
 
         pipe = cache.pipeline()
@@ -34,13 +32,11 @@ class TestPipelineBasic:
         assert results[2] == "new_value"
 
     def test_pipeline_empty_execute(self, cache: KeyValueCache):
-        """Test executing an empty pipeline."""
         pipe = cache.pipeline()
         results = pipe.execute()
         assert results == []
 
     def test_pipeline_chaining(self, cache: KeyValueCache):
-        """Test that pipeline methods return self for chaining."""
         pipe = cache.pipeline()
         result = pipe.set("chain1", "a").set("chain2", "b").get("chain1").get("chain2")
         assert result is pipe
@@ -49,7 +45,6 @@ class TestPipelineBasic:
         assert results == [True, True, "a", "b"]
 
     def test_pipeline_transaction(self, cache: KeyValueCache):
-        """Test pipeline with transaction=True (default)."""
         pipe = cache.pipeline(transaction=True)
         pipe.set("tx_key", "tx_value")
         pipe.get("tx_key")
@@ -57,7 +52,6 @@ class TestPipelineBasic:
         assert results == [True, "tx_value"]
 
     def test_pipeline_no_transaction(self, cache: KeyValueCache):
-        """Test pipeline with transaction=False."""
         pipe = cache.pipeline(transaction=False)
         pipe.set("notx_key", "notx_value")
         pipe.get("notx_key")
@@ -69,7 +63,6 @@ class TestPipelineCacheOperations:
     """Test standard cache operations in pipeline."""
 
     def test_pipeline_get_set(self, cache: KeyValueCache):
-        """Test get/set operations in pipeline."""
         pipe = cache.pipeline()
         pipe.set("key1", "value1")
         pipe.set("key2", {"nested": "dict"})
@@ -85,7 +78,6 @@ class TestPipelineCacheOperations:
         assert results[4] is None
 
     def test_pipeline_delete(self, cache: KeyValueCache):
-        """Test delete in pipeline."""
         cache.set("{pipe_del}key1", "a")
         cache.set("{pipe_del}key2", "b")
 
@@ -100,7 +92,6 @@ class TestPipelineCacheOperations:
         assert results[2] is False
 
     def test_pipeline_exists(self, cache: KeyValueCache):
-        """Test exists in pipeline."""
         cache.set("{pipe_ex}key", "value")
 
         pipe = cache.pipeline()
@@ -112,7 +103,6 @@ class TestPipelineCacheOperations:
         assert results[1] is False
 
     def test_pipeline_expire_ttl(self, cache: KeyValueCache):
-        """Test expire and ttl in pipeline."""
         cache.set("expire_key", "value")
 
         pipe = cache.pipeline()
@@ -124,7 +114,6 @@ class TestPipelineCacheOperations:
         assert 0 < results[1] <= 100
 
     def test_pipeline_incr_decr(self, cache: KeyValueCache):
-        """Test incr/decr in pipeline."""
         cache.set("counter", 10)
 
         pipe = cache.pipeline()
@@ -146,7 +135,6 @@ class TestPipelineListOperations:
     """Test list operations in pipeline."""
 
     def test_pipeline_lpush_rpush(self, cache: KeyValueCache):
-        """Test lpush/rpush in pipeline."""
         pipe = cache.pipeline()
         pipe.rpush("pipe_list", "a", "b", "c")
         pipe.lpush("pipe_list", "x", "y")
@@ -158,7 +146,6 @@ class TestPipelineListOperations:
         assert results[2] == ["y", "x", "a", "b", "c"]
 
     def test_pipeline_lpop_rpop(self, cache: KeyValueCache):
-        """Test lpop/rpop in pipeline."""
         cache.rpush("pipe_list2", "a", "b", "c", "d")
 
         pipe = cache.pipeline()
@@ -172,7 +159,6 @@ class TestPipelineListOperations:
         assert results[2] == ["b", "c"]
 
     def test_pipeline_llen_lindex(self, cache: KeyValueCache):
-        """Test llen/lindex in pipeline."""
         cache.rpush("pipe_list3", "a", "b", "c")
 
         pipe = cache.pipeline()
@@ -186,7 +172,6 @@ class TestPipelineListOperations:
         assert results[2] == "c"
 
     def test_pipeline_lset_lrem(self, cache: KeyValueCache):
-        """Test lset/lrem in pipeline."""
         cache.rpush("pipe_list4", "a", "b", "a", "c")
 
         pipe = cache.pipeline()
@@ -200,7 +185,6 @@ class TestPipelineListOperations:
         assert results[2] == ["B", "a", "c"]
 
     def test_pipeline_ltrim(self, cache: KeyValueCache):
-        """Test ltrim in pipeline."""
         cache.rpush("pipe_list5", "a", "b", "c", "d", "e")
 
         pipe = cache.pipeline()
@@ -212,7 +196,6 @@ class TestPipelineListOperations:
         assert results[1] == ["b", "c", "d"]
 
     def test_pipeline_linsert(self, cache: KeyValueCache):
-        """Test linsert in pipeline."""
         cache.rpush("pipe_list6", "a", "c")
 
         pipe = cache.pipeline()
@@ -226,7 +209,6 @@ class TestPipelineListOperations:
         assert results[2] == ["a", "b", "c", "d"]
 
     def test_pipeline_lpos(self, cache: KeyValueCache):
-        """Test lpos in pipeline."""
         cache.rpush("pipe_list7", "a", "b", "c", "b", "d")
 
         pipe = cache.pipeline()
@@ -240,7 +222,6 @@ class TestPipelineListOperations:
         assert results[2] is None
 
     def test_pipeline_lmove(self, cache: KeyValueCache):
-        """Test lmove in pipeline."""
         # Use hash tags to ensure keys are on same cluster slot
         cache.rpush("{pipe}src", "a", "b", "c")
         cache.rpush("{pipe}dst", "x")
@@ -260,7 +241,6 @@ class TestPipelineSetOperations:
     """Test set operations in pipeline."""
 
     def test_pipeline_sadd_smembers(self, cache: KeyValueCache):
-        """Test sadd/smembers in pipeline."""
         pipe = cache.pipeline()
         pipe.sadd("pipe_set", "a", "b", "c")
         pipe.smembers("pipe_set")
@@ -270,7 +250,6 @@ class TestPipelineSetOperations:
         assert results[1] == {"a", "b", "c"}
 
     def test_pipeline_scard_sismember(self, cache: KeyValueCache):
-        """Test scard/sismember in pipeline."""
         cache.sadd("pipe_set2", "a", "b", "c")
 
         pipe = cache.pipeline()
@@ -284,7 +263,6 @@ class TestPipelineSetOperations:
         assert results[2] is False
 
     def test_pipeline_srem(self, cache: KeyValueCache):
-        """Test srem in pipeline."""
         cache.sadd("pipe_set3", "a", "b", "c")
 
         pipe = cache.pipeline()
@@ -296,7 +274,6 @@ class TestPipelineSetOperations:
         assert results[1] == {"a"}
 
     def test_pipeline_sdiff_sinter_sunion(self, cache: KeyValueCache, client_class: str):
-        """Test set operations in pipeline."""
         # Redis Cluster doesn't support sdiff/sinter/sunion in pipeline mode
         if client_class == "cluster":
             pytest.skip("sdiff/sinter/sunion blocked in cluster pipeline mode")
@@ -316,7 +293,6 @@ class TestPipelineSetOperations:
         assert results[2] == {"a", "b", "c", "d"}
 
     def test_pipeline_spop(self, cache: KeyValueCache):
-        """Test spop in pipeline."""
         cache.sadd("pipe_set4", "a", "b", "c")
 
         pipe = cache.pipeline()
@@ -328,7 +304,6 @@ class TestPipelineSetOperations:
         assert results[1] == 2
 
     def test_pipeline_smismember(self, cache: KeyValueCache):
-        """Test smismember in pipeline."""
         cache.sadd("pipe_set5", "a", "b", "c")
 
         pipe = cache.pipeline()
@@ -338,7 +313,6 @@ class TestPipelineSetOperations:
         assert results[0] == [True, False, True]
 
     def test_pipeline_smove(self, cache: KeyValueCache, client_class: str):
-        """Test smove in pipeline."""
         # Redis Cluster doesn't support smove in pipeline mode
         if client_class == "cluster":
             pytest.skip("smove blocked in cluster pipeline mode")
@@ -362,7 +336,6 @@ class TestPipelineHashOperations:
     """Test hash operations in pipeline."""
 
     def test_pipeline_hset_hget(self, cache: KeyValueCache):
-        """Test hset/hget in pipeline."""
         pipe = cache.pipeline()
         pipe.hset("pipe_hash", "field1", "value1")
         pipe.hset("pipe_hash", "field2", {"nested": "value"})
@@ -376,7 +349,6 @@ class TestPipelineHashOperations:
         assert results[3] == {"nested": "value"}
 
     def test_pipeline_hset_mapping_hmget(self, cache: KeyValueCache):
-        """Test hset with mapping / hmget in pipeline."""
         pipe = cache.pipeline()
         pipe.hset("pipe_hash2", mapping={"f1": "v1", "f2": "v2", "f3": "v3"})
         pipe.hmget("pipe_hash2", "f1", "f3", "nonexistent")
@@ -386,7 +358,6 @@ class TestPipelineHashOperations:
         assert results[1] == ["v1", "v3", None]
 
     def test_pipeline_hgetall(self, cache: KeyValueCache):
-        """Test hgetall in pipeline."""
         cache.hset("pipe_hash3", mapping={"a": "1", "b": "2"})
 
         pipe = cache.pipeline()
@@ -396,7 +367,6 @@ class TestPipelineHashOperations:
         assert results[0] == {"a": "1", "b": "2"}
 
     def test_pipeline_hdel_hlen(self, cache: KeyValueCache):
-        """Test hdel/hlen in pipeline."""
         cache.hset("pipe_hash4", mapping={"a": "1", "b": "2", "c": "3"})
 
         pipe = cache.pipeline()
@@ -408,7 +378,6 @@ class TestPipelineHashOperations:
         assert results[1] == 2
 
     def test_pipeline_hkeys_hvals(self, cache: KeyValueCache):
-        """Test hkeys/hvals in pipeline."""
         cache.hset("pipe_hash5", mapping={"a": "1", "b": "2"})
 
         pipe = cache.pipeline()
@@ -420,7 +389,6 @@ class TestPipelineHashOperations:
         assert set(results[1]) == {"1", "2"}
 
     def test_pipeline_hexists(self, cache: KeyValueCache):
-        """Test hexists in pipeline."""
         cache.hset("pipe_hash6", "field", "value")
 
         pipe = cache.pipeline()
@@ -432,7 +400,6 @@ class TestPipelineHashOperations:
         assert results[1] is False
 
     def test_pipeline_hincrby(self, cache: KeyValueCache):
-        """Test hincrby/hincrbyfloat in pipeline."""
         cache.hset("pipe_hash7", "count", 10)
 
         pipe = cache.pipeline()
@@ -446,7 +413,6 @@ class TestPipelineHashOperations:
         assert results[2] == 1.5
 
     def test_pipeline_hsetnx(self, cache: KeyValueCache):
-        """Test hsetnx in pipeline."""
         cache.hset("pipe_hash8", "existing", "value")
 
         pipe = cache.pipeline()
@@ -466,7 +432,6 @@ class TestPipelineSortedSetOperations:
     """Test sorted set operations in pipeline."""
 
     def test_pipeline_zadd_zrange(self, cache: KeyValueCache):
-        """Test zadd/zrange in pipeline."""
         pipe = cache.pipeline()
         pipe.zadd("pipe_zset", {"a": 1, "b": 2, "c": 3})
         pipe.zrange("pipe_zset", 0, -1)
@@ -478,7 +443,6 @@ class TestPipelineSortedSetOperations:
         assert results[2] == [("a", 1.0), ("b", 2.0), ("c", 3.0)]
 
     def test_pipeline_zcard_zcount(self, cache: KeyValueCache):
-        """Test zcard/zcount in pipeline."""
         cache.zadd("pipe_zset2", {"a": 1, "b": 2, "c": 3, "d": 4})
 
         pipe = cache.pipeline()
@@ -490,7 +454,6 @@ class TestPipelineSortedSetOperations:
         assert results[1] == 2  # b and c
 
     def test_pipeline_zincrby(self, cache: KeyValueCache):
-        """Test zincrby in pipeline."""
         cache.zadd("pipe_zset3", {"item": 10})
 
         pipe = cache.pipeline()
@@ -504,7 +467,6 @@ class TestPipelineSortedSetOperations:
         assert results[2] == 12.0
 
     def test_pipeline_zrank_zrevrank(self, cache: KeyValueCache):
-        """Test zrank/zrevrank in pipeline."""
         cache.zadd("pipe_zset4", {"a": 1, "b": 2, "c": 3})
 
         pipe = cache.pipeline()
@@ -518,7 +480,6 @@ class TestPipelineSortedSetOperations:
         assert results[2] is None
 
     def test_pipeline_zrem(self, cache: KeyValueCache):
-        """Test zrem in pipeline."""
         cache.zadd("pipe_zset5", {"a": 1, "b": 2, "c": 3})
 
         pipe = cache.pipeline()
@@ -530,7 +491,6 @@ class TestPipelineSortedSetOperations:
         assert results[1] == ["a", "c"]
 
     def test_pipeline_zpopmin_zpopmax(self, cache: KeyValueCache):
-        """Test zpopmin/zpopmax in pipeline."""
         cache.zadd("pipe_zset6", {"a": 1, "b": 2, "c": 3})
 
         pipe = cache.pipeline()
@@ -544,7 +504,6 @@ class TestPipelineSortedSetOperations:
         assert results[2] == ["b"]
 
     def test_pipeline_zrangebyscore(self, cache: KeyValueCache):
-        """Test zrangebyscore/zrevrangebyscore in pipeline."""
         cache.zadd("pipe_zset7", {"a": 1, "b": 2, "c": 3, "d": 4})
 
         pipe = cache.pipeline()
@@ -556,7 +515,6 @@ class TestPipelineSortedSetOperations:
         assert results[1] == ["c", "b"]
 
     def test_pipeline_zremrangebyscore(self, cache: KeyValueCache):
-        """Test zremrangebyscore in pipeline."""
         cache.zadd("pipe_zset8", {"a": 1, "b": 2, "c": 3, "d": 4})
 
         pipe = cache.pipeline()
@@ -568,7 +526,6 @@ class TestPipelineSortedSetOperations:
         assert results[1] == ["a", "d"]
 
     def test_pipeline_zremrangebyrank(self, cache: KeyValueCache):
-        """Test zremrangebyrank in pipeline."""
         cache.zadd("pipe_zset9", {"a": 1, "b": 2, "c": 3, "d": 4})
 
         pipe = cache.pipeline()
@@ -580,7 +537,6 @@ class TestPipelineSortedSetOperations:
         assert results[1] == ["a", "d"]
 
     def test_pipeline_zmscore(self, cache: KeyValueCache):
-        """Test zmscore in pipeline."""
         cache.zadd("pipe_zset10", {"a": 1, "b": 2, "c": 3})
 
         pipe = cache.pipeline()
@@ -594,7 +550,6 @@ class TestPipelineVersionSupport:
     """Test version parameter support in pipeline."""
 
     def test_pipeline_with_version(self, cache: KeyValueCache):
-        """Test pipeline operations with version parameter."""
         pipe = cache.pipeline(version=1)
         pipe.set("versioned_key", "v1_value")
         pipe.get("versioned_key")
@@ -609,7 +564,6 @@ class TestPipelineVersionSupport:
         assert cache.get("versioned_key", version=1) == "v1_value"
 
     def test_pipeline_version_override(self, cache: KeyValueCache):
-        """Test that individual operations can override pipeline version."""
         pipe = cache.pipeline(version=1)
         pipe.set("key_v1", "value1")
         pipe.set("key_v2", "value2", version=2)  # Override version
@@ -633,7 +587,6 @@ class TestPipelineMixedOperations:
     """Test mixing different operation types in a single pipeline."""
 
     def test_mixed_data_structures(self, cache: KeyValueCache):
-        """Test using different data structures in one pipeline."""
         pipe = cache.pipeline()
         # Cache operations
         pipe.set("string_key", "string_value")
@@ -674,7 +627,6 @@ class TestPipelineMissingOperations:
     """Test operations that were missing from initial coverage."""
 
     def test_pipeline_set_with_timeout(self, cache: KeyValueCache):
-        """Test set with timeout parameter."""
         pipe = cache.pipeline()
         pipe.set("timeout_key", "value", timeout=100)
         pipe.ttl("timeout_key")
@@ -716,7 +668,6 @@ class TestPipelineMissingOperations:
         assert results[3] is False  # key wasn't created
 
     def test_pipeline_srandmember(self, cache: KeyValueCache):
-        """Test srandmember in pipeline."""
         cache.sadd("srand_set", "a", "b", "c")
 
         pipe = cache.pipeline()
@@ -729,7 +680,6 @@ class TestPipelineMissingOperations:
         assert all(m in {"a", "b", "c"} for m in results[1])
 
     def test_pipeline_sdiffstore(self, cache: KeyValueCache, client_class: str):
-        """Test sdiffstore in pipeline."""
         # Redis Cluster doesn't support sdiffstore in pipeline mode
         if client_class == "cluster":
             pytest.skip("sdiffstore blocked in cluster pipeline mode")
@@ -747,7 +697,6 @@ class TestPipelineMissingOperations:
         assert results[1] == {"a"}
 
     def test_pipeline_sinterstore(self, cache: KeyValueCache, client_class: str):
-        """Test sinterstore in pipeline."""
         # Redis Cluster doesn't support sinterstore in pipeline mode
         if client_class == "cluster":
             pytest.skip("sinterstore blocked in cluster pipeline mode")
@@ -765,7 +714,6 @@ class TestPipelineMissingOperations:
         assert results[1] == {"b", "c"}
 
     def test_pipeline_sunionstore(self, cache: KeyValueCache, client_class: str):
-        """Test sunionstore in pipeline."""
         # Redis Cluster doesn't support sunionstore in pipeline mode
         if client_class == "cluster":
             pytest.skip("sunionstore blocked in cluster pipeline mode")
@@ -783,7 +731,6 @@ class TestPipelineMissingOperations:
         assert results[1] == {"a", "b", "c", "d"}
 
     def test_pipeline_zrevrange(self, cache: KeyValueCache):
-        """Test zrevrange in pipeline."""
         cache.zadd("zrev_set", {"a": 1, "b": 2, "c": 3, "d": 4})
 
         pipe = cache.pipeline()
@@ -819,7 +766,6 @@ class TestPipelineCommandCombinations:
         assert results[5] == 13  # final value
 
     def test_combination_list_queue_pattern(self, cache: KeyValueCache):
-        """Test queue pattern: push items, check length, pop items."""
         pipe = cache.pipeline()
         pipe.rpush("{combo2}queue", "task1", "task2", "task3")
         pipe.llen("{combo2}queue")
@@ -837,7 +783,6 @@ class TestPipelineCommandCombinations:
         assert results[5] == ["task3"]  # remaining
 
     def test_combination_hash_user_profile(self, cache: KeyValueCache):
-        """Test user profile pattern: set fields, check existence, get all."""
         pipe = cache.pipeline()
         pipe.hset("{combo3}user:1", "name", "Alice")
         pipe.hset("{combo3}user:1", "email", "alice@example.com")
@@ -857,7 +802,6 @@ class TestPipelineCommandCombinations:
         assert results[5]["login_count"] == 1
 
     def test_combination_sorted_set_leaderboard(self, cache: KeyValueCache):
-        """Test leaderboard pattern: add scores, get rankings, update scores."""
         pipe = cache.pipeline()
         pipe.zadd("{combo4}leaderboard", {"alice": 100, "bob": 85, "charlie": 92})
         pipe.zrevrange("{combo4}leaderboard", 0, 2, withscores=True)  # Top 3

--- a/tests/cache/test_cache_scripts.py
+++ b/tests/cache/test_cache_scripts.py
@@ -20,12 +20,10 @@ class TestEvalScript:
     """Test eval_script execution."""
 
     def test_eval_script_simple(self, cache: KeyValueCache):
-        """Test simple script execution."""
         result = cache.eval_script("return 42")
         assert result == 42
 
     def test_eval_script_with_keys_and_args(self, cache: KeyValueCache):
-        """Test script execution with keys and args."""
         script = """
         local current = redis.call('GET', KEYS[1]) or 0
         local new = tonumber(current) + tonumber(ARGV[1])
@@ -50,7 +48,6 @@ class TestEvalScript:
         assert result == b"myvalue"
 
     def test_eval_script_with_encoding(self, cache: KeyValueCache):
-        """Test script with full encoding of values."""
         script = """
         redis.call('SET', KEYS[1], ARGV[1])
         return redis.call('GET', KEYS[1])
@@ -67,7 +64,6 @@ class TestEvalScript:
         assert result == test_obj
 
     def test_eval_script_with_version(self, cache: KeyValueCache):
-        """Test script execution with explicit version."""
         script = """
         redis.call('SET', KEYS[1], ARGV[1])
         return redis.call('GET', KEYS[1])
@@ -103,12 +99,10 @@ class TestEvalScript:
         assert v2_val == "v2"
 
     def test_eval_script_string_return(self, cache: KeyValueCache):
-        """Test script returning a string."""
         result = cache.eval_script("return 'hello'")
         assert result == b"hello"
 
     def test_eval_script_no_keys(self, cache: KeyValueCache):
-        """Test script with no keys or args."""
         result = cache.eval_script("return 1 + 2")
         assert result == 3
 
@@ -117,7 +111,6 @@ class TestScriptHelpers:
     """Test ScriptHelpers functionality."""
 
     def test_script_helpers_make_keys(self, cache: KeyValueCache):
-        """Test ScriptHelpers.make_keys method."""
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
             encode=cache._cache.encode,
@@ -132,7 +125,6 @@ class TestScriptHelpers:
         assert keys[1] != "key2"
 
     def test_script_helpers_encode_decode(self, cache: KeyValueCache):
-        """Test ScriptHelpers encode/decode methods."""
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
             encode=cache._cache.encode,
@@ -170,7 +162,6 @@ class TestPreBuiltHooks:
         assert proc_args == [1, 2, "three"]
 
     def test_full_encode_pre(self, cache: KeyValueCache):
-        """Test full_encode_pre helper."""
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
             encode=cache._cache.encode,
@@ -190,7 +181,6 @@ class TestPreBuiltHooks:
         assert isinstance(proc_args[0], bytes)
 
     def test_decode_single_post(self, cache: KeyValueCache):
-        """Test decode_single_post helper."""
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
             encode=cache._cache.encode,
@@ -208,7 +198,6 @@ class TestPreBuiltHooks:
         assert decode_single_post(helpers, None) is None
 
     def test_decode_list_post(self, cache: KeyValueCache):
-        """Test decode_list_post helper."""
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
             encode=cache._cache.encode,
@@ -230,7 +219,6 @@ class TestPipelineScripts:
     """Test script execution in pipelines."""
 
     def test_pipeline_eval_script(self, cache: KeyValueCache):
-        """Test eval_script in pipeline."""
         script = "return redis.call('INCR', KEYS[1])"
 
         pipe = cache.pipeline()
@@ -242,7 +230,6 @@ class TestPipelineScripts:
         assert results == [1, 2, 3]
 
     def test_pipeline_eval_script_mixed(self, cache: KeyValueCache):
-        """Test mixing eval_script with other operations."""
         script = "redis.call('SET', KEYS[1], ARGV[1]); return 'ok'"
 
         pipe = cache.pipeline()
@@ -256,7 +243,6 @@ class TestPipelineScripts:
         assert results[2] == "regular_value"  # get
 
     def test_pipeline_eval_script_with_post_hook(self, cache: KeyValueCache):
-        """Test pipeline eval_script with post_hook decoder."""
         script = """
         redis.call('SET', KEYS[1], ARGV[1])
         return redis.call('GET', KEYS[1])
@@ -277,7 +263,6 @@ class TestPipelineScripts:
         assert results[0] == test_obj
 
     def test_pipeline_eval_script_chaining(self, cache: KeyValueCache):
-        """Test that eval_script returns self for chaining."""
         pipe = cache.pipeline()
         result = pipe.eval_script("return 1").eval_script("return 2")
         assert result is pipe
@@ -288,12 +273,10 @@ class TestAsyncScriptExecution:
     """Test async script execution functionality."""
 
     async def test_aeval_script_simple(self, cache: KeyValueCache):
-        """Test simple async script execution."""
         result = await cache.aeval_script("return 'async'")
         assert result == b"async"
 
     async def test_aeval_script_with_encoding(self, cache: KeyValueCache):
-        """Test async script with encoding."""
         script = """
         redis.call('SET', KEYS[1], ARGV[1])
         return redis.call('GET', KEYS[1])

--- a/tests/cache/test_cache_sets.py
+++ b/tests/cache/test_cache_sets.py
@@ -147,7 +147,6 @@ class TestVersionSrcDst:
     """Tests for version_src/version_dst on smove."""
 
     def test_smove_version_src_dst(self, cache: KeyValueCache):
-        """smove with different source and destination versions."""
         cache.sadd("{vs}:ssrc", "a", "b", version=1)
         cache.sadd("{vs}:sdst", "x", version=2)
 

--- a/tests/cache/test_cache_sets_async.py
+++ b/tests/cache/test_cache_sets_async.py
@@ -170,7 +170,6 @@ class TestAsyncVersionSrcDst:
 
     @pytest.mark.asyncio
     async def test_asmove_version_src_dst(self, cache: KeyValueCache):
-        """asmove with different source and destination versions."""
         cache.sadd("{vs}:assrc", "a", "b", version=1)
         cache.sadd("{vs}:asdst", "x", version=2)
 

--- a/tests/cache/test_cache_sorted_sets.py
+++ b/tests/cache/test_cache_sorted_sets.py
@@ -8,7 +8,6 @@ class TestSortedSetOperations:
     """Tests for sorted set (ZSET) operations."""
 
     def test_zadd_basic(self, cache: KeyValueCache):
-        """Test adding members to sorted set."""
         result = cache.zadd("scores", {"player1": 100.0, "player2": 200.0})
         assert result == 2
         assert cache.zcard("scores") == 2
@@ -31,26 +30,22 @@ class TestSortedSetOperations:
         assert cache.zscore("scores", "charlie") is None
 
     def test_zadd_with_ch(self, cache: KeyValueCache):
-        """Test zadd with ch flag (return changed count)."""
         cache.zadd("scores", {"player1": 100.0})
         result = cache.zadd("scores", {"player1": 150.0, "player2": 200.0}, ch=True)
         assert result == 2  # 1 changed + 1 added
 
     def test_zcard(self, cache: KeyValueCache):
-        """Test getting sorted set cardinality."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0})
         assert cache.zcard("scores") == 3
         assert cache.zcard("nonexistent") == 0
 
     def test_zcount(self, cache: KeyValueCache):
-        """Test counting members in score range."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0, "e": 5.0})
         assert cache.zcount("scores", 2.0, 4.0) == 3  # b, c, d
         assert cache.zcount("scores", "-inf", "+inf") == 5
         assert cache.zcount("scores", 10.0, 20.0) == 0
 
     def test_zincrby(self, cache: KeyValueCache):
-        """Test incrementing member score."""
         cache.zadd("scores", {"player1": 100.0})
         new_score = cache.zincrby("scores", 50.0, "player1")
         assert new_score == 150.0
@@ -59,7 +54,6 @@ class TestSortedSetOperations:
         assert new_score == 25.0
 
     def test_zpopmax(self, cache: KeyValueCache):
-        """Test popping highest scored members."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0})
         result = cache.zpopmax("scores")
         assert result == [("c", 3.0)]
@@ -71,7 +65,6 @@ class TestSortedSetOperations:
         assert result[1][0] == "d" and result[1][1] == 4.0
 
     def test_zpopmin(self, cache: KeyValueCache):
-        """Test popping lowest scored members."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0})
         result = cache.zpopmin("scores")
         assert result == [("a", 1.0)]
@@ -83,7 +76,6 @@ class TestSortedSetOperations:
         assert result[1][0] == "d" and result[1][1] == 0.5
 
     def test_zrange_basic(self, cache: KeyValueCache):
-        """Test getting range of members by index."""
         cache.zadd("scores", {"alice": 10.0, "bob": 20.0, "charlie": 15.0})
         result = cache.zrange("scores", 0, -1)
         assert result == ["alice", "charlie", "bob"]
@@ -91,19 +83,16 @@ class TestSortedSetOperations:
         assert result == ["alice", "charlie"]
 
     def test_zrange_withscores(self, cache: KeyValueCache):
-        """Test zrange with scores."""
         cache.zadd("scores", {"alice": 10.5, "bob": 20.0, "charlie": 15.5})
         result = cache.zrange("scores", 0, -1, withscores=True)
         assert result == [("alice", 10.5), ("charlie", 15.5), ("bob", 20.0)]
 
     def test_zrevrange(self, cache: KeyValueCache):
-        """Test zrevrange for descending order."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0})
         result = cache.zrevrange("scores", 0, -1)
         assert result == ["c", "b", "a"]
 
     def test_zrangebyscore(self, cache: KeyValueCache):
-        """Test getting members by score range."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0, "e": 5.0})
         result = cache.zrangebyscore("scores", 2.0, 4.0)
         assert result == ["b", "c", "d"]
@@ -111,20 +100,17 @@ class TestSortedSetOperations:
         assert result == ["a", "b"]
 
     def test_zrangebyscore_withscores(self, cache: KeyValueCache):
-        """Test zrangebyscore with scores."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0})
         result = cache.zrangebyscore("scores", 1.0, 2.0, withscores=True)
         assert result == [("a", 1.0), ("b", 2.0)]
 
     def test_zrangebyscore_pagination(self, cache: KeyValueCache):
-        """Test zrangebyscore with pagination."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0, "e": 5.0})
         result = cache.zrangebyscore("scores", "-inf", "+inf", start=1, num=2)
         assert len(result) == 2
         assert result == ["b", "c"]
 
     def test_zrank(self, cache: KeyValueCache):
-        """Test getting member rank."""
         cache.zadd("scores", {"alice": 10.0, "bob": 20.0, "charlie": 15.0})
         assert cache.zrank("scores", "alice") == 0  # Lowest score
         assert cache.zrank("scores", "charlie") == 1
@@ -132,7 +118,6 @@ class TestSortedSetOperations:
         assert cache.zrank("scores", "nonexistent") is None
 
     def test_zrem(self, cache: KeyValueCache):
-        """Test removing members from sorted set."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0})
         result = cache.zrem("scores", "b")
         assert result == 1
@@ -142,7 +127,6 @@ class TestSortedSetOperations:
         assert cache.zcard("scores") == 0
 
     def test_zremrangebyscore(self, cache: KeyValueCache):
-        """Test removing members by score range."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0, "e": 5.0})
         result = cache.zremrangebyscore("scores", 2.0, 4.0)
         assert result == 3  # b, c, d removed
@@ -150,33 +134,28 @@ class TestSortedSetOperations:
         assert cache.zrange("scores", 0, -1) == ["a", "e"]
 
     def test_zrevrange_withscores(self, cache: KeyValueCache):
-        """Test zrevrange with scores."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0})
         result = cache.zrevrange("scores", 0, -1, withscores=True)
         assert result == [("c", 3.0), ("b", 2.0), ("a", 1.0)]
 
     def test_zrevrangebyscore(self, cache: KeyValueCache):
-        """Test getting reverse range by score."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0, "e": 5.0})
         result = cache.zrevrangebyscore("scores", 4.0, 2.0)
         assert result == ["d", "c", "b"]
 
     def test_zscore(self, cache: KeyValueCache):
-        """Test getting member score."""
         cache.zadd("scores", {"alice": 42.5, "bob": 100.0})
         assert cache.zscore("scores", "alice") == 42.5
         assert cache.zscore("scores", "bob") == 100.0
         assert cache.zscore("scores", "nonexistent") is None
 
     def test_sorted_set_serialization(self, cache: KeyValueCache):
-        """Test that complex objects serialize correctly as members."""
         cache.zadd("complex", {("tuple", "key"): 1.0, "string": 2.0})
         result = cache.zrange("complex", 0, -1)
         assert ("tuple", "key") in result or ["tuple", "key"] in result
         assert "string" in result
 
     def test_sorted_set_version_support(self, cache: KeyValueCache):
-        """Test version parameter works correctly."""
         cache.zadd("data", {"v1": 1.0}, version=1)
         cache.zadd("data", {"v2": 2.0}, version=2)
 
@@ -186,7 +165,6 @@ class TestSortedSetOperations:
         assert cache.zrange("data", 0, -1, version=2) == ["v2"]
 
     def test_sorted_set_float_scores(self, cache: KeyValueCache):
-        """Test that float scores work correctly."""
         cache.zadd("precise", {"a": 1.1, "b": 1.2, "c": 1.15})
         result = cache.zrange("precise", 0, -1, withscores=True)
         assert result[0] == ("a", 1.1)
@@ -194,20 +172,17 @@ class TestSortedSetOperations:
         assert result[2] == ("b", 1.2)
 
     def test_sorted_set_negative_scores(self, cache: KeyValueCache):
-        """Test that negative scores work correctly."""
         cache.zadd("temps", {"freezing": -10.0, "cold": 0.0, "warm": 20.0})
         result = cache.zrange("temps", 0, -1)
         assert result == ["freezing", "cold", "warm"]
 
     def test_zpopmin_empty_set(self, cache: KeyValueCache):
-        """Test zpopmin on empty sorted set."""
         result = cache.zpopmin("nonexistent")
         assert result == []
         result = cache.zpopmin("nonexistent", count=5)
         assert result == []
 
     def test_zpopmax_empty_set(self, cache: KeyValueCache):
-        """Test zpopmax on empty sorted set."""
         result = cache.zpopmax("nonexistent")
         assert result == []
         result = cache.zpopmax("nonexistent", count=5)
@@ -222,13 +197,11 @@ class TestSortedSetOperations:
         assert cache.zrevrank("scores", "nonexistent") is None
 
     def test_zmscore(self, cache: KeyValueCache):
-        """Test getting multiple scores at once."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0})
         scores = cache.zmscore("scores", "a", "c", "nonexistent")
         assert scores == [1.0, 3.0, None]
 
     def test_zremrangebyrank(self, cache: KeyValueCache):
-        """Test removing members by rank range."""
         cache.zadd("scores", {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0, "e": 5.0})
         # Remove elements at rank 1-3 (b, c, d)
         result = cache.zremrangebyrank("scores", 1, 3)

--- a/tests/cache/test_cache_tiered.py
+++ b/tests/cache/test_cache_tiered.py
@@ -161,7 +161,6 @@ class TestTieredBasicOps:
         assert tiered_cache.get("dict") == {"a": 1}
 
     def test_set_none_value(self, tiered_cache: BaseCache):
-        """Storing None should be distinguishable from missing."""
         tiered_cache.set("none_key", None)
         assert tiered_cache.get("none_key", "MISS") is None
 
@@ -182,7 +181,6 @@ class TestL1Behavior:
         assert l1.get("l1key") == "l1val"
 
     def test_l1_populated_on_get_miss(self, tiered_cache: BaseCache):
-        """When L1 misses but L2 hits, L1 is populated."""
         l1 = self._get_l1()
         tiered_cache.set("pop_key", "pop_val")
         # Clear L1 only
@@ -306,14 +304,12 @@ class TestL1Behavior:
         assert tiered_cache.has_key("hk_key") is True
 
     def test_add_populates_l1_on_success(self, tiered_cache: BaseCache):
-        """add() populates L1 when L2 add succeeds."""
         tiered_cache.delete("add_l1")
         tiered_cache.add("add_l1", "new_val")
         l1 = self._get_l1()
         assert l1.get("add_l1") == "new_val"
 
     def test_add_skips_l1_on_failure(self, tiered_cache: BaseCache):
-        """add() does not update L1 when key already exists in L2."""
         tiered_cache.set("add_exists", "original")
         l1 = self._get_l1()
         l1.delete("add_exists")
@@ -323,7 +319,6 @@ class TestL1Behavior:
         assert l1.get("add_exists") is None
 
     def test_touch_refreshes_l1(self, tiered_cache: BaseCache):
-        """touch() refreshes L1 TTL when L2 touch succeeds."""
         tiered_cache.set("touch_l1", "val")
         l1 = self._get_l1()
         assert l1.get("touch_l1") == "val"
@@ -450,7 +445,6 @@ class TestTieredAsync:
         assert await tiered_cache.aget("acl") is None
 
     async def test_async_l1_populated_on_miss(self, tiered_cache: BaseCache):
-        """Async get populates L1 on L2 hit."""
         await tiered_cache.aset("al1pop", "val")
         l1 = caches["l1"]
         l1.delete("al1pop")
@@ -460,7 +454,6 @@ class TestTieredAsync:
         assert l1.get("al1pop") == "val"
 
     async def test_async_get_many_partial_l1(self, tiered_cache: BaseCache):
-        """Async get_many with partial L1 hits."""
         await tiered_cache.aset_many({"agm1": "a", "agm2": "b"})
         l1 = caches["l1"]
         l1.delete("agm2")
@@ -501,11 +494,9 @@ class TestTieredCacheConfig:
             caches["default"].get("test")
 
     def test_l1_timeout_from_option(self, tiered_cache: BaseCache):
-        """L1 TTL cap comes from TieredCache's L1_TIMEOUT option."""
         assert tiered_cache._l1_cap == L1_TIMEOUT
 
     def test_l1_timeout_fallback_to_l1_default(self, redis_container: RedisContainerInfo):
-        """When L1_TIMEOUT is omitted, _l1_cap falls back to L1's default_timeout."""
         options = _get_client_library_options(redis_container.client_library)
         location = f"redis://{redis_container.host}:{redis_container.port}?db=1"
         backend_class = BACKENDS[("default", redis_container.client_library, "py")]
@@ -533,17 +524,14 @@ class TestTieredCacheConfig:
             assert cache._l1_cap == 42
 
     def test_cachex_support_level(self, tiered_cache: BaseCache):
-        """TieredCache has 'cachex' support level for admin."""
         assert tiered_cache._cachex_support == "cachex"
 
     def test_locmem_support_level(self):
-        """Our LocMemCache overrides CachexMixin to 'cachex'."""
         from django_cachex.cache.locmem import LocMemCache
 
         assert LocMemCache._cachex_support == "cachex"
 
     def test_mixin_support_level(self):
-        """CachexMixin itself defaults to 'wrapped'."""
         from django_cachex.cache.mixin import CachexMixin
 
         assert CachexMixin._cachex_support == "wrapped"
@@ -566,6 +554,5 @@ class TestTieredSetManyOrdering:
         assert tiered_cache._l2.get("order_b") == "vb"
 
     def test_set_many_returns_l2_result(self, tiered_cache: BaseCache):
-        """set_many should return L2's result (empty list = no failures)."""
         result = tiered_cache.set_many({"order_c": "vc"})
         assert result == []

--- a/tests/cache/test_client.py
+++ b/tests/cache/test_client.py
@@ -55,7 +55,6 @@ class TestRedisCacheClient:
         init_mock,
         get_client_mock,
     ):
-        """Test that delete_pattern passes the pattern directly to scan_iter."""
         mock_client = Mock()
         mock_client.scan_iter.return_value = []
         get_client_mock.return_value = mock_client
@@ -98,7 +97,6 @@ class TestRedisCacheClient:
         init_mock,
         get_client_mock,
     ):
-        """Test that delete_pattern deletes all keys found by scan_iter."""
         mock_client = Mock()
         mock_client.scan_iter.return_value = [":1:foo", ":1:foo-a"]
         mock_client.delete.return_value = 2

--- a/tests/cache/test_cluster_client.py
+++ b/tests/cache/test_cluster_client.py
@@ -28,7 +28,6 @@ class TestRedisClusterCacheClient:
     """Tests for RedisClusterCacheClient."""
 
     def test_get_client_creates_cluster(self):
-        """Test get_client creates a RedisCluster instance."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -41,7 +40,6 @@ class TestRedisClusterCacheClient:
         mock_cluster_cls.assert_called_once()
 
     def test_get_client_caches_cluster(self):
-        """Test get_client caches cluster instances."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -55,7 +53,6 @@ class TestRedisClusterCacheClient:
         assert mock_cluster_cls.call_count == 1
 
     def test_group_keys_by_slot(self):
-        """Test _group_keys_by_slot groups keys correctly."""
         client = setup_cluster_client()
 
         # Keys with same hash tag should be in same slot
@@ -68,7 +65,6 @@ class TestRedisClusterCacheClient:
         assert len(slot_keys) == 3
 
     def test_group_keys_by_slot_different_slots(self):
-        """Test _group_keys_by_slot separates keys in different slots."""
         client = setup_cluster_client()
 
         # Use hash tags that are guaranteed to hash to different slots:
@@ -120,14 +116,12 @@ class TestRedisClusterCacheClient:
         assert "value_c" in result.values()
 
     def test_get_many_empty_keys(self):
-        """Test get_many with empty keys list."""
         client = setup_cluster_client()
 
         result = client.get_many([])
         assert result == {}
 
     def test_delete_many_groups_by_slot(self):
-        """Test delete_many handles cross-slot keys."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -149,7 +143,6 @@ class TestRedisClusterCacheClient:
         assert mock_cluster.delete.call_count == 3
 
     def test_delete_many_empty_keys(self):
-        """Test delete_many with empty keys list."""
         client = setup_cluster_client()
 
         client.delete_many([])
@@ -177,7 +170,6 @@ class TestRedisClusterCacheClient:
         mock_cluster.delete.assert_called_once()
 
     def test_clear_flushes_all_primaries(self):
-        """Test low-level clear() calls flushdb on all primary nodes."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -192,7 +184,6 @@ class TestRedisClusterCacheClient:
         mock_cluster.flushdb.assert_called_once_with(target_nodes="primaries")
 
     def test_keys_scans_all_primaries(self):
-        """Test keys() returns keys from all primary nodes."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -226,7 +217,6 @@ class TestRedisClusterCacheClient:
         assert "prefix:1:foo_3" in result
 
     def test_keys_empty_result(self):
-        """Test keys() with no matching keys."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -247,7 +237,6 @@ class TestRedisClusterCacheClient:
         mock_cluster.keys.assert_called_once()
 
     def test_iter_keys_scans_all_primaries(self):
-        """Test iter_keys() iterates keys from all primary nodes."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -284,7 +273,6 @@ class TestRedisClusterCacheClient:
         assert "prefix:1:bar_3" in result
 
     def test_iter_keys_with_itersize(self):
-        """Test iter_keys() passes itersize to scan_iter."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -307,7 +295,6 @@ class TestRedisClusterCacheClient:
         assert call_kwargs.get("target_nodes") == "primaries"
 
     def test_delete_pattern_deletes_across_primaries(self):
-        """Test delete_pattern() deletes keys from all primary nodes."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -341,7 +328,6 @@ class TestRedisClusterCacheClient:
         assert result == 3
 
     def test_delete_pattern_empty_result(self):
-        """Test delete_pattern() with no matching keys."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster
@@ -363,7 +349,6 @@ class TestRedisClusterCacheClient:
         mock_cluster.delete.assert_not_called()
 
     def test_delete_pattern_groups_by_slot(self):
-        """Test delete_pattern() groups keys by slot for deletion."""
         mock_cluster_cls = MagicMock()
         mock_cluster = MagicMock()
         mock_cluster_cls.return_value = mock_cluster

--- a/tests/cache/test_compressor_fallback.py
+++ b/tests/cache/test_compressor_fallback.py
@@ -8,7 +8,6 @@ class TestDefaultClientCompressorConfig:
     """Tests for DefaultClient compressor configuration handling."""
 
     def test_single_string_config_backwards_compatible(self, redis_container):
-        """Test that single string compressor config still works."""
         from django.test import override_settings
 
         host, port = redis_container.host, redis_container.port
@@ -31,7 +30,6 @@ class TestDefaultClientCompressorConfig:
             cache.delete("test_key")
 
     def test_list_config_with_fallback(self, redis_container):
-        """Test that list compressor config with fallback works."""
         from django.test import override_settings
 
         host, port = redis_container.host, redis_container.port
@@ -58,7 +56,6 @@ class TestDefaultClientCompressorConfig:
             cache.delete("test_key")
 
     def test_migration_scenario(self, redis_container):
-        """Test migrating from one compressor to another."""
         from django.test import override_settings
 
         host, port = redis_container.host, redis_container.port
@@ -111,7 +108,6 @@ class TestDecompressFallback:
     """Tests for the _decompress fallback logic."""
 
     def test_decompress_gzip_with_multiple_compressors(self):
-        """Test that _decompress correctly decompresses gzip data."""
         from django_cachex.client import RedisCacheClient
 
         client = RedisCacheClient(
@@ -190,7 +186,6 @@ class TestDecompressFallback:
             client._decompress(fake_gzip)
 
     def test_decompress_with_no_compressors_returns_raw(self):
-        """When no compressors are configured, _decompress is a no-op pass-through."""
         from django_cachex.client import RedisCacheClient
 
         client = RedisCacheClient(

--- a/tests/cache/test_django_cachex_internals.py
+++ b/tests/cache/test_django_cachex_internals.py
@@ -32,7 +32,6 @@ class TestRedisCacheInternals:
     """
 
     def test_incr_write_connection(self, cache: KeyValueCache):
-        """Verify incr uses write connection."""
         cache.set("number", 42)
         with mock.patch.object(cache._cache, "get_client", wraps=cache._cache.get_client) as mocked_get_client:
             cache.incr("number")
@@ -40,14 +39,12 @@ class TestRedisCacheInternals:
             assert mocked_get_client.call_args.kwargs.get("write") is True
 
     def test_cache_client_class(self, cache: KeyValueCache):
-        """Verify RedisCacheClient class is used."""
         # Check _class attribute points to correct client class
         assert cache._class == RedisCacheClient or issubclass(cache._class, RedisCacheClient.__class__.__bases__)  # type: ignore[attr-defined]
         # Check _cache is an instance of the client
         assert isinstance(cache._cache, cache._class)
 
     def test_get_backend_timeout_method(self, cache: KeyValueCache):
-        """Test get_backend_timeout handles positive, negative, and None values."""
         # Positive timeout returns as-is
         positive_timeout = 10
         positive_backend_timeout = cache.get_backend_timeout(positive_timeout)
@@ -64,7 +61,6 @@ class TestRedisCacheInternals:
         assert none_backend_timeout is None
 
     def test_get_connection_pool_index(self, cache: KeyValueCache):
-        """Test connection pool index selection logic."""
         # Write always returns index 0 (primary)
         pool_index = cache._cache._get_connection_pool_index(write=True)
         assert pool_index == 0
@@ -78,7 +74,6 @@ class TestRedisCacheInternals:
             assert pool_index < len(cache._cache._servers)
 
     def test_get_connection_pool(self, cache: KeyValueCache):
-        """Test ConnectionPool instantiation."""
         import redis
 
         # Write pool
@@ -113,7 +108,6 @@ class TestRedisCacheInternals:
         assert isinstance(cache._cache.encode("abc"), bytes)
 
     def test_redis_pool_options(self, redis_container: RedisContainerInfo):
-        """Test that pool OPTIONS are passed to connection pool."""
         from contextlib import suppress
 
         host = redis_container.host
@@ -153,7 +147,6 @@ class TestRedisCacheClientMethods:
     """Additional tests for CacheClient method behavior."""
 
     def test_get_client_write_vs_read(self, cache: KeyValueCache):
-        """Test get_client respects write parameter."""
         # Both should return valid Redis clients
         write_client = cache._cache.get_client(write=True)
         read_client = cache._cache.get_client(write=False)
@@ -162,7 +155,6 @@ class TestRedisCacheClientMethods:
         assert read_client is not None
 
     def test_connection_pool_caching(self, cache: KeyValueCache):
-        """Test that connection pools are cached and reused."""
         pool1 = cache._cache._get_connection_pool(write=True)
         pool2 = cache._cache._get_connection_pool(write=True)
 
@@ -170,7 +162,6 @@ class TestRedisCacheClientMethods:
         assert pool1 is pool2
 
     def test_multiple_servers_pool_selection(self, redis_container: RedisContainerInfo):
-        """Test pool selection with multiple servers configured."""
         from contextlib import suppress
 
         host = redis_container.host
@@ -208,7 +199,6 @@ class TestConnectionCleanup:
     """Tests for connection pool cleanup behavior."""
 
     def test_sync_pool_is_cached_per_instance(self, cache: KeyValueCache):
-        """Test that sync pools are cached per instance."""
         # Get pool twice - should be same object
         pool1 = cache._cache._get_connection_pool(write=True)
         pool2 = cache._cache._get_connection_pool(write=True)
@@ -410,7 +400,6 @@ class TestConnectionCleanup:
 
     @pytest.mark.asyncio
     async def test_async_pool_reuse_after_operations(self, cache: KeyValueCache):
-        """Test that async pool is reused across multiple async operations."""
         # Skip if async not supported (cluster/sentinel don't have async yet)
         if cache._cache._async_pool_class is None:
             pytest.skip("Async not supported for this client type")
@@ -430,7 +419,6 @@ class TestConnectionCleanup:
 
     @pytest.mark.asyncio
     async def test_mixed_sync_async_operations(self, cache: KeyValueCache):
-        """Test that sync and async operations use separate pools."""
         # Skip if async not supported (cluster/sentinel don't have async yet)
         if cache._cache._async_pool_class is None:
             pytest.skip("Async not supported for this client type")

--- a/tests/cache/test_django_compat.py
+++ b/tests/cache/test_django_compat.py
@@ -20,7 +20,6 @@ class TestDjangoStyleOptions:
     """Test that Django-style configuration OPTIONS work."""
 
     def test_db_option(self, redis_container: RedisContainerInfo):
-        """Test that db option is handled correctly."""
         host = redis_container.host
         port = redis_container.port
 
@@ -43,7 +42,6 @@ class TestDjangoStyleOptions:
             cache.delete("test_db_option")
 
     def test_pool_class_option(self, redis_container: RedisContainerInfo):
-        """Test that pool_class option works (Django-style lowercase)."""
         host = redis_container.host
         port = redis_container.port
 
@@ -64,7 +62,6 @@ class TestDjangoStyleOptions:
             cache.delete("test_pool_class")
 
     def test_parser_class_option(self, redis_container: RedisContainerInfo):
-        """Test that parser_class option works (Django-style lowercase)."""
         host = redis_container.host
         port = redis_container.port
 
@@ -89,7 +86,6 @@ class TestSerializerConfiguration:
     """Test various serializer configuration styles."""
 
     def test_serializer_class(self, redis_container: RedisContainerInfo):
-        """Test serializer as a class (Django builtin style)."""
         host = redis_container.host
         port = redis_container.port
 
@@ -123,7 +119,6 @@ class TestSerializerConfiguration:
             cache.delete("test_class_serializer")
 
     def test_serializer_instance(self, redis_container: RedisContainerInfo):
-        """Test serializer as an instance (Django builtin style)."""
         host = redis_container.host
         port = redis_container.port
 
@@ -154,7 +149,6 @@ class TestSerializerConfiguration:
             cache.delete("test_instance_serializer")
 
     def test_serializer_class_no_options(self, redis_container: RedisContainerInfo):
-        """Test serializer class that doesn't accept options kwarg."""
         host = redis_container.host
         port = redis_container.port
 
@@ -199,20 +193,17 @@ class TestIntegerOptimization:
         assert isinstance(result, int)
 
     def test_large_integer(self, cache: KeyValueCache):
-        """Large integers should work correctly."""
         large_int = 2**60
         cache.set("test_large_int", large_int)
         result = cache.get("test_large_int")
         assert result == large_int
 
     def test_negative_integer(self, cache: KeyValueCache):
-        """Negative integers should work correctly."""
         cache.set("test_neg_int", -999)
         result = cache.get("test_neg_int")
         assert result == -999
 
     def test_boolean_not_integer_optimized(self, cache: KeyValueCache):
-        """Booleans should be serialized (not treated as integers)."""
         cache.set("test_bool_true", True)
         cache.set("test_bool_false", False)
         assert cache.get("test_bool_true") is True
@@ -223,7 +214,6 @@ class TestLocationFormats:
     """Test various LOCATION format variations."""
 
     def test_list_location(self, redis_container: RedisContainerInfo):
-        """Test LOCATION as a list of URLs."""
         host = redis_container.host
         port = redis_container.port
         url = f"redis://{host}:{port}/6"
@@ -242,7 +232,6 @@ class TestLocationFormats:
             cache.delete("test_list_location")
 
     def test_comma_separated_location(self, redis_container: RedisContainerInfo):
-        """Test LOCATION as comma-separated string."""
         host = redis_container.host
         port = redis_container.port
         url = f"redis://{host}:{port}/6"
@@ -266,14 +255,12 @@ class TestAsyncMethods:
     """Test that async methods inherited from Django's BaseCache work."""
 
     async def test_async_get_set(self, cache: KeyValueCache):
-        """Test aget and aset methods."""
         await cache.aset("async_test_key", "async_value")
         result = await cache.aget("async_test_key")
         assert result == "async_value"
         await cache.adelete("async_test_key")
 
     async def test_async_add(self, cache: KeyValueCache):
-        """Test aadd method."""
         await cache.adelete("async_add_key")
         result = await cache.aadd("async_add_key", "first_value")
         assert result is True
@@ -283,21 +270,18 @@ class TestAsyncMethods:
         await cache.adelete("async_add_key")
 
     async def test_async_delete(self, cache: KeyValueCache):
-        """Test adelete method."""
         await cache.aset("async_delete_key", "value")
         result = await cache.adelete("async_delete_key")
         assert result is True
         assert await cache.aget("async_delete_key") is None
 
     async def test_async_has_key(self, cache: KeyValueCache):
-        """Test ahas_key method."""
         await cache.aset("async_has_key", "value")
         assert await cache.ahas_key("async_has_key") is True
         await cache.adelete("async_has_key")
         assert await cache.ahas_key("async_has_key") is False
 
     async def test_async_get_many(self, cache: KeyValueCache):
-        """Test aget_many method."""
         await cache.aset("async_many_1", "value1")
         await cache.aset("async_many_2", "value2")
         result = await cache.aget_many(["async_many_1", "async_many_2", "async_missing"])
@@ -306,7 +290,6 @@ class TestAsyncMethods:
         await cache.adelete("async_many_2")
 
     async def test_async_set_many(self, cache: KeyValueCache):
-        """Test aset_many method."""
         await cache.aset_many({"async_set_1": "v1", "async_set_2": "v2"})
         assert await cache.aget("async_set_1") == "v1"
         assert await cache.aget("async_set_2") == "v2"
@@ -314,7 +297,6 @@ class TestAsyncMethods:
         await cache.adelete("async_set_2")
 
     async def test_async_incr_decr(self, cache: KeyValueCache):
-        """Test aincr and adecr methods."""
         await cache.aset("async_counter", 10)
         result = await cache.aincr("async_counter")
         assert result == 11
@@ -323,7 +305,6 @@ class TestAsyncMethods:
         await cache.adelete("async_counter")
 
     async def test_async_touch(self, cache: KeyValueCache):
-        """Test atouch method."""
         await cache.aset("async_touch_key", "value", timeout=100)
         result = await cache.atouch("async_touch_key", timeout=200)
         assert result is True

--- a/tests/cache/test_django_core_compat.py
+++ b/tests/cache/test_django_core_compat.py
@@ -140,7 +140,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """delete() behaves identically."""
         # Set values
         django_core_cache.set("del_test_dj", "value")
         cachex_cache.set("del_test_cx", "value")
@@ -166,7 +165,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """has_key() behaves identically."""
         django_core_cache.set("has_key_dj", "value")
         cachex_cache.set("has_key_cx", "value")
 
@@ -191,7 +189,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """get_many() behaves identically."""
         # Set some values with both caches
         django_core_cache.set("many_1", "v1")
         django_core_cache.set("many_2", "v2")
@@ -216,7 +213,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """set_many() behaves identically."""
         data = {"sm_a": "val_a", "sm_b": "val_b", "sm_c": 123}
 
         # Both set_many calls
@@ -247,7 +243,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """delete_many() behaves identically."""
         # Set values
         django_core_cache.set("dm_1", "v1")
         django_core_cache.set("dm_2", "v2")
@@ -272,7 +267,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """incr() and decr() behave identically."""
         # Set initial values
         django_core_cache.set("counter_dj", 10)
         cachex_cache.set("counter_cx", 10)
@@ -314,7 +308,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """touch() behaves identically."""
         django_core_cache.set("touch_dj", "value", timeout=100)
         cachex_cache.set("touch_cx", "value", timeout=100)
 
@@ -358,7 +351,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """get_or_set() behaves identically."""
         # Non-existent key - should set and return default
         dj_result = django_core_cache.get_or_set("gos_dj", "default_val")
         cx_result = cachex_cache.get_or_set("gos_cx", "default_val")
@@ -384,7 +376,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """get_or_set() with callable default behaves identically."""
         call_count = {"dj": 0, "cx": 0}
 
         def dj_factory() -> str:
@@ -420,7 +411,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """get() with default parameter behaves identically."""
         dj_result = django_core_cache.get("missing_key", default="fallback")
         cx_result = cachex_cache.get("missing_key", default="fallback")
         assert dj_result == "fallback"
@@ -437,7 +427,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """set() with timeout behaves identically."""
         import time
 
         # Set with very short timeout
@@ -460,7 +449,6 @@ class TestDjangoCoreRedisCompatibility:
         django_core_cache: DjangoCoreRedisCache,
         cachex_cache: CachexRedisCache,
     ) -> None:
-        """set() with timeout=None uses default timeout."""
         # This tests that None timeout behaves consistently
         django_core_cache.set("none_timeout_dj", "value", timeout=None)
         cachex_cache.set("none_timeout_cx", "value", timeout=None)

--- a/tests/cache/test_replica.py
+++ b/tests/cache/test_replica.py
@@ -232,7 +232,6 @@ class TestReplicaSetup:
         self,
         replica_containers: ReplicaSetContainerInfo,
     ):
-        """Test that _servers list is correctly configured."""
         master_url = f"redis://{replica_containers.master_host}:{replica_containers.master_port}/0"
         replica_urls = [
             f"redis://{host}:{port}/0"

--- a/tests/cache/test_sentinel.py
+++ b/tests/cache/test_sentinel.py
@@ -27,7 +27,6 @@ class TestSentinelSetup:
         sentinel_container: SentinelContainerInfo,
         redis_images: tuple[str, str],
     ):
-        """Test that sentinel containers start successfully."""
         _image, client_library = redis_images
         assert sentinel_container.host
         assert sentinel_container.port > 0
@@ -38,7 +37,6 @@ class TestSentinelSetup:
         sentinel_container: SentinelContainerInfo,
         redis_images: tuple[str, str],
     ):
-        """Test basic cache operations through Sentinel."""
         image, client_library = redis_images
 
         # Use appropriate backend based on client library
@@ -91,7 +89,6 @@ class TestSentinelSetup:
         sentinel_container: SentinelContainerInfo,
         redis_images: tuple[str, str],
     ):
-        """Test increment/decrement operations through Sentinel."""
         _image, client_library = redis_images
 
         if client_library == "valkey":
@@ -144,7 +141,6 @@ class TestSentinelAsync:
         sentinel_container: SentinelContainerInfo,
         redis_images: tuple[str, str],
     ):
-        """Test async operations work with Sentinel setup."""
         image, client_library = redis_images
 
         if client_library == "valkey":

--- a/tests/cache/test_serializer_fallback.py
+++ b/tests/cache/test_serializer_fallback.py
@@ -25,7 +25,6 @@ class TestDefaultClientSerializerConfig:
         assert client._serializers[0].__class__.__name__ == "PickleSerializer"
 
     def test_list_config_with_fallback(self, redis_container):
-        """Test that a list config creates multiple serializers."""
         client = RedisCacheClient(
             servers=["redis://localhost:6379/0"],
             serializer=[
@@ -92,7 +91,6 @@ class TestDeserializeFallback:
     """Tests for the _deserialize fallback logic."""
 
     def test_deserialize_json_with_multiple_serializers(self, redis_container):
-        """Test that _deserialize correctly deserializes JSON data."""
         client = RedisCacheClient(
             servers=["redis://localhost:6379/0"],
             serializer=[
@@ -107,7 +105,6 @@ class TestDeserializeFallback:
         assert client._deserialize(json_data) == data
 
     def test_deserialize_pickle_with_json_first(self, redis_container):
-        """Test that _deserialize falls back to pickle for pickle-serialized data."""
         client = RedisCacheClient(
             servers=["redis://localhost:6379/0"],
             serializer=[
@@ -138,7 +135,6 @@ class TestDeserializeFallback:
             client._deserialize(invalid_data)
 
     def test_deserialize_continues_on_failure(self, redis_container):
-        """Test that _deserialize continues to next serializer on failure."""
         client = RedisCacheClient(
             servers=["redis://localhost:6379/0"],
             serializer=[

--- a/tests/cache/test_stampede.py
+++ b/tests/cache/test_stampede.py
@@ -19,14 +19,12 @@ class TestShouldRecompute:
     """Tests for the should_recompute() XFetch function."""
 
     def test_fresh_value_no_recompute(self):
-        """With plenty of TTL remaining, should never trigger."""
         config = StampedeConfig(buffer=60, delta=1.0, beta=1.0)
         # TTL = 350 → remaining = 350 - 60 = 290s
         triggers = sum(1 for _ in range(1000) if should_recompute(350, config))
         assert triggers == 0
 
     def test_expired_always_recomputes(self):
-        """When TTL <= buffer, always triggers (logically expired)."""
         config = StampedeConfig(buffer=60, delta=1.0, beta=1.0)
         # TTL = 50 → remaining = 50 - 60 = -10 → always True
         assert should_recompute(50, config) is True
@@ -41,7 +39,6 @@ class TestShouldRecompute:
         assert triggers > 50
 
     def test_higher_beta_triggers_more(self):
-        """Higher beta increases recomputation probability."""
         low_beta = StampedeConfig(buffer=60, delta=2.0, beta=0.5)
         high_beta = StampedeConfig(buffer=60, delta=2.0, beta=5.0)
         # TTL = 65 → remaining = 5s
@@ -148,7 +145,6 @@ class TestStampedeExtendedTTL:
         assert 300 < ttl <= 360
 
     def test_no_timeout_no_buffer(self, stampede_cache: KeyValueCache):
-        """Persistent keys (timeout=None) should not have TTL extended."""
         stampede_cache.set("sp_persist", "val", timeout=None)
         ttl = stampede_cache.ttl("sp_persist")
         assert ttl is None  # No expiry
@@ -168,7 +164,6 @@ class TestStampedeGetMany:
         assert len(result) == 2
 
     def test_get_many_filters_expired(self, stampede_cache: KeyValueCache):
-        """get_many should filter out logically expired keys."""
         stampede_cache.set("sp_gm_exp", "val", timeout=300)
         # Shrink TTL below buffer → logically expired
         stampede_cache.expire("sp_gm_exp", 50)
@@ -340,7 +335,6 @@ class TestShouldRecomputeEdgeCases:
             assert isinstance(result, bool)
 
     def test_expovariate_edge_via_mock(self):
-        """Mock expovariate to return extreme values and verify no crash."""
         config = StampedeConfig(buffer=60, delta=1.0, beta=1.0)
 
         # Very large expovariate value → large negative threshold → always triggers
@@ -405,7 +399,6 @@ class TestStampedeGetManyConsistency:
     """get_many() stampede behavior should match get() for various value types."""
 
     def test_get_many_filters_logically_expired_consistently(self, stampede_cache: KeyValueCache):
-        """get_many() and get() should agree on which keys are logically expired."""
         stampede_cache.set("sp_gmc_str", "hello", timeout=300)
         stampede_cache.set("sp_gmc_int", 42, timeout=300)
         # Shrink TTL below buffer → logically expired
@@ -419,7 +412,6 @@ class TestStampedeGetManyConsistency:
         assert len(result) == 0
 
     def test_get_many_preserves_fresh_values(self, stampede_cache: KeyValueCache):
-        """Fresh values (well above buffer) should never be filtered."""
         stampede_cache.set("sp_gmc_fresh1", "val", timeout=300)
         stampede_cache.set("sp_gmc_fresh2", 99, timeout=300)
 


### PR DESCRIPTION
Audit follow-up from #86 (theme 5: docstring noise).

## Problem

The audit flagged "hundreds of redundant per-test docstrings" — single-line docstrings that just restate the test function name in English without adding signal. Examples:

```python
def test_index_help_button(self, ...):
    """Help button should show help message."""

def test_pipeline_returns_pipeline_object(self, cache):
    """Test that pipeline() returns a Pipeline object."""

def test_aclear_removes_all(self, cache):
    """Test aclear removes all keys."""
```

A reader gets nothing from the docstring that the test name + body don't already communicate.

## What this PR does

Removes **338 such docstrings** across **24 test files**. **Keeps 132** docstrings that carry real signal.

## Heuristic for "keep"

A docstring is kept if any of the following hold:

- Mentions an issue / PR ref (`#NN`)
- Contains numbers (status codes, sizes, counts, score collisions, etc.)
- Contains semantic terms that document non-obvious behaviour:
  - **Concurrency / correctness:** race, regression, concurrent, atomic, thread, retry, deadlock, flaky, fork
  - **Compatibility / migration:** backwards, migration, compat
  - **Semantic qualifiers:** only, must, even, also, instead, without, before, after, either, both, neither, actually, via
  - **Consistency model:** eventually, idempotent, consistency, guarantee, invariant
  - **Cluster / replication:** redirect, MOVED, ASK, replica, master
  - **Edge cases / bugs:** edge, corner, issue, bug, fix, previously, used to, bypass
  - **Exception class refs:** raises, ImproperlyConfigured, ValueError
- Is substantially longer than the test name alone would suggest (more than `name_tokens + 6` words)

## Sample of kept docstrings (signal worth keeping)

```python
def test_zset_zadd_nx_flag(...):
    """ZADD action with NX flag should only add new members, not update existing."""

def test_close_is_noop(...):
    """Test close() is a no-op — pools persist after close."""

def test_set_get_cross_read(...):
    """Values set by Django core can be read by django-cachex and vice versa."""

def test_l1_serves_without_l2_call(...):
    """After set, L1 has the value so get doesn't need L2."""
```

## Sample of removed docstrings (pure name-restate)

```python
def test_pipeline_lpush_rpush(...):
    """Test lpush/rpush in pipeline."""

def test_aget_many_retrieves_multiple(...):
    """Test aget_many retrieves multiple values."""

def test_decode_single_post(...):
    """Test decode_single_post helper."""
```

## Method

Applied via a small AST-aware regex script (not committed). Caught one bug during dry-run review (regex group misnumbering would have clobbered kept docstrings); reverted, fixed, re-applied. All deletions are pure — no insertions. Verified by `git diff --stat`.

## Test plan

- [x] `ruff check tests/` clean
- [x] `ruff format --check tests/` clean (85 files)
- [x] `pytest tests/admin/` — 356 passed
- [x] `pytest tests/cache/` (excl. cluster/sentinel/replica Docker) — 7488 passed
- [x] Spot-checked diff: pure deletion shape, no test bodies modified

## Net

24 files changed, **−338 / +0**. Test functions are now shorter and lead with their actual logic.

Refs: #86
