### PR TITLE
refactor: cache-backends prose + small correctness fixes (#86)

### DIFF
--- a/django_cachex/cache/database.py
+++ b/django_cachex/cache/database.py
@@ -188,32 +188,26 @@ class DatabaseCache(CachexMixin, DjangoDatabaseCache):
     # =========================================================================
 
     def info(self, section: str | None = None) -> dict[str, Any]:
-        """Get DatabaseCache info in structured format."""
+        """Get DatabaseCache info in Redis-INFO-shaped format for admin uniformity."""
         conn = self._get_connection()
         table = self._get_table_name()
         quoted = conn.ops.quote_name(table)
 
-        total_count: int | str = 0
-        active_count: int | str = 0
-        expired_count: int | str = 0
-
+        total_count = 0
+        active_count = 0
         try:
             with conn.cursor() as cursor:
                 cursor.execute(f"SELECT COUNT(*) FROM {quoted}")  # noqa: S608
                 total_count = cursor.fetchone()[0]
-
                 now_adapted = _adapt_dt(conn, _now())
                 cursor.execute(
                     f"SELECT COUNT(*) FROM {quoted} WHERE expires > %s",  # noqa: S608
                     [now_adapted],
                 )
                 active_count = cursor.fetchone()[0]
-                expired_count = (
-                    total_count - active_count if isinstance(total_count, int) and isinstance(active_count, int) else 0
-                )
-        except Exception:  # noqa: BLE001
-            total_count = "error"
-            active_count = "error"
+        except Exception:  # noqa: BLE001, S110
+            # Don't crash the admin if a query fails; return zeros.
+            pass
 
         return {
             "backend": "DatabaseCache",
@@ -223,11 +217,11 @@ class DatabaseCache(CachexMixin, DjangoDatabaseCache):
             },
             "keyspace": {
                 "db0": {
-                    "keys": active_count if active_count != "error" else 0,
-                    "expires": active_count if active_count != "error" else 0,
+                    "keys": active_count,
+                    "expires": active_count,
                 },
             },
             "stats": {
-                "expired_keys": expired_count,
+                "expired_keys": total_count - active_count,
             },
         }

--- a/django_cachex/cache/default.py
+++ b/django_cachex/cache/default.py
@@ -782,9 +782,9 @@ class KeyValueCache(BaseCache):
     def flush_db(self) -> bool:
         """Flush the entire Redis database (``FLUSHDB``).
 
-        **Danger:** This removes *all* keys in the database, not just those
-        belonging to this cache. Only use when this cache has a dedicated
-        Redis database.
+        Removes all keys in the database, not just those belonging to this
+        cache. Only use when this cache has a dedicated Redis database;
+        otherwise use ``clear()``.
         """
         return self._cache.clear()
 

--- a/django_cachex/cache/locmem.py
+++ b/django_cachex/cache/locmem.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import fnmatch
 import threading
 import time
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from django.core.cache.backends.locmem import LocMemCache as DjangoLocMemCache
@@ -54,6 +55,14 @@ class LocMemCache(CachexMixin, DjangoLocMemCache):
 
     _cachex_support: str = "cachex"
 
+    # Type-only declarations for attributes Django's BaseCache + LocMemCache
+    # set in __init__ but don't surface in stubs.
+    if TYPE_CHECKING:
+        _cache: dict[str, Any]
+        _expire_info: dict[str, float | None]
+        _max_entries: int
+        _cull_frequency: int
+
     def __init__(self, name: str, params: dict[str, Any]) -> None:
         super().__init__(name, params)
         # Per-name reentrant lock so concurrent compound ops serialize.
@@ -76,11 +85,11 @@ class LocMemCache(CachexMixin, DjangoLocMemCache):
 
     def _get_internal_cache(self) -> dict[str, Any]:
         """Access the internal cache dictionary of LocMemCache."""
-        return getattr(self, "_cache", {})
+        return self._cache
 
     def _get_expire_info(self) -> dict[str, float | None]:
         """Access the internal expiry info dictionary."""
-        return getattr(self, "_expire_info", {})
+        return self._expire_info
 
     # =========================================================================
     # TTL Operations
@@ -105,8 +114,6 @@ class LocMemCache(CachexMixin, DjangoLocMemCache):
 
     def expire(self, key: KeyT, timeout: ExpiryT, version: int | None = None) -> bool:
         """Set the TTL of a key."""
