### PR TITLE
docs: trim AI-style prose + fix doc/code drift (#86)

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@
 
 - Python 3.14+ (free-threaded supported)
 - Django 6.0+
-- valkey-py 6.1+ or redis-py 6+
+- valkey-py 6.1+ or redis-py 6.0+
 - Valkey server 7+ or Redis server 6+
 
 ## Install with uv
@@ -13,7 +13,7 @@
 uv add django-cachex
 ```
 
-## Install with libvalkey/hiredis (recommended)
+## Install with libvalkey/hiredis
 
 For better performance, install with the libvalkey (for Valkey) or hiredis (for Redis) parser:
 
@@ -25,7 +25,7 @@ uv add django-cachex[libvalkey]
 uv add django-cachex[hiredis]
 ```
 
-These provide C-based parsers that significantly improve performance.
+These provide C-based parsers that improve protocol parsing throughput on the hot read path.
 
 ## Rust I/O driver (optional)
 
@@ -35,16 +35,17 @@ a separate package, `django-cachex-rust`, so users who only want the
 pure-Python backends never carry the binary.
 
 ```console
-# Pure Python (default — no Rust binary)
+# Pure Python (default; no Rust binary)
 uv add django-cachex[valkey]
 
 # With the Rust I/O driver
 uv add django-cachex[valkey,redis-rs]
 ```
 
-Prebuilt `django-cachex-rust` wheels are published for Linux x86_64
-(cp314, cp314t). On other platforms pip will try to build from source,
-which needs the Rust toolchain — drop the `redis-rs` extra to avoid that.
+Prebuilt `django-cachex-rust` wheels are published for Linux x86_64,
+Linux aarch64, macOS arm64, and Windows amd64 on both cp314 and cp314t.
+On other platforms pip will try to build from source, which needs the
+Rust toolchain. Drop the `redis-rs` extra to avoid that.
 
 When the binary isn't installed, `RustValkeyCache` / `RustRedisCache`
 classes are still importable but raise a clean `ImportError` on first

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Valkey and Redis cache backend for Django, with a Django admin UI for cache insp
 A drop-in replacement for Django's built-in Redis cache, plus:
 
 - One package for both Valkey and Redis, default and Sentinel and Cluster.
-- Sync and async are first-class. The async cache also works from sync code.
+- Sync and async support sharing one configuration. The async cache works from sync code too.
 - Hash, list, set, sorted set, and stream operations on the cache object.
 - TTL and pattern helpers (`ttl()`, `expire()`, `keys()`, `delete_pattern()`).
 - Distributed locks: `cache.lock()`.
@@ -20,7 +20,7 @@ A drop-in replacement for Django's built-in Redis cache, plus:
 - Cache stampede prevention (TTL-based XFetch).
 - Two composite backends: `SyncCache` (cross-pod stream-synchronized in-memory cache) and `TieredCache` (L1/L2 with TTL propagation).
 - Django `LocMemCache` and `DatabaseCache` extensions with the same data-structure ops and admin support.
-- Optional Rust I/O driver (PyO3 + tokio + redis-rs) under the same `KeyValueCache` API. Free-threaded CPython (3.14t) supported.
+- Optional Rust I/O driver (PyO3 + tokio + redis-rs) behind the same `KeyValueCache` API. Free-threaded CPython (3.14t) supported.
 - Django admin UI for browsing keys, inspecting values, editing, and flushing.
 
 ## Requirements
@@ -61,7 +61,7 @@ INSTALLED_APPS = [
 
 This project was inspired by [django-redis](https://github.com/jazzband/django-redis) and Django's official [Redis cache backend](https://docs.djangoproject.com/en/stable/topics/cache/#redis). Some utility code for serializers and compressors is derived from django-redis, licensed under BSD-3-Clause. The admin functionality was inspired by [django-redisboard](https://github.com/ionelmc/django-redisboard).
 
-The Rust I/O driver and async bridge are heavily inspired by — and in places directly adapted from — [django-vcache](https://gitlab.com/glitchtip/django-vcache) (MIT, by David Burke / GlitchTip). The fork-safe tokio runtime, the `RustAwaitable` deferred-loop-binding pattern, and the multiplexed-connection design all originate there.
+The Rust I/O driver and async bridge are heavily inspired by, and in places directly adapted from, [django-vcache](https://gitlab.com/glitchtip/django-vcache) (MIT, by David Burke / GlitchTip). The fork-safe tokio runtime, the `RustAwaitable` deferred-loop-binding pattern, and the multiplexed-connection design all originate there.
 
 See also [django-valkey](https://github.com/django-commons/django-valkey) and [dj-cache-panel](https://github.com/yassi/dj-cache-panel) for related projects with similar goals.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -69,10 +69,10 @@ For Sentinel: Use `django_cachex.cache.RedisSentinelCache` instead of `CLIENT_CL
 
 After migrating, you gain:
 
-- **Unified Valkey + Redis support** in one package
-- **Multi-serializer/compressor fallback** for safe migrations
-- **Extended data structures** (hashes, lists, sets, sorted sets) directly on cache
-- **TTL operations** (`ttl()`, `pttl()`, `expire()`, `persist()`)
-- **Pattern operations** (`keys()`, `iter_keys()`, `delete_pattern()`)
-- **Distributed locking** (`cache.lock()`)
-- **Pipelines** (`cache.pipeline()`)
+- Valkey and Redis in one package.
+- Multi-serializer/compressor fallback for safe migrations.
+- Extended data structures (hashes, lists, sets, sorted sets) directly on the cache object.
+- TTL operations: `ttl()`, `pttl()`, `expire()`, `persist()`.
+- Pattern operations: `keys()`, `iter_keys()`, `delete_pattern()`.
+- Distributed locking via `cache.lock()`.
+- Pipelines via `cache.pipeline()`.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -230,6 +230,9 @@ await cache._cache.ahset(key, "field", "value")
 - `asadd`, `asrem`, `asmembers`, `asismember`, `asmismember`, `ascard`, `aspop`, `asrandmember`, `asmove`, `asdiff`, `asdiffstore`, `asinter`, `asinterstore`, `asunion`, `asunionstore`
 - `azadd`, `azcard`, `azcount`, `azincrby`, `azrange`, `azrevrange`, `azrangebyscore`, `azrevrangebyscore`, `azrank`, `azrevrank`, `azrem`, `azremrangebyrank`, `azremrangebyscore`, `azscore`, `azmscore`, `azpopmin`, `azpopmax`
 - `allen`, `alpush`, `arpush`, `alpop`, `arpop`, `alindex`, `alrange`, `alset`, `altrim`, `alrem`, `alpos`, `almove`, `alinsert`, `ablpop`, `abrpop`, `ablmove`
+- `asscan`, `asscan_iter`
+
+The cache object also exposes `aexpire_at` / `apexpire_at` (with underscore) as ergonomic aliases for the client's `aexpireat` / `apexpireat`.
 
 ## Raw Client Access
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -6,7 +6,7 @@
 
 - **Python 3.14+ required.** Dropped support for 3.12 and 3.13. The package now ships on cp314 and cp314t (free-threaded) wheels.
 - **Django 6.0+ required.** Dropped support for Django 5.2.
-- **`SyncCache` wire format changed.** Stream entries now flow through the transport's serializer + compressor pipeline instead of raw pickle. Pods running the new code cannot read entries written by older pods on the same stream — coordinate the rollout (drain or rotate `STREAM_KEY`).
+- **`SyncCache` wire format changed.** Stream entries now flow through the transport's serializer + compressor pipeline instead of raw pickle. Pods running the new code cannot read entries written by older pods on the same stream; coordinate the rollout (drain or rotate `STREAM_KEY`).
 - **`hmset` removed.** Use `hset(key, mapping=...)` or `hset(key, items=...)` (flat key-value list, matching redis-py/valkey-py).
 - **`django_cachex.unfold` removed.** The django-unfold theme variant of the admin is gone, along with the `[unfold]` extra and `examples/unfold/`. Plain `django_cachex.admin` remains. Unfold support may return as a thin theme override once the core admin app stabilises.
 - **`ZStdCompressor` renamed to `ZstdCompressor`** (`django_cachex.compressors.zstd.ZstdCompressor`). Update `OPTIONS["compressor"]` strings.
@@ -67,29 +67,28 @@ Initial stable release of django-cachex.
 
 ### Features
 
-- **Unified Valkey + Redis support** in one package
-- **Full-featured cache backend** for Django
-- **Session backend support** via Django's cache sessions
-- **Pluggable clients** (Default, Sentinel, Cluster)
-- **Pluggable serializers** (Pickle, JSON, MsgPack)
-- **Pluggable compressors** (Zlib, Gzip, LZMA, LZ4, Zstandard)
-- **Multi-serializer/compressor fallback** for safe migrations
-- **Connection pooling** with configurable options
-- **Primary/replica replication** support
-- **Valkey/Redis Sentinel support** for high availability
-- **Valkey/Redis Cluster support** with automatic slot handling
-- **Distributed locks** compatible with `threading.Lock`
-- **TTL operations** (`ttl()`, `pttl()`, `expire()`, `persist()`)
-- **Pattern operations** (`keys()`, `iter_keys()`, `delete_pattern()`)
-- **Pipelines** for batched operations
-- **Lua script interface** with automatic key prefixing and value encoding/decoding
-- **Django Cache Admin** for cache inspection and management
-  - Browse, search, edit, and delete cache keys
-  - View server info, memory statistics, and slowlog
-  - Key type filter sidebar
-  - Support for Django builtin backends (LocMemCache, DatabaseCache, FileBasedCache) via wrappers
-  - Django Unfold theme support (`django_cachex.unfold`)
-- **Async support** for all extended methods
+- Valkey and Redis support in one package.
+- Session backend support via Django's cache sessions.
+- Pluggable clients: Default, Sentinel, Cluster.
+- Pluggable serializers: Pickle, JSON, MsgPack.
+- Pluggable compressors: Zlib, Gzip, LZMA, LZ4, Zstandard.
+- Multi-serializer/compressor fallback for safe migrations.
+- Connection pooling with configurable options.
+- Primary/replica replication support.
+- Valkey/Redis Sentinel support for high availability.
+- Valkey/Redis Cluster support with automatic slot handling.
+- Distributed locks compatible with `threading.Lock`.
+- TTL operations: `ttl()`, `pttl()`, `expire()`, `persist()`.
+- Pattern operations: `keys()`, `iter_keys()`, `delete_pattern()`.
+- Pipelines for batched operations.
+- Lua script interface with automatic key prefixing and value encoding/decoding.
+- Django Cache Admin for cache inspection and management:
+  - Browse, search, edit, and delete cache keys.
+  - View server info, memory statistics, and slowlog.
+  - Key type filter sidebar.
+  - Support for Django builtin backends (LocMemCache, DatabaseCache, FileBasedCache) via wrappers.
+  - Django Unfold theme support (`django_cachex.unfold`).
+- Async support for all extended methods.
 
 ### Data Structure Operations
 

--- a/docs/user-guide/admin.md
+++ b/docs/user-guide/admin.md
@@ -20,11 +20,11 @@ The cache admin will appear in the Django admin sidebar under "Caches".
 
 The admin uses Django's built-in permission system. Superusers have full access. Staff users need explicit permissions:
 
-- `django_cachex.view_cache` / `view_key` — view caches and keys
-- `django_cachex.change_cache` — flush caches, update TTL
-- `django_cachex.add_key` — create keys
-- `django_cachex.change_key` — edit values
-- `django_cachex.delete_key` — delete keys
+- `django_cachex.view_cache` / `view_key`: view caches and keys
+- `django_cachex.change_cache`: flush caches, update TTL
+- `django_cachex.add_key`: create keys
+- `django_cachex.change_key`: edit values
+- `django_cachex.delete_key`: delete keys
 
 ## Support Levels
 
@@ -38,7 +38,7 @@ Different cache backends have different levels of support:
 
 ### Using Redis/Valkey?
 
-If you are using Django's builtin Redis backend (`django.core.cache.backends.redis.RedisCache`), consider switching to django-cachex's `ValkeyCache` or `RedisCache` backends for full admin functionality: key browsing, pattern search, TTL inspection, native data type support, and server statistics. See the [quickstart guide](../getting-started/quickstart.md) for migration instructions.
+The admin works against Django's builtin Redis backend (`django.core.cache.backends.redis.RedisCache`) at the **limited** support level only. Switch to `ValkeyCache` / `RedisCache` for full functionality. See the [quickstart guide](../getting-started/quickstart.md) for migration instructions.
 
 ## Views
 

--- a/docs/user-guide/async.md
+++ b/docs/user-guide/async.md
@@ -1,10 +1,10 @@
 # Async Support
 
-django-cachex implements Django's async cache methods (`aget`, `aset`, `adelete`, etc.) using native async clients from `redis.asyncio` and `valkey.asyncio`. There is no threadpool round-trip.
+django-cachex implements Django's async cache methods (`aget`, `aset`, `adelete`, etc.) using native async clients from `redis.asyncio` and `valkey.asyncio`, so async callers don't pay the asgiref threadpool round-trip.
 
 ## Overview
 
-A single cache backend serves both sync and async callers. `cache.get()` and `await cache.aget()` operate on the same backend with no separate configuration.
+`cache.get()` and `await cache.aget()` operate on the same backend with no separate configuration.
 
 ## Basic Usage
 
@@ -277,7 +277,7 @@ async def user_profile(request, user_id):
 
 async def leaderboard(request):
     # Get top 10 from sorted set (descending by score)
-    top_players = cache.zrevrange(
+    top_players = await cache.azrevrange(
         "game:leaderboard",
         0, 9,
         withscores=True,

--- a/docs/user-guide/compression.md
+++ b/docs/user-guide/compression.md
@@ -24,18 +24,17 @@ CACHES = {
 | `django_cachex.compressors.gzip.GzipCompressor` | — (stdlib) |
 | `django_cachex.compressors.lzma.LzmaCompressor` | — (stdlib) |
 | `django_cachex.compressors.lz4.Lz4Compressor` | `lz4` |
-| `django_cachex.compressors.zstd.ZstdCompressor` | `zstd` (Python < 3.14) |
+| `django_cachex.compressors.zstd.ZstdCompressor` | — (stdlib on 3.14+) |
 
 Install optional dependencies:
 
 ```console
 uv add django-cachex[lz4]
-uv add django-cachex[zstd]   # Python 3.14+ uses the stdlib `compression.zstd` module instead
 ```
 
 ## Performance
 
-Two views — pick whichever matches the decision you're making.
+Two views; pick whichever matches the decision you're making.
 
 ### Micro: algorithm in isolation
 
@@ -55,7 +54,7 @@ compress/decompress are absolute MB/s on the benchmark host.
 
 Same compressors, but measured through `cache.get()` / `cache.set()` /
 `cache.get_many()` / `cache.set_many()` against a real Valkey server.
-Throughput factor is normalized to **no compression** — so the table reads
+Throughput factor is normalized to **no compression**, so the table reads
 "this is what enabling each compressor costs you."
 
 | Compressor | Throughput vs no-compression³ |
@@ -69,14 +68,14 @@ Throughput factor is normalized to **no compression** — so the table reads
 
 Picking guide:
 
-- **`zstd`** is the all-rounder — same ratio as `lzma` at ~60× the compress speed, and only ~10 % slower end-to-end than running with no compression at all. Default choice if available.
-- **`lz4`** when CPU is the bottleneck and a ~40 % larger payload is acceptable. End-to-end throughput is statistically indistinguishable from no compression while still cutting payload size 6×.
-- **`lzma`** only when output size matters more than write latency — and even then `zstd` is usually a better trade now (same ratio, ~3× faster end-to-end).
-- **`zlib`** / **`gzip`** are nearly identical — pick `zlib` unless you need gzip's framing for an external consumer.
-- **No compression** sets the throughput ceiling but stores ~8× more server memory. Outside narrow latency-critical paths, compression almost always wins.
+- `zstd`: same ratio as `lzma` at ~60× the compress speed, and only ~10 % slower end-to-end than no compression at all. Default choice if available.
+- `lz4`: pick when CPU is the bottleneck and a ~40 % larger payload is acceptable. End-to-end throughput is statistically indistinguishable from no compression while still cutting payload size 6×.
+- `lzma`: pick only when output size matters more than write latency. Even then, `zstd` is usually a better trade now (same ratio, ~3× faster end-to-end).
+- `zlib` / `gzip`: nearly identical. Pick `zlib` unless you need gzip's framing for an external consumer.
+- No compression: sets the throughput ceiling but stores ~8× more server memory. Outside narrow latency-critical paths, compression almost always wins.
 
 ¹ Compressed size as a percentage of the input (~14 KiB pickled queryset-shaped payload).
-² Absolute compress/decompress throughput in a tight loop (200 ops × 20 runs, median, single core). Numbers are hardware-dependent — use the ratios between rows, not the absolute values. Real-world impact also depends on payload compressibility — text/JSON compresses ~10×, already-compressed bytes barely shrink.
+² Absolute compress/decompress throughput in a tight loop (200 ops × 20 runs, median, single core). Numbers are hardware-dependent; use the ratios between rows, not the absolute values. Real-world impact also depends on payload compressibility (text/JSON compresses ~10×; already-compressed bytes barely shrink).
 ³ Geometric mean of `get`/`set`/`mget`/`mset` ops/sec end-to-end via Django cache → `rust-valkey` driver → localhost Valkey, normalized to running without a compressor. Reproduce with the [benchmarks](https://github.com/e1plus/django-cachex/tree/main/benchmarks) harness.
 
 ## Fallback for Migration

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -36,7 +36,7 @@ All backends live in `django_cachex.cache`.
 
 ### Valkey / Redis (Rust driver)
 
-Same wire-level features, dispatched through the bundled `_driver` Rust extension (PyO3 + tokio + redis-rs). Async paths skip the threadpool round-trip and a single tokio runtime serves sync and async callers.
+Same wire-level features as the Python driver, dispatched through the optional `django-cachex-rust` extension (PyO3 + tokio + redis-rs). Sync and async share one tokio runtime, so async paths skip the asgiref threadpool round-trip. Install via the `redis-rs` extra.
 
 | Backend | Description |
 |---------|-------------|
@@ -62,7 +62,7 @@ Same wire-level features, dispatched through the bundled `_driver` Rust extensio
 | `TieredCache` | Composes two existing `CACHES` entries as L1/L2 with TTL propagation |
 
 !!! note "Valkey and Redis Compatibility"
-    Valkey and Redis are likely still fully compatible, so either backend works with either server. Valkey is recommended as it remains fully open source.
+    Valkey and Redis are protocol-compatible, so either backend works with either server. Valkey is recommended as it remains fully open source.
 
 ## LOCATION
 

--- a/docs/user-guide/serializers.md
+++ b/docs/user-guide/serializers.md
@@ -20,11 +20,11 @@ CACHES = {
 
 | Serializer | Description | Extra |
 |------------|-------------|-------|
-| `django_cachex.serializers.pickle.PickleSerializer` | Python pickle (default) — supports nearly all Python types | — |
-| `django_cachex.serializers.json.JSONSerializer` | JSON via Django's `DjangoJSONEncoder` — best Django type coverage of the JSON family | — |
-| `django_cachex.serializers.msgpack.MessagePackSerializer` | Pure-Python MessagePack — compact binary format | `msgpack` |
-| `django_cachex.serializers.orjson.OrjsonSerializer` | Rust-backed JSON — fastest JSON, fewer types than `DjangoJSONEncoder` | `orjson` |
-| `django_cachex.serializers.ormsgpack.OrMessagePackSerializer` | Rust-backed MessagePack — fastest overall in our benchmarks | `ormsgpack` |
+| `django_cachex.serializers.pickle.PickleSerializer` | Python pickle (default); supports nearly all Python types | — |
+| `django_cachex.serializers.json.JSONSerializer` | JSON via Django's `DjangoJSONEncoder` (broadest Django type coverage of the JSON family) | — |
+| `django_cachex.serializers.msgpack.MessagePackSerializer` | Pure-Python MessagePack; compact binary format | `msgpack` |
+| `django_cachex.serializers.orjson.OrjsonSerializer` | Rust-backed JSON; fewer types than `DjangoJSONEncoder` | `orjson` |
+| `django_cachex.serializers.ormsgpack.OrMessagePackSerializer` | Rust-backed MessagePack | `ormsgpack` |
 
 Install optional serializers via the matching extra:
 
@@ -62,7 +62,7 @@ Real network or larger payloads dampen the spread. Reproduce with the
 
 Notes:
 
-- The "~" cells are not bugs — they reflect what the underlying format can
+- The "~" cells are not bugs; they reflect what the underlying format can
   represent. `Decimal("1.99")` round-trips through `DjangoJSONEncoder` as the
   string `"1.99"`; if you need a `Decimal` back, convert on read.
 - `orjson` natively encodes `dataclass` and `Enum` values, but loses the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Django CacheX
-site_description: Full featured Redis and Valkey cache backend for Django
+site_description: Valkey and Redis cache backend for Django, with a Django admin UI for cache inspection.
 site_url: https://oliverhaas.github.io/django-cachex/
 repo_url: https://github.com/oliverhaas/django-cachex
 repo_name: oliverhaas/django-cachex


### PR DESCRIPTION
## Summary

Docs portion of the [#86](https://github.com/oliverhaas/django-cachex/issues/86) audit. The findings split into two buckets:

### Real correctness fixes
- [async.md](https://github.com/oliverhaas/django-cachex/blob/main/docs/user-guide/async.md) `leaderboard` example used sync `cache.zrevrange` inside an `async def` view — now `await cache.azrevrange(...)`.
- [compression.md](https://github.com/oliverhaas/django-cachex/blob/main/docs/user-guide/compression.md) zstd extras qualifier said \"(Python < 3.14)\" but the project requires 3.14+ (the extra is a no-op now). Updated.
- [api.md](https://github.com/oliverhaas/django-cachex/blob/main/docs/reference/api.md) async list missed `asscan` / `asscan_iter`. Added, plus a note that the cache exposes underscore aliases (`aexpire_at`, `apexpire_at`) for the client's no-underscore names.
- [installation.md](https://github.com/oliverhaas/django-cachex/blob/main/docs/getting-started/installation.md) prebuilt-wheel claim updated to match PR #92's expanded matrix (Linux x86_64/aarch64, macOS arm64, Windows amd64); valkey-py / redis-py minimum-version notation aligned with [index.md](https://github.com/oliverhaas/django-cachex/blob/main/docs/index.md).
- [configuration.md](https://github.com/oliverhaas/django-cachex/blob/main/docs/user-guide/configuration.md) \"Valkey and Redis are *likely still* fully compatible\" → the confident wording quickstart.md already uses.
- `mkdocs.yml` `site_description` rewritten away from \"Full featured ...\" marketing phrasing.

### Prose cleanup
- Em-dash sweep across compression.md, serializers.md, admin.md, index.md, changelog.md (mid-sentence em-dashes → commas / colons / semicolons / parens).
- Unbolded lead phrases in changelog.md \"0.1.0 Features\" and migration.md \"New Features\" lists.
- Tightened a few promotional phrasings: \"first-class\", \"consider switching to ... for full admin functionality\", \"There is no threadpool round-trip.\", the Rust-driver pitch in configuration.md.
- Dropped \"(recommended)\" from the libvalkey/hiredis section header; the body explains why.

### Findings deliberately not applied
- ttl `-2` doc/type drift: the doc is correct (Redis returns -2 for not found); the `int | None` annotation is misleading but fixing it is a code change, out of scope.
- `noop_post` flagged as a no-op helper of unclear purpose: kept as documented public API for hooks where you only want key prefixing on the pre side.
- `D7` ASCII pool diagram in async.md: useful mental model for the per-event-loop caching, kept.
- `K8` uniform bullet grammar across multiple files: largely subjective. Did not rewrite tables and lists where the parallel structure is part of the format.
- `D6` short subsections in advanced.md (SETNX, Increment/Decrement): kept; readers scan via the section header.
- `recipes.md` `fakeredis.FakeConnectionPool` example: fakeredis isn't in our test deps so I couldn't verify, but the recipe pre-dates the audit and reads plausibly. Left as-is.
- `retry_on_timeout=True` example: still works in current redis-py (verified locally with no `DeprecationWarning`); left as-is.

### Net

11 files changed, +71 / −69 lines.

## Test plan

- [x] \`mkdocs build --strict\` clean
- [x] \`ruff check\` / \`ruff format --check\` clean (workflow runs the full lint stack)
- [x] No broken markdown links or anchor refs introduced

Refs #86.