-        from datetime import timedelta
-
         internal_key = self.make_key(str(key), version=version)
         internal_cache = self._get_internal_cache()
         if internal_key not in internal_cache:
@@ -171,8 +178,8 @@ class LocMemCache(CachexMixin, DjangoLocMemCache):
             total_size += sum(_deep_getsizeof(k) for k in internal_cache)
         except Exception:  # noqa: BLE001
             total_size = 0
-        max_entries = getattr(self, "_max_entries", 300)
-        cull_frequency = getattr(self, "_cull_frequency", 3)
+        max_entries = self._max_entries
+        cull_frequency = self._cull_frequency
         return {
             "backend": "LocMemCache",
             "server": {

--- a/django_cachex/cache/mixin.py
+++ b/django_cachex/cache/mixin.py
@@ -48,31 +48,21 @@ def _compound_op(method: Callable[..., Any]) -> Callable[..., Any]:
 
 
 class CachexMixin(BaseCacheExtensions):
-    """Mixin providing cachex extension methods for any BaseCache subclass.
+    """Cachex extension methods for any BaseCache subclass.
 
-    Add this as a parent class alongside a Django cache backend to get:
-    - Data structure operations (lists, sets, hashes, sorted sets)
-    - Type detection
-    - Admin support markers (``_cachex_support``)
-    - Default ``scan()`` built on ``keys()``
-
-    Inherits from ``BaseCacheExtensions``, which provides the full method
-    surface as ``raise NotSupportedError`` defaults — this class overrides
-    only the operations it implements via get/set on Python objects.
-
+    Adds data structure ops (lists, sets, hashes, sorted sets), type
+    detection, admin markers, and a default ``scan()`` built on ``keys()``.
     Subclasses should implement ``ttl()``, ``expire()``, ``persist()``,
     ``info()``, and ``keys()`` for full admin support.
 
-    **Limitations:**
-
-    - **Thread safety:** Compound read-modify-write ops (``lpush``, ``sadd``,
-      ``hset``, ``hincrby``, ``zadd``, …) are wrapped in
-      ``self._compound_op_lock()``, which defaults to a no-op. Subclasses
-      with thread-safe locking primitives (e.g. ``LocMemCache``, which has
-      ``self._lock``) should override the hook to make these ops atomic.
-    - **Type detection:** ``type()`` inspects the stored Python value. Sorted
-      sets (stored as ``dict[Any, float]``) are indistinguishable from hashes
-      (``dict[str, Any]``) when the sorted set has string keys.
+    Limitations:
+    - Compound read-modify-write ops (``lpush``/``sadd``/``hset``/etc.) are
+      wrapped in ``self._compound_op_lock()``, which defaults to a no-op.
+      Subclasses with locking primitives should override the hook to make
+      these ops atomic (``LocMemCache`` does so via its own ``RLock``).
+    - ``type()`` inspects the stored Python value, so sorted sets stored
+      as ``dict[Any, float]`` with string members are indistinguishable
+      from hashes.
     """
 
     _cachex_support = "wrapped"

--- a/django_cachex/cache/rust.py
+++ b/django_cachex/cache/rust.py
@@ -1,10 +1,8 @@
 """Django cache backends backed by the Rust ``RustValkeyDriver``.
 
-These backends extend :class:`KeyValueCache` and only differ from the
-existing pure-Python backends in their ``_class`` attribute — every
-high-level cache method is inherited unchanged. Users opt in via Django's
-``CACHES["default"]["BACKEND"]`` setting; the existing
-``ValkeyCache`` / ``RedisCache`` etc. continue to work side by side.
+Each subclass differs from the corresponding pure-Python backend only in its
+``_class`` attribute; every high-level cache method is inherited unchanged.
+Users opt in via ``CACHES["default"]["BACKEND"]``.
 """
 
 from __future__ import annotations

--- a/django_cachex/cache/sync.py
+++ b/django_cachex/cache/sync.py
@@ -26,19 +26,19 @@ Configuration::
         },
     }
 
-``TRANSPORT`` is the alias of any cachex ``KeyValueCache`` subclass — pure-Python
-or Rust-driver-backed — used for stream I/O.
+``TRANSPORT`` is the alias of any cachex ``KeyValueCache`` subclass (pure-Python
+or Rust-driver-backed) used for stream I/O.
 ``STREAM_KEY`` is the Redis Stream key shared by all pods (default ``cache:sync``).
 ``MAXLEN`` caps stream length via approximate trimming (default 10000).
 ``BLOCK_TIMEOUT`` is the XREAD BLOCK timeout in milliseconds (default 1000).
 ``REPLAY`` is the number of recent stream entries to replay on startup to
-warm the local cache (default 0 = no replay). Values up to ``MAXLEN`` are
-useful — e.g. ``1000`` replays the last 1000 mutations so a restarting pod
-doesn't start with an empty cache.
+warm the local cache (default 0 = no replay). Values up to ``MAXLEN`` work;
+``1000`` replays the last 1000 mutations so a restarting pod doesn't start
+with an empty cache.
 
-**Wire format:** stream fields go through the *transport* cache's high-level
+Wire format: stream fields go through the transport cache's high-level
 ``xadd``/``xread``/``xrevrange`` methods, which apply its configured serializer
-and compressor end-to-end. So if the transport is configured with
+and compressor end-to-end. If the transport is configured with
 ``OPTIONS={"serializer": "msgpack", "compressor": "zstd"}``, stream entries
 are msgpack-then-zstd. All pods sharing one ``STREAM_KEY`` must use the same
 transport ``BACKEND`` + ``OPTIONS`` so their serializers agree.
@@ -75,21 +75,19 @@ logger = logging.getLogger(__name__)
 class SyncCache(LocMemCache):
     """Stream-synchronized in-memory cache.
 
-    Extends Django's ``LocMemCache`` with cross-pod synchronization. All reads
-    are local dict lookups (inherited from ``LocMemCache``). Writes update
-    the local dict and publish to a Redis Stream via the transport cache's
-    high-level ``xadd``. A daemon thread consumes the stream via ``xread``
-    and applies remote changes. All supported operations are
-    **eventually consistent** (last-writer-wins).
+    Extends Django's ``LocMemCache`` with cross-pod synchronization. Reads are
+    local dict lookups (inherited from ``LocMemCache``). Writes update the
+    local dict and publish to a Redis Stream via the transport cache's
+    ``xadd``. A daemon thread consumes the stream via ``xread`` and applies
+    remote changes. Supported operations are eventually consistent
+    (last-writer-wins).
 
-    **Unsupported operations**: ``add``, ``incr``, and ``decr`` raise
-    ``NotSupportedError``. These have semantics (atomic check-and-set,
-    atomic increment) that cannot be provided with eventual consistency.
-    Use the transport cache directly for these.
+    ``add``, ``incr``, and ``decr`` raise ``NotSupportedError``: their
+    semantics (atomic check-and-set, atomic increment) can't be provided
+    with eventual consistency. Use the transport cache directly for these.
 
-    **Fail-safe**: The consumer thread is automatically restarted if it dies.
-    Use ``info()["sync"]`` to monitor consumer health, last read age, and
-    stream position.
+    The consumer thread is restarted if it dies; use ``info()["sync"]`` to
+    monitor consumer health, last read age, and stream position.
     """
 
     _cachex_support: str = "cachex"
@@ -526,7 +524,7 @@ class SyncCache(LocMemCache):
         self._publish("clear")
 
     def close(self, **kwargs: Any) -> None:
-        """No-op: consumer thread persists across requests (daemon=True for cleanup)."""
+        """No-op. Use ``shutdown()`` to stop the consumer thread + publish executor."""
 
     # -- Admin methods (local implementations for fast reads) --
 

--- a/django_cachex/cache/tiered.py
+++ b/django_cachex/cache/tiered.py
@@ -45,7 +45,7 @@ from django_cachex.exceptions import NotSupportedError
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
-    from django_cachex.types import KeyT
+    from django_cachex.types import ExpiryT, KeyT
 
 # Sentinel to distinguish "not in L1" from a stored None
 _L1_MISS = object()
@@ -401,7 +401,7 @@ class TieredCache(BaseCache):
     def persist(self, key: KeyT, version: int | None = None) -> bool:
         return self._delegate("persist", key, version=version)
 
-    def expire(self, key: KeyT, timeout: int, version: int | None = None) -> bool:
+    def expire(self, key: KeyT, timeout: ExpiryT, version: int | None = None) -> bool:
         self._l1.delete(key, version=version)
         return self._delegate("expire", key, timeout, version=version)
 


### PR DESCRIPTION
## Summary

Cache-backends portion of the [#86](https://github.com/oliverhaas/django-cachex/issues/86) audit. **A lot of the findings in the audit comment were wrong on a second pass** — listing those first since they shape what this PR does (and doesn't) do.

### Findings the audit got wrong

- **CRITICAL "Python-2 syntax" claim in `tiered.py`** (lines 120, 128, 354). `except AttributeError, NotSupportedError, TypeError:` is **valid Python 3.14+** under PEP 758. Verified locally: `from django_cachex.cache.tiered import TieredCache` imports fine; the package's main test suite was passing on `main` all along. Closing the finding (and dropping the audit-summary sentence that claimed the package fails to import).
- **`[L4]` "double-prefixing risk in `TieredCache`"**: false positive. L1 and L2 are independent `BaseCache` instances each with its own prefix scope; `TieredCache` itself doesn't add a prefix.
- **`[F2]` `_delegate` re-raises `NotSupportedError` "adding nothing"**: wrong. It swaps L2's attribution for `TieredCache`'s, which is what the admin needs to identify which cache failed.
- **`[K1]` line 6 em-dash in `tiered.py`**: there's no em-dash on line 6.
- **`[D7]` `cluster.py:38` "marketing"**: `\"Keys are sharded across nodes by hash slot.\"` is a one-line factual description, not marketing.

### What this PR actually changes

- `database.py info()`: dropped the `int | str` "error" sentinel and the redundant `isinstance(...)` re-checks. On query failure we report zeros, which is what the admin renders anyway.
- `locmem.py`: dropped defensive `getattr(self, "_cache", {})` / `getattr(self, "_max_entries", 300)` patterns (these are guaranteed by Django's `BaseCache` / `LocMemCache.__init__`). Added a `TYPE_CHECKING` declaration block so type checkers see them. Moved `from datetime import timedelta` out of the `expire()` body to module-level (matches `database.py`).
- `mixin.py`: trimmed the marketing-style class docstring + `**Limitations:**` bold-headers down to a plain prose Limitations block.
- `sync.py`: trimmed em-dashes in the module docstring; unbolded `**Unsupported operations**:` / `**Fail-safe**:` lead phrases; clarified misleading `close()` docstring.
- `rust.py`: tightened module docstring, dropped the em-dashed "only differ from the existing pure-Python backends" framing.
- `default.py`: unbolded the `**Danger:**` flush_db warning.
- `tiered.py`: `expire(timeout: int)` → `expire(timeout: ExpiryT)` to match the rest of the cache surface.

### Findings deliberately not applied (kept)

- `[A4]` 2800 lines of 1:1 `default.py` method delegation: necessary by design — Django's `BaseCache` requires these on the cache, not the client.
- `[A6]` `cluster.py pipeline(transaction=...)` ignored: kept for signature parity with the parent class so cluster cache is interchangeable with non-cluster.
- `[D6]` section dividers in `default.py`: useful navigational anchors in a 2800-line file.
- `[H2]` cluster.py vs sentinel.py import-fallback style: cosmetic; both are clear enough.
- `[L5]` `database.py` info() Redis-INFO-shaped, `[C1]/[D3]` "db0" / `redis_version`: by design — admin treats all caches uniformly.
- `[L5]` `mixin.py` / `sync.py` `type()` doesn't return Redis types: fundamental limitation of stores that don't have native zsets/streams.
- `[B5]` `tiered.py:107 is DEFAULT_TIMEOUT`: identity-comparison against Django's own sentinel constant — Django uses this pattern itself.
- `[F4]/[F5]` tiered.py `_delegate` multi-class except + `from None`: graceful fallback that intentionally replaces L2's attribution with TieredCache's.
- `[A2]/[A8]` mixin / locmem 1-line getter helpers: centralize the "this is how we reach Django's internal dict" knowledge for the data-structure ops; inlining 6× would lose that anchor.
- `[D1]` simple-wrapper docstrings in `default.py`: most are short and describe public behaviour; bulk-removing them would harm IDE introspection.

### Net

7 files, **+62 / −75 LoC** (-13).

## Test plan

- [x] \`ruff check\` / \`ruff format --check\`
- [x] \`mypy django_cachex/\` — 53 source files, clean
- [x] \`ty check django_cachex/\` — clean
- [x] Full cache + admin suite — 7881 passed, 241 skipped
  - Two cluster-container startup races under parallel `-n auto` pytest, unrelated; pass cleanly when run isolated.

Refs #86.