### PR TITLE
refactor(architecture): move encoding stack from Adapter to Cache layer

### DIFF
--- a/django_cachex/adapter/cluster.py
+++ b/django_cachex/adapter/cluster.py
@@ -19,7 +19,7 @@ from django_cachex.exceptions import NotSupportedError
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 
-    from django_cachex.adapter.pipeline import Pipeline
+    from django_cachex.adapter.pipeline import BaseKeyValuePipelineAdapter
     from django_cachex.types import KeyT
 
 # =============================================================================
@@ -160,7 +160,7 @@ class BaseKeyValueClusterAdapter(BaseKeyValueAdapter):
                 if isinstance(ttl, int) and ttl > 0 and should_recompute(ttl, config):
                     del found[k]
 
-        return {k: self.decode(v) for k, v in found.items()}
+        return dict(found.items())
 
     @override
     def set_many(
@@ -176,7 +176,7 @@ class BaseKeyValueClusterAdapter(BaseKeyValueAdapter):
 
         client = self.get_client(write=True)
 
-        prepared_data = {k: self.encode(v) for k, v in data.items()}
+        prepared_data = dict(data.items())
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -333,7 +333,7 @@ class BaseKeyValueClusterAdapter(BaseKeyValueAdapter):
                 if isinstance(ttl, int) and ttl > 0 and should_recompute(ttl, config):
                     del found[k]
 
-        return {k: self.decode(v) for k, v in found.items()}
+        return dict(found.items())
 
     @override
     async def aset_many(
@@ -349,7 +349,7 @@ class BaseKeyValueClusterAdapter(BaseKeyValueAdapter):
 
         client = self.get_async_client(write=True)
 
-        prepared_data = {k: self.encode(v) for k, v in data.items()}
+        prepared_data = dict(data.items())
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -469,18 +469,12 @@ class BaseKeyValueClusterAdapter(BaseKeyValueAdapter):
         """No-op. Cluster lives for the instance's lifetime (matches Django's BaseCache)."""
 
     @override
-    def pipeline(
-        self,
-        *,
-        transaction: bool = True,
-        version: int | None = None,
-    ) -> Pipeline:
-        """Create a pipeline for batched operations. Transactions are ignored in cluster mode."""
-        from django_cachex.adapter.pipeline import Pipeline, RedisPipelineAdapter
+    def pipeline(self, *, transaction: bool = True) -> BaseKeyValuePipelineAdapter:
+        """Construct a cluster pipeline adapter. Transactions are ignored in cluster mode."""
+        from django_cachex.adapter.pipeline import RedisPipelineAdapter
 
         client = self.get_client(write=True)
-        pipeline_adapter = RedisPipelineAdapter(client.pipeline(transaction=False))
-        return Pipeline(adapter=self, pipeline_adapter=pipeline_adapter, version=version)
+        return RedisPipelineAdapter(client.pipeline(transaction=False))
 
 
 # =============================================================================

--- a/django_cachex/adapter/default.py
+++ b/django_cachex/adapter/default.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from django.utils.module_loading import import_string
 
-from django_cachex.exceptions import CompressorError, SerializerError, _main_exceptions
+from django_cachex.exceptions import _main_exceptions
 from django_cachex.stampede import StampedeConfig, should_recompute
 from django_cachex.types import KeyType
 
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     import builtins
     from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 
-    from django_cachex.adapter.pipeline import Pipeline
+    from django_cachex.adapter.pipeline import BaseKeyValuePipelineAdapter
     from django_cachex.types import AbsExpiryT, ExpiryT, KeyT, _Set
 
 # Try to import redis-py and/or valkey-py
@@ -69,15 +69,6 @@ except ImportError:
 _ASYNC_POOLS: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[tuple[Any, ...], Any]] = (
     weakref.WeakKeyDictionary()
 )
-
-
-def _load_codec(config: str | type | Any) -> Any:
-    """Resolve a serializer/compressor config: dotted-path / class / instance → instance."""
-    if isinstance(config, str):
-        config = import_string(config)
-    if callable(config):
-        return config()
-    return config
 
 
 def _options_key(options: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
@@ -131,13 +122,18 @@ class BaseKeyValueAdapter:
     def __init__(
         self,
         servers: list[str],
-        serializer: str | list | builtins.type[Any] | None = None,
         pool_class: str | builtins.type[Any] | None = None,
         parser_class: str | builtins.type[Any] | None = None,
         async_pool_class: str | builtins.type[Any] | None = None,
         **options: Any,
     ) -> None:
-        """Initialize the cache client."""
+        """Initialize the wire-level adapter.
+
+        Encoding (serializer + compressor) is owned by the cache layer
+        (``KeyValueCache``); adapter methods take and return raw bytes.
+        ``serializer`` / ``compressor`` keys in ``options`` are silently
+        ignored here — the cache reads them directly from its own options.
+        """
         # Store servers
         self._servers = servers
         self._pools: dict[int, Any] = {}
@@ -171,19 +167,6 @@ class BaseKeyValueAdapter:
         # Store full options for our extensions
         self._options = options
 
-        # Setup compressors (extension beyond Django)
-        compressor_config = options.get("compressor")
-        self._compressors = self._create_compressors(compressor_config)
-
-        # Setup multi-serializer fallback (extension beyond Django)
-        # Use the explicit serializer parameter if provided, otherwise check options
-        serializer_config = (
-            serializer
-            if serializer is not None
-            else options.get("serializer", "django_cachex.serializers.pickle.PickleSerializer")
-        )
-        self._serializers = self._create_serializers(serializer_config)
-
         # Setup stampede prevention (XFetch algorithm)
         stampede_config = options.get("stampede_prevention")
         if stampede_config:
@@ -193,77 +176,6 @@ class BaseKeyValueAdapter:
                 self._stampede_config = StampedeConfig()
         else:
             self._stampede_config = None
-
-    # =========================================================================
-    # Serializer/Compressor Setup
-    # =========================================================================
-
-    def _create_serializers(self, config: str | list | builtins.type[Any] | Any) -> list:
-        if config is None:
-            config = "django_cachex.serializers.pickle.PickleSerializer"
-        items: list = config if isinstance(config, list) else [config]
-        return [_load_codec(item) for item in items]
-
-    def _create_compressors(self, config: str | list | builtins.type[Any] | Any | None) -> list:
-        if config is None:
-            return []
-        items: list = config if isinstance(config, list) else [config]
-        return [_load_codec(item) for item in items]
-
-    def _decompress(self, value: bytes) -> bytes:
-        """Decompress with fallback support for multiple compressors.
-
-        Returns ``value`` unchanged when no compressors are configured. Raises
-        ``CompressorError`` if every configured compressor fails — symmetric
-        with ``_deserialize``. To accept uncompressed payloads alongside
-        compressed ones (e.g. mid-migration), keep the previously-used
-        compressor at the end of the fallback chain.
-        """
-        if not self._compressors:
-            return value
-        last_error: CompressorError | None = None
-        for compressor in self._compressors:
-            try:
-                return compressor.decompress(value)
-            except CompressorError as e:
-                last_error = e
-        # Every configured compressor failed.
-        raise last_error if last_error is not None else CompressorError("decompression failed")
-
-    def _deserialize(self, value: bytes) -> Any:
-        """Deserialize with fallback support for multiple serializers."""
-        last_error: SerializerError | None = None
-        for serializer in self._serializers:
-            try:
-                return serializer.loads(value)
-            except SerializerError as e:
-                last_error = e
-                continue
-
-        if last_error is not None:
-            raise last_error
-        raise SerializerError("No serializers configured")
-
-    # =========================================================================
-    # Encoding/Decoding
-    # =========================================================================
-
-    def encode(self, value: Any) -> bytes | int:
-        """Encode a value for storage (serialize + compress). Plain ints pass through unchanged."""
-        if isinstance(value, bool) or not isinstance(value, int):
-            value = self._serializers[0].dumps(value)
-            if self._compressors:
-                return self._compressors[0].compress(value)
-            return value
-        return value
-
-    def decode(self, value: Any) -> Any:
-        """Decode a value from storage. Returns int directly if parseable, otherwise decompress + deserialize."""
-        try:
-            return int(value)
-        except ValueError, TypeError:
-            value = self._decompress(value)
-            return self._deserialize(value)
 
     # =========================================================================
     # Stampede Prevention Helpers
@@ -401,7 +313,7 @@ class BaseKeyValueAdapter:
     ) -> bool:
         """Set a value only if the key doesn't exist."""
         client = self.get_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -420,7 +332,7 @@ class BaseKeyValueAdapter:
     ) -> bool:
         """Set a value only if the key doesn't exist, asynchronously."""
         client = self.get_async_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -440,7 +352,7 @@ class BaseKeyValueAdapter:
             ttl = client.ttl(key)
             if ttl > 0 and should_recompute(ttl, config):
                 return None
-        return self.decode(val)
+        return val
 
     async def aget(self, key: KeyT, *, stampede_prevention: bool | dict | None = None) -> Any:
         """Fetch a value from the cache asynchronously."""
@@ -453,7 +365,7 @@ class BaseKeyValueAdapter:
             ttl = await client.ttl(key)
             if ttl > 0 and should_recompute(ttl, config):
                 return None
-        return self.decode(val)
+        return val
 
     def set(
         self,
@@ -465,7 +377,7 @@ class BaseKeyValueAdapter:
     ) -> None:
         """Set a value in the cache (standard Django interface)."""
         client = self.get_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -483,7 +395,7 @@ class BaseKeyValueAdapter:
     ) -> None:
         """Set a value in the cache asynchronously."""
         client = self.get_async_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -508,7 +420,7 @@ class BaseKeyValueAdapter:
         (decoded) when get=True.
         """
         client = self.get_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -519,7 +431,7 @@ class BaseKeyValueAdapter:
         if get:
             if result is None:
                 return None
-            return self.decode(result)
+            return result
         return bool(result)
 
     async def aset_with_flags(
@@ -539,7 +451,7 @@ class BaseKeyValueAdapter:
         (decoded) when get=True.
         """
         client = self.get_async_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -550,7 +462,7 @@ class BaseKeyValueAdapter:
         if get:
             if result is None:
                 return None
-            return self.decode(result)
+            return result
         return bool(result)
 
     def touch(self, key: KeyT, timeout: int | None) -> bool:
@@ -607,7 +519,7 @@ class BaseKeyValueAdapter:
                     if isinstance(ttl, int) and ttl > 0 and should_recompute(ttl, config):
                         del found[k]
 
-        return {k: self.decode(v) for k, v in found.items()}
+        return dict(found.items())
 
     async def aget_many(
         self,
@@ -640,7 +552,7 @@ class BaseKeyValueAdapter:
                     if isinstance(ttl, int) and ttl > 0 and should_recompute(ttl, config):
                         del found[k]
 
-        return {k: self.decode(v) for k, v in found.items()}
+        return dict(found.items())
 
     def has_key(self, key: KeyT) -> bool:
         """Check if a key exists."""
@@ -694,7 +606,7 @@ class BaseKeyValueAdapter:
             return []
 
         client = self.get_client(write=True)
-        prepared = {k: self.encode(v) for k, v in data.items()}
+        prepared = dict(data.items())
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -721,7 +633,7 @@ class BaseKeyValueAdapter:
             return []
 
         client = self.get_async_client(write=True)
-        prepared = {k: self.encode(v) for k, v in data.items()}
+        prepared = dict(data.items())
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -1086,18 +998,17 @@ class BaseKeyValueAdapter:
             thread_local=thread_local,
         )
 
-    def pipeline(
-        self,
-        *,
-        transaction: bool = True,
-        version: int | None = None,
-    ) -> Pipeline:
-        """Create a pipeline for batched operations."""
-        from django_cachex.adapter.pipeline import Pipeline, RedisPipelineAdapter
+    def pipeline(self, *, transaction: bool = True) -> BaseKeyValuePipelineAdapter:
+        """Construct a pipeline adapter (raw command queue) for this driver.
+
+        Returns the per-driver :class:`BaseKeyValuePipelineAdapter` subclass.
+        ``KeyValueCache.pipeline()`` wraps the result in a :class:`Pipeline`
+        that adds key-prefixing, value encoding, and result decoding.
+        """
+        from django_cachex.adapter.pipeline import RedisPipelineAdapter
 
         client = self.get_client(write=True)
-        pipeline_adapter = RedisPipelineAdapter(client.pipeline(transaction=transaction))
-        return Pipeline(adapter=self, pipeline_adapter=pipeline_adapter, version=version)
+        return RedisPipelineAdapter(client.pipeline(transaction=transaction))
 
     # =========================================================================
     # Server Operations
@@ -1179,16 +1090,16 @@ class BaseKeyValueAdapter:
     ) -> int:
         """Set hash field(s). Use field/value, mapping, or items (flat key-value pairs)."""
         client = self.get_client(key, write=True)
-        nvalue = self.encode(value) if field is not None else None
-        nmapping = {f: self.encode(v) for f, v in mapping.items()} if mapping else None
-        nitems = [self.encode(v) if i % 2 else v for i, v in enumerate(items)] if items else None
+        nvalue = value if field is not None else None
+        nmapping = dict(mapping.items()) if mapping else None
+        nitems = list(items) if items else None
 
         return cast("int", client.hset(key, field, nvalue, mapping=nmapping, items=nitems))
 
     def hsetnx(self, key: KeyT, field: str, value: Any) -> bool:
         """Set a hash field only if it doesn't exist."""
         client = self.get_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
 
         return bool(client.hsetnx(key, field, nvalue))
 
@@ -1197,21 +1108,21 @@ class BaseKeyValueAdapter:
         client = self.get_client(key, write=False)
 
         val = client.hget(key, field)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     def hmget(self, key: KeyT, *fields: str) -> list[Any | None]:
         """Get multiple hash fields."""
         client = self.get_client(key, write=False)
 
         values = client.hmget(key, fields)
-        return [self.decode(v) if v is not None else None for v in values]
+        return [v if v is not None else None for v in values]
 
     def hgetall(self, key: KeyT) -> dict[str, Any]:
         """Get all hash fields."""
         client = self.get_client(key, write=False)
 
         raw = client.hgetall(key)
-        return {(f.decode() if isinstance(f, bytes) else f): self.decode(v) for f, v in raw.items()}
+        return {(f.decode() if isinstance(f, bytes) else f): v for f, v in raw.items()}
 
     def hdel(self, key: KeyT, *fields: str) -> int:
         """Delete hash fields."""
@@ -1243,7 +1154,7 @@ class BaseKeyValueAdapter:
         client = self.get_client(key, write=False)
 
         values = client.hvals(key)
-        return [self.decode(v) for v in values]
+        return list(values)
 
     def hincrby(self, key: KeyT, field: str, amount: int = 1) -> int:
         """Increment a hash field by an integer."""
@@ -1267,16 +1178,16 @@ class BaseKeyValueAdapter:
     ) -> int:
         """Set hash field(s) asynchronously. Use field/value, mapping, or items (flat key-value pairs)."""
         client = self.get_async_client(key, write=True)
-        nvalue = self.encode(value) if field is not None else None
-        nmapping = {f: self.encode(v) for f, v in mapping.items()} if mapping else None
-        nitems = [self.encode(v) if i % 2 else v for i, v in enumerate(items)] if items else None
+        nvalue = value if field is not None else None
+        nmapping = dict(mapping.items()) if mapping else None
+        nitems = list(items) if items else None
 
         return cast("int", await client.hset(key, field, nvalue, mapping=nmapping, items=nitems))
 
     async def ahsetnx(self, key: KeyT, field: str, value: Any) -> bool:
         """Set a hash field only if it doesn't exist, asynchronously."""
         client = self.get_async_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
 
         return bool(await client.hsetnx(key, field, nvalue))
 
@@ -1285,21 +1196,21 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(key, write=False)
 
         val = await client.hget(key, field)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     async def ahmget(self, key: KeyT, *fields: str) -> list[Any | None]:
         """Get multiple hash fields asynchronously."""
         client = self.get_async_client(key, write=False)
 
         values = await client.hmget(key, fields)
-        return [self.decode(v) if v is not None else None for v in values]
+        return [v if v is not None else None for v in values]
 
     async def ahgetall(self, key: KeyT) -> dict[str, Any]:
         """Get all hash fields asynchronously."""
         client = self.get_async_client(key, write=False)
 
         raw = await client.hgetall(key)
-        return {(f.decode() if isinstance(f, bytes) else f): self.decode(v) for f, v in raw.items()}
+        return {(f.decode() if isinstance(f, bytes) else f): v for f, v in raw.items()}
 
     async def ahdel(self, key: KeyT, *fields: str) -> int:
         """Delete hash fields asynchronously."""
@@ -1331,7 +1242,7 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(key, write=False)
 
         values = await client.hvals(key)
-        return [self.decode(v) for v in values]
+        return list(values)
 
     async def ahincrby(self, key: KeyT, field: str, amount: int = 1) -> int:
         """Increment a hash field by an integer asynchronously."""
@@ -1352,14 +1263,14 @@ class BaseKeyValueAdapter:
     def lpush(self, key: KeyT, *values: Any) -> int:
         """Push values to the left of a list."""
         client = self.get_client(key, write=True)
-        nvalues = [self.encode(v) for v in values]
+        nvalues = list(values)
 
         return cast("int", client.lpush(key, *nvalues))
 
     def rpush(self, key: KeyT, *values: Any) -> int:
         """Push values to the right of a list."""
         client = self.get_client(key, write=True)
-        nvalues = [self.encode(v) for v in values]
+        nvalues = list(values)
 
         return cast("int", client.rpush(key, *nvalues))
 
@@ -1369,9 +1280,9 @@ class BaseKeyValueAdapter:
 
         if count is not None:
             vals = client.lpop(key, count)
-            return [self.decode(v) for v in vals] if vals else []
+            return list(vals) if vals else []
         val = client.lpop(key)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     def rpop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         """Pop value(s) from the right of a list."""
@@ -1379,9 +1290,9 @@ class BaseKeyValueAdapter:
 
         if count is not None:
             vals = client.rpop(key, count)
-            return [self.decode(v) for v in vals] if vals else []
+            return list(vals) if vals else []
         val = client.rpop(key)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     def llen(self, key: KeyT) -> int:
         """Get the length of a list."""
@@ -1399,7 +1310,7 @@ class BaseKeyValueAdapter:
     ) -> int | list[int] | None:
         """Find position(s) of element in list."""
         client = self.get_client(key, write=False)
-        encoded_value = self.encode(value)
+        encoded_value = value
 
         kwargs: dict[str, Any] = {}
         if rank is not None:
@@ -1422,26 +1333,26 @@ class BaseKeyValueAdapter:
         client = self.get_client(src, write=True)
 
         val = client.lmove(src, dst, wherefrom, whereto)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     def lrange(self, key: KeyT, start: int, end: int) -> list[Any]:
         """Get a range of elements from a list."""
         client = self.get_client(key, write=False)
 
         values = client.lrange(key, start, end)
-        return [self.decode(v) for v in values]
+        return list(values)
 
     def lindex(self, key: KeyT, index: int) -> Any | None:
         """Get an element from a list by index."""
         client = self.get_client(key, write=False)
 
         val = client.lindex(key, index)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     def lset(self, key: KeyT, index: int, value: Any) -> bool:
         """Set an element in a list by index."""
         client = self.get_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
 
         client.lset(key, index, nvalue)
         return True
@@ -1449,7 +1360,7 @@ class BaseKeyValueAdapter:
     def lrem(self, key: KeyT, count: int, value: Any) -> int:
         """Remove elements from a list."""
         client = self.get_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
 
         return cast("int", client.lrem(key, count, nvalue))
 
@@ -1469,8 +1380,8 @@ class BaseKeyValueAdapter:
     ) -> int:
         """Insert an element before or after another element."""
         client = self.get_client(key, write=True)
-        npivot = self.encode(pivot)
-        nvalue = self.encode(value)
+        npivot = pivot
+        nvalue = value
 
         return cast("int", client.linsert(key, where, npivot, nvalue))
 
@@ -1487,7 +1398,7 @@ class BaseKeyValueAdapter:
             return None
         key_bytes, value_bytes = result
         key_str = key_bytes.decode() if isinstance(key_bytes, bytes) else key_bytes
-        return (key_str, self.decode(value_bytes))
+        return (key_str, value_bytes)
 
     def brpop(
         self,
@@ -1502,7 +1413,7 @@ class BaseKeyValueAdapter:
             return None
         key_bytes, value_bytes = result
         key_str = key_bytes.decode() if isinstance(key_bytes, bytes) else key_bytes
-        return (key_str, self.decode(value_bytes))
+        return (key_str, value_bytes)
 
     def blmove(
         self,
@@ -1516,19 +1427,19 @@ class BaseKeyValueAdapter:
         client = self.get_client(src, write=True)
 
         val = client.blmove(src, dst, timeout, wherefrom, whereto)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     async def alpush(self, key: KeyT, *values: Any) -> int:
         """Push values to the left of a list asynchronously."""
         client = self.get_async_client(key, write=True)
-        nvalues = [self.encode(v) for v in values]
+        nvalues = list(values)
 
         return cast("int", await client.lpush(key, *nvalues))
 
     async def arpush(self, key: KeyT, *values: Any) -> int:
         """Push values to the right of a list asynchronously."""
         client = self.get_async_client(key, write=True)
-        nvalues = [self.encode(v) for v in values]
+        nvalues = list(values)
 
         return cast("int", await client.rpush(key, *nvalues))
 
@@ -1538,9 +1449,9 @@ class BaseKeyValueAdapter:
 
         if count is not None:
             vals = await client.lpop(key, count)
-            return [self.decode(v) for v in vals] if vals else []
+            return list(vals) if vals else []
         val = await client.lpop(key)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     async def arpop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         """Pop value(s) from the right of a list asynchronously."""
@@ -1548,9 +1459,9 @@ class BaseKeyValueAdapter:
 
         if count is not None:
             vals = await client.rpop(key, count)
-            return [self.decode(v) for v in vals] if vals else []
+            return list(vals) if vals else []
         val = await client.rpop(key)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     async def allen(self, key: KeyT) -> int:
         """Get the length of a list asynchronously."""
@@ -1568,7 +1479,7 @@ class BaseKeyValueAdapter:
     ) -> int | list[int] | None:
         """Find position(s) of element in list asynchronously."""
         client = self.get_async_client(key, write=False)
-        encoded_value = self.encode(value)
+        encoded_value = value
 
         kwargs: dict[str, Any] = {}
         if rank is not None:
@@ -1591,26 +1502,26 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(src, write=True)
 
         val = await client.lmove(src, dst, wherefrom, whereto)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     async def alrange(self, key: KeyT, start: int, end: int) -> list[Any]:
         """Get a range of elements from a list asynchronously."""
         client = self.get_async_client(key, write=False)
 
         values = await client.lrange(key, start, end)
-        return [self.decode(v) for v in values]
+        return list(values)
 
     async def alindex(self, key: KeyT, index: int) -> Any | None:
         """Get an element from a list by index asynchronously."""
         client = self.get_async_client(key, write=False)
 
         val = await client.lindex(key, index)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     async def alset(self, key: KeyT, index: int, value: Any) -> bool:
         """Set an element in a list by index asynchronously."""
         client = self.get_async_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
 
         await client.lset(key, index, nvalue)
         return True
@@ -1618,7 +1529,7 @@ class BaseKeyValueAdapter:
     async def alrem(self, key: KeyT, count: int, value: Any) -> int:
         """Remove elements from a list asynchronously."""
         client = self.get_async_client(key, write=True)
-        nvalue = self.encode(value)
+        nvalue = value
 
         return cast("int", await client.lrem(key, count, nvalue))
 
@@ -1638,8 +1549,8 @@ class BaseKeyValueAdapter:
     ) -> int:
         """Insert an element before or after another element asynchronously."""
         client = self.get_async_client(key, write=True)
-        npivot = self.encode(pivot)
-        nvalue = self.encode(value)
+        npivot = pivot
+        nvalue = value
 
         return cast("int", await client.linsert(key, where, npivot, nvalue))
 
@@ -1656,7 +1567,7 @@ class BaseKeyValueAdapter:
             return None
         key_bytes, value_bytes = result
         key_str = key_bytes.decode() if isinstance(key_bytes, bytes) else key_bytes
-        return (key_str, self.decode(value_bytes))
+        return (key_str, value_bytes)
 
     async def abrpop(
         self,
@@ -1671,7 +1582,7 @@ class BaseKeyValueAdapter:
             return None
         key_bytes, value_bytes = result
         key_str = key_bytes.decode() if isinstance(key_bytes, bytes) else key_bytes
-        return (key_str, self.decode(value_bytes))
+        return (key_str, value_bytes)
 
     async def ablmove(
         self,
@@ -1685,7 +1596,7 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(src, write=True)
 
         val = await client.blmove(src, dst, timeout, wherefrom, whereto)
-        return self.decode(val) if val is not None else None
+        return val if val is not None else None
 
     # =========================================================================
     # Set Operations
@@ -1694,14 +1605,14 @@ class BaseKeyValueAdapter:
     def sadd(self, key: KeyT, *members: Any) -> int:
         """Add members to a set."""
         client = self.get_client(key, write=True)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         return cast("int", client.sadd(key, *nmembers))
 
     def srem(self, key: KeyT, *members: Any) -> int:
         """Remove members from a set."""
         client = self.get_client(key, write=True)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         return cast("int", client.srem(key, *nmembers))
 
@@ -1710,12 +1621,12 @@ class BaseKeyValueAdapter:
         client = self.get_client(key, write=False)
 
         result = client.smembers(key)
-        return {self.decode(v) for v in result}
+        return set(result)
 
     def sismember(self, key: KeyT, member: Any) -> bool:
         """Check if a value is a member of a set."""
         client = self.get_client(key, write=False)
-        nmember = self.encode(member)
+        nmember = member
 
         return bool(client.sismember(key, nmember))
 
@@ -1731,9 +1642,9 @@ class BaseKeyValueAdapter:
 
         if count is None:
             val = client.spop(key)
-            return self.decode(val) if val is not None else None
+            return val if val is not None else None
         vals = client.spop(key, count)
-        return [self.decode(v) for v in vals] if vals else []
+        return list(vals) if vals else []
 
     def srandmember(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         """Get random member(s) from a set."""
@@ -1741,14 +1652,14 @@ class BaseKeyValueAdapter:
 
         if count is None:
             val = client.srandmember(key)
-            return self.decode(val) if val is not None else None
+            return val if val is not None else None
         vals = client.srandmember(key, count)
-        return [self.decode(v) for v in vals] if vals else []
+        return list(vals) if vals else []
 
     def smove(self, src: KeyT, dst: KeyT, member: Any) -> bool:
         """Move a member from one set to another."""
         client = self.get_client(write=True)
-        nmember = self.encode(member)
+        nmember = member
 
         return bool(client.smove(src, dst, nmember))
 
@@ -1757,7 +1668,7 @@ class BaseKeyValueAdapter:
         client = self.get_client(write=False)
 
         result = client.sdiff(keys)
-        return {self.decode(v) for v in result}
+        return set(result)
 
     def sdiffstore(self, dest: KeyT, keys: KeyT | Sequence[KeyT]) -> int:
         """Store the difference of sets."""
@@ -1770,7 +1681,7 @@ class BaseKeyValueAdapter:
         client = self.get_client(write=False)
 
         result = client.sinter(keys)
-        return {self.decode(v) for v in result}
+        return set(result)
 
     def sinterstore(self, dest: KeyT, keys: KeyT | Sequence[KeyT]) -> int:
         """Store the intersection of sets."""
@@ -1783,7 +1694,7 @@ class BaseKeyValueAdapter:
         client = self.get_client(write=False)
 
         result = client.sunion(keys)
-        return {self.decode(v) for v in result}
+        return set(result)
 
     def sunionstore(self, dest: KeyT, keys: KeyT | Sequence[KeyT]) -> int:
         """Store the union of sets."""
@@ -1794,7 +1705,7 @@ class BaseKeyValueAdapter:
     def smismember(self, key: KeyT, *members: Any) -> list[bool]:
         """Check if multiple values are members of a set."""
         client = self.get_client(key, write=False)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         result = client.smismember(key, nmembers)
         return [bool(v) for v in result]
@@ -1810,7 +1721,7 @@ class BaseKeyValueAdapter:
         client = self.get_client(key, write=False)
 
         next_cursor, members = client.sscan(key, cursor=cursor, match=match, count=count)
-        return next_cursor, {self.decode(m) for m in members}
+        return next_cursor, set(members)
 
     def sscan_iter(
         self,
@@ -1821,20 +1732,19 @@ class BaseKeyValueAdapter:
         """Iterate over set members using SSCAN."""
         client = self.get_client(key, write=False)
 
-        for member in client.sscan_iter(key, match=match, count=count):
-            yield self.decode(member)
+        yield from client.sscan_iter(key, match=match, count=count)
 
     async def asadd(self, key: KeyT, *members: Any) -> int:
         """Add members to a set asynchronously."""
         client = self.get_async_client(key, write=True)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         return cast("int", await client.sadd(key, *nmembers))
 
     async def asrem(self, key: KeyT, *members: Any) -> int:
         """Remove members from a set asynchronously."""
         client = self.get_async_client(key, write=True)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         return cast("int", await client.srem(key, *nmembers))
 
@@ -1843,12 +1753,12 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(key, write=False)
 
         result = await client.smembers(key)
-        return {self.decode(v) for v in result}
+        return set(result)
 
     async def asismember(self, key: KeyT, member: Any) -> bool:
         """Check if a value is a member of a set asynchronously."""
         client = self.get_async_client(key, write=False)
-        nmember = self.encode(member)
+        nmember = member
 
         return bool(await client.sismember(key, nmember))
 
@@ -1864,9 +1774,9 @@ class BaseKeyValueAdapter:
 
         if count is None:
             val = await client.spop(key)
-            return self.decode(val) if val is not None else None
+            return val if val is not None else None
         vals = await client.spop(key, count)
-        return [self.decode(v) for v in vals] if vals else []
+        return list(vals) if vals else []
 
     async def asrandmember(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         """Get random member(s) from a set asynchronously."""
@@ -1874,14 +1784,14 @@ class BaseKeyValueAdapter:
 
         if count is None:
             val = await client.srandmember(key)
-            return self.decode(val) if val is not None else None
+            return val if val is not None else None
         vals = await client.srandmember(key, count)
-        return [self.decode(v) for v in vals] if vals else []
+        return list(vals) if vals else []
 
     async def asmove(self, src: KeyT, dst: KeyT, member: Any) -> bool:
         """Move a member from one set to another asynchronously."""
         client = self.get_async_client(write=True)
-        nmember = self.encode(member)
+        nmember = member
 
         return bool(await client.smove(src, dst, nmember))
 
@@ -1890,7 +1800,7 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(write=False)
 
         result = await client.sdiff(keys)
-        return {self.decode(v) for v in result}
+        return set(result)
 
     async def asdiffstore(self, dest: KeyT, keys: KeyT | Sequence[KeyT]) -> int:
         """Store the difference of sets asynchronously."""
@@ -1903,7 +1813,7 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(write=False)
 
         result = await client.sinter(keys)
-        return {self.decode(v) for v in result}
+        return set(result)
 
     async def asinterstore(self, dest: KeyT, keys: KeyT | Sequence[KeyT]) -> int:
         """Store the intersection of sets asynchronously."""
@@ -1916,7 +1826,7 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(write=False)
 
         result = await client.sunion(keys)
-        return {self.decode(v) for v in result}
+        return set(result)
 
     async def asunionstore(self, dest: KeyT, keys: KeyT | Sequence[KeyT]) -> int:
         """Store the union of sets asynchronously."""
@@ -1927,7 +1837,7 @@ class BaseKeyValueAdapter:
     async def asmismember(self, key: KeyT, *members: Any) -> list[bool]:
         """Check if multiple values are members of a set asynchronously."""
         client = self.get_async_client(key, write=False)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         result = await client.smismember(key, nmembers)
         return [bool(v) for v in result]
@@ -1943,7 +1853,7 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(key, write=False)
 
         next_cursor, members = await client.sscan(key, cursor=cursor, match=match, count=count)
-        return next_cursor, {self.decode(m) for m in members}
+        return next_cursor, set(members)
 
     async def asscan_iter(
         self,
@@ -1955,7 +1865,7 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(key, write=False)
 
         async for member in client.sscan_iter(key, match=match, count=count):
-            yield self.decode(member)
+            yield member
 
     # =========================================================================
     # Sorted Set Operations
@@ -1974,21 +1884,21 @@ class BaseKeyValueAdapter:
     ) -> int:
         """Add members to a sorted set."""
         client = self.get_client(key, write=True)
-        scored_mapping = {self.encode(m): s for m, s in mapping.items()}
+        scored_mapping = dict(mapping.items())
 
         return cast("int", client.zadd(key, scored_mapping, nx=nx, xx=xx, gt=gt, lt=lt, ch=ch))
 
     def zrem(self, key: KeyT, *members: Any) -> int:
         """Remove members from a sorted set."""
         client = self.get_client(key, write=True)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         return cast("int", client.zrem(key, *nmembers))
 
     def zscore(self, key: KeyT, member: Any) -> float | None:
         """Get the score of a member."""
         client = self.get_client(key, write=False)
-        nmember = self.encode(member)
+        nmember = member
 
         result = client.zscore(key, nmember)
         return float(result) if result is not None else None
@@ -1996,14 +1906,14 @@ class BaseKeyValueAdapter:
     def zrank(self, key: KeyT, member: Any) -> int | None:
         """Get the rank of a member (0-based)."""
         client = self.get_client(key, write=False)
-        nmember = self.encode(member)
+        nmember = member
 
         return client.zrank(key, nmember)
 
     def zrevrank(self, key: KeyT, member: Any) -> int | None:
         """Get the reverse rank of a member."""
         client = self.get_client(key, write=False)
-        nmember = self.encode(member)
+        nmember = member
 
         return client.zrevrank(key, nmember)
 
@@ -2022,7 +1932,7 @@ class BaseKeyValueAdapter:
     def zincrby(self, key: KeyT, amount: float, member: Any) -> float:
         """Increment the score of a member."""
         client = self.get_client(key, write=True)
-        nmember = self.encode(member)
+        nmember = member
 
         return float(client.zincrby(key, amount, nmember))
 
@@ -2039,8 +1949,8 @@ class BaseKeyValueAdapter:
 
         result = client.zrange(key, start, end, withscores=withscores)
         if withscores:
-            return [(self.decode(m), float(s)) for m, s in result]
-        return [self.decode(m) for m in result]
+            return [(m, float(s)) for m, s in result]
+        return list(result)
 
     def zrevrange(
         self,
@@ -2055,8 +1965,8 @@ class BaseKeyValueAdapter:
 
         result = client.zrevrange(key, start, end, withscores=withscores)
         if withscores:
-            return [(self.decode(m), float(s)) for m, s in result]
-        return [self.decode(m) for m in result]
+            return [(m, float(s)) for m, s in result]
+        return list(result)
 
     def zrangebyscore(
         self,
@@ -2080,8 +1990,8 @@ class BaseKeyValueAdapter:
             withscores=withscores,
         )
         if withscores:
-            return [(self.decode(m), float(s)) for m, s in result]
-        return [self.decode(m) for m in result]
+            return [(m, float(s)) for m, s in result]
+        return list(result)
 
     def zrevrangebyscore(
         self,
@@ -2105,8 +2015,8 @@ class BaseKeyValueAdapter:
             withscores=withscores,
         )
         if withscores:
-            return [(self.decode(m), float(s)) for m, s in result]
-        return [self.decode(m) for m in result]
+            return [(m, float(s)) for m, s in result]
+        return list(result)
 
     def zremrangebyrank(self, key: KeyT, start: int, end: int) -> int:
         """Remove members by rank range."""
@@ -2125,19 +2035,19 @@ class BaseKeyValueAdapter:
         client = self.get_client(key, write=True)
 
         result = client.zpopmin(key, count)
-        return [(self.decode(m), float(s)) for m, s in result]
+        return [(m, float(s)) for m, s in result]
 
     def zpopmax(self, key: KeyT, count: int | None = None) -> list[tuple[Any, float]]:
         """Remove and return members with highest scores."""
         client = self.get_client(key, write=True)
 
         result = client.zpopmax(key, count)
-        return [(self.decode(m), float(s)) for m, s in result]
+        return [(m, float(s)) for m, s in result]
 
     def zmscore(self, key: KeyT, *members: Any) -> list[float | None]:
         """Get scores for multiple members."""
         client = self.get_client(key, write=False)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         results = client.zmscore(key, nmembers)
         return [float(r) if r is not None else None for r in results]
@@ -2155,21 +2065,21 @@ class BaseKeyValueAdapter:
     ) -> int:
         """Add members to a sorted set asynchronously."""
         client = self.get_async_client(key, write=True)
-        scored_mapping = {self.encode(m): s for m, s in mapping.items()}
+        scored_mapping = dict(mapping.items())
 
         return cast("int", await client.zadd(key, scored_mapping, nx=nx, xx=xx, gt=gt, lt=lt, ch=ch))
 
     async def azrem(self, key: KeyT, *members: Any) -> int:
         """Remove members from a sorted set asynchronously."""
         client = self.get_async_client(key, write=True)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         return cast("int", await client.zrem(key, *nmembers))
 
     async def azscore(self, key: KeyT, member: Any) -> float | None:
         """Get the score of a member asynchronously."""
         client = self.get_async_client(key, write=False)
-        nmember = self.encode(member)
+        nmember = member
 
         result = await client.zscore(key, nmember)
         return float(result) if result is not None else None
@@ -2177,14 +2087,14 @@ class BaseKeyValueAdapter:
     async def azrank(self, key: KeyT, member: Any) -> int | None:
         """Get the rank of a member (0-based) asynchronously."""
         client = self.get_async_client(key, write=False)
-        nmember = self.encode(member)
+        nmember = member
 
         return await client.zrank(key, nmember)
 
     async def azrevrank(self, key: KeyT, member: Any) -> int | None:
         """Get the reverse rank of a member asynchronously."""
         client = self.get_async_client(key, write=False)
-        nmember = self.encode(member)
+        nmember = member
 
         return await client.zrevrank(key, nmember)
 
@@ -2203,7 +2113,7 @@ class BaseKeyValueAdapter:
     async def azincrby(self, key: KeyT, amount: float, member: Any) -> float:
         """Increment the score of a member asynchronously."""
         client = self.get_async_client(key, write=True)
-        nmember = self.encode(member)
+        nmember = member
 
         return float(await client.zincrby(key, amount, nmember))
 
@@ -2220,8 +2130,8 @@ class BaseKeyValueAdapter:
 
         result = await client.zrange(key, start, end, withscores=withscores)
         if withscores:
-            return [(self.decode(m), float(s)) for m, s in result]
-        return [self.decode(m) for m in result]
+            return [(m, float(s)) for m, s in result]
+        return list(result)
 
     async def azrevrange(
         self,
@@ -2236,8 +2146,8 @@ class BaseKeyValueAdapter:
 
         result = await client.zrevrange(key, start, end, withscores=withscores)
         if withscores:
-            return [(self.decode(m), float(s)) for m, s in result]
-        return [self.decode(m) for m in result]
+            return [(m, float(s)) for m, s in result]
+        return list(result)
 
     async def azrangebyscore(
         self,
@@ -2261,8 +2171,8 @@ class BaseKeyValueAdapter:
             withscores=withscores,
         )
         if withscores:
-            return [(self.decode(m), float(s)) for m, s in result]
-        return [self.decode(m) for m in result]
+            return [(m, float(s)) for m, s in result]
+        return list(result)
 
     async def azrevrangebyscore(
         self,
@@ -2286,8 +2196,8 @@ class BaseKeyValueAdapter:
             withscores=withscores,
         )
         if withscores:
-            return [(self.decode(m), float(s)) for m, s in result]
-        return [self.decode(m) for m in result]
+            return [(m, float(s)) for m, s in result]
+        return list(result)
 
     async def azremrangebyrank(self, key: KeyT, start: int, end: int) -> int:
         """Remove members by rank range asynchronously."""
@@ -2306,19 +2216,19 @@ class BaseKeyValueAdapter:
         client = self.get_async_client(key, write=True)
 
         result = await client.zpopmin(key, count)
-        return [(self.decode(m), float(s)) for m, s in result]
+        return [(m, float(s)) for m, s in result]
 
     async def azpopmax(self, key: KeyT, count: int | None = None) -> list[tuple[Any, float]]:
         """Remove and return members with highest scores asynchronously."""
         client = self.get_async_client(key, write=True)
 
         result = await client.zpopmax(key, count)
-        return [(self.decode(m), float(s)) for m, s in result]
+        return [(m, float(s)) for m, s in result]
 
     async def azmscore(self, key: KeyT, *members: Any) -> list[float | None]:
         """Get scores for multiple members asynchronously."""
         client = self.get_async_client(key, write=False)
-        nmembers = [self.encode(m) for m in members]
+        nmembers = list(members)
 
         results = await client.zmscore(key, nmembers)
         return [float(r) if r is not None else None for r in results]
@@ -2340,7 +2250,7 @@ class BaseKeyValueAdapter:
     ) -> str:
         """Add an entry to a stream."""
         client = self.get_client(key, write=True)
-        encoded_fields = {k: self.encode(v) for k, v in fields.items()}
+        encoded_fields = dict(fields.items())
 
         result = client.xadd(
             key,
@@ -2362,7 +2272,7 @@ class BaseKeyValueAdapter:
         return [
             (
                 entry_id.decode() if isinstance(entry_id, bytes) else entry_id,
-                {k.decode() if isinstance(k, bytes) else k: self.decode(v) for k, v in fields.items()},
+                {k.decode() if isinstance(k, bytes) else k: v for k, v in fields.items()},
             )
             for entry_id, fields in results
         ]
@@ -2644,7 +2554,7 @@ class BaseKeyValueAdapter:
     ) -> str:
         """Add an entry to a stream asynchronously."""
         client = self.get_async_client(key, write=True)
-        encoded_fields = {k: self.encode(v) for k, v in fields.items()}
+        encoded_fields = dict(fields.items())
 
         result = await client.xadd(
             key,

--- a/django_cachex/adapter/glide.py
+++ b/django_cachex/adapter/glide.py
@@ -28,7 +28,6 @@ from django_cachex.types import KeyType
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
 
-    from django_cachex.adapter.pipeline import Pipeline
     from django_cachex.types import KeyT
 
 
@@ -711,7 +710,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         stampede_prevention: bool | dict | None = None,
     ) -> bool:
         client = self._client()
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -742,7 +741,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
 
             if ttl > 0 and should_recompute(ttl, config):
                 return None
-        return self.decode(val)
+        return val
 
     def set(
         self,
@@ -753,7 +752,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         stampede_prevention: bool | dict | None = None,
     ) -> None:
         client = self._client()
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -775,7 +774,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         stampede_prevention: bool | dict | None = None,
     ) -> bool | Any:
         client = self._client()
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -793,7 +792,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
 
         result = client.set(key, _enc(nvalue), **kw)
         if get:
-            return None if result is None else self.decode(result)
+            return None if result is None else result
         return result == "OK"
 
     def touch(self, key: KeyT, timeout: int | None) -> bool:
@@ -828,7 +827,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
                     if isinstance(ttl, int) and ttl > 0 and should_recompute(ttl, config):
                         del found[k]
 
-        return {k: self.decode(v) for k, v in found.items()}
+        return dict(found.items())
 
     def has_key(self, key: KeyT) -> bool:
         return bool(self._client().exists([key]))
@@ -855,7 +854,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         if not data:
             return []
         client = self._client()
-        prepared = {k: _enc(self.encode(v)) for k, v in data.items()}
+        prepared = {k: _enc(v) for k, v in data.items()}
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -956,38 +955,38 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         client = self._client()
         m: dict[Any, Any] = {}
         if field is not None:
-            m[field] = _enc(self.encode(value))
+            m[field] = _enc(value)
         if mapping:
-            m.update({f: _enc(self.encode(v)) for f, v in mapping.items()})
+            m.update({f: _enc(v) for f, v in mapping.items()})
         if items:
             for i in range(0, len(items), 2):
-                m[items[i]] = _enc(self.encode(items[i + 1]))
+                m[items[i]] = _enc(items[i + 1])
         if not m:
             return 0
         return client.hset(key, m)
 
     def hsetnx(self, key: KeyT, field: str, value: Any) -> bool:
-        return self._client().hsetnx(key, field, _enc(self.encode(value)))
+        return self._client().hsetnx(key, field, _enc(value))
 
     def hget(self, key: KeyT, field: str) -> Any | None:
         val = self._client().hget(key, field)
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     def hmget(self, key: KeyT, *fields: str) -> list[Any]:
         if len(fields) == 1 and isinstance(fields[0], (list, tuple)):
             fields = tuple(fields[0])
         values = self._client().hmget(key, list(fields))
-        return [self.decode(v) if v is not None else None for v in values]
+        return [v if v is not None else None for v in values]
 
     def hgetall(self, key: KeyT) -> dict[str, Any]:
         result = self._client().hgetall(key)
-        return {k.decode() if isinstance(k, bytes) else k: self.decode(v) for k, v in result.items()}
+        return {k.decode() if isinstance(k, bytes) else k: v for k, v in result.items()}
 
     def hkeys(self, key: KeyT) -> list[str]:
         return [k.decode() if isinstance(k, bytes) else k for k in self._client().hkeys(key)]
 
     def hvals(self, key: KeyT) -> list[Any]:
-        return [self.decode(v) for v in self._client().hvals(key)]
+        return list(self._client().hvals(key))
 
     def hlen(self, key: KeyT) -> int:
         return self._client().hlen(key)
@@ -1009,19 +1008,19 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
     # =========================================================================
 
     def sadd(self, key: KeyT, *members: Any) -> int:
-        return self._client().sadd(key, [_enc(self.encode(m)) for m in members])
+        return self._client().sadd(key, [_enc(m) for m in members])
 
     def srem(self, key: KeyT, *members: Any) -> int:
-        return self._client().srem(key, [_enc(self.encode(m)) for m in members])
+        return self._client().srem(key, [_enc(m) for m in members])
 
     def smembers(self, key: KeyT) -> _BuiltinSet[Any]:
-        return {self.decode(m) for m in self._client().smembers(key)}
+        return set(self._client().smembers(key))
 
     def sismember(self, key: KeyT, member: Any) -> bool:
-        return bool(self._client().sismember(key, _enc(self.encode(member))))
+        return bool(self._client().sismember(key, _enc(member)))
 
     def smismember(self, key: KeyT, *members: Any) -> list[bool]:
-        return list(self._client().smismember(key, [_enc(self.encode(m)) for m in members]))
+        return list(self._client().smismember(key, [_enc(m) for m in members]))
 
     def scard(self, key: KeyT) -> int:
         return self._client().scard(key)
@@ -1030,27 +1029,27 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         client = self._client()
         if count is None:
             v = client.spop(key)
-            return None if v is None else self.decode(v)
-        return {self.decode(v) for v in client.spop_count(key, count)}
+            return None if v is None else v
+        return set(client.spop_count(key, count))
 
     def srandmember(self, key: KeyT, count: int | None = None) -> Any:
         client = self._client()
         if count is None:
             v = client.srandmember(key)
-            return None if v is None else self.decode(v)
-        return [self.decode(v) for v in client.srandmember_count(key, count)]
+            return None if v is None else v
+        return list(client.srandmember_count(key, count))
 
     def smove(self, src: KeyT, dst: KeyT, member: Any) -> bool:
-        return bool(self._client().smove(src, dst, _enc(self.encode(member))))
+        return bool(self._client().smove(src, dst, _enc(member)))
 
     def sinter(self, *keys: KeyT) -> _BuiltinSet[Any]:
-        return {self.decode(m) for m in self._client().sinter(list(keys))}
+        return set(self._client().sinter(list(keys)))
 
     def sunion(self, *keys: KeyT) -> _BuiltinSet[Any]:
-        return {self.decode(m) for m in self._client().sunion(list(keys))}
+        return set(self._client().sunion(list(keys)))
 
     def sdiff(self, *keys: KeyT) -> _BuiltinSet[Any]:
-        return {self.decode(m) for m in self._client().sdiff(list(keys))}
+        return set(self._client().sdiff(list(keys)))
 
     def sinterstore(self, dst: KeyT, *keys: KeyT) -> int:
         return self._client().sinterstore(dst, list(keys))
@@ -1069,7 +1068,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         count: int | None = None,
     ) -> tuple[bytes, list]:
         result = self._client().sscan(key, _enc(cursor), match=match, count=count)
-        return result[0], [self.decode(v) for v in result[1]]
+        return result[0], list(result[1])
 
     def sscan_iter(self, key: KeyT, match: str | None = None, count: int | None = None) -> Iterable[Any]:
         client = self._client()
@@ -1077,8 +1076,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         while True:
             result = client.sscan(key, cursor, match=match, count=count)
             cursor, members = result[0], result[1]
-            for m in members:
-                yield self.decode(m)
+            yield from members
             if cursor in (b"0", "0", 0):
                 return
 
@@ -1099,27 +1097,27 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
             if kwargs.get("incr"):
                 args.append(b"INCR")
             for member, score in mapping.items():
-                args.extend([_enc(score), _enc(self.encode(member))])
+                args.extend([_enc(score), _enc(member)])
             return client.custom_command(args)
-        return client.zadd(key, {_enc(self.encode(m)): float(s) for m, s in mapping.items()})
+        return client.zadd(key, {_enc(m): float(s) for m, s in mapping.items()})
 
     def zrem(self, key: KeyT, *members: Any) -> int:
-        return self._client().zrem(key, [_enc(self.encode(m)) for m in members])
+        return self._client().zrem(key, [_enc(m) for m in members])
 
     def zscore(self, key: KeyT, member: Any) -> float | None:
-        return self._client().zscore(key, _enc(self.encode(member)))
+        return self._client().zscore(key, _enc(member))
 
     def zmscore(self, key: KeyT, members: list[Any]) -> list[float | None]:
-        return list(self._client().zmscore(key, [_enc(self.encode(m)) for m in members]))
+        return list(self._client().zmscore(key, [_enc(m) for m in members]))
 
     def zrank(self, key: KeyT, member: Any) -> int | None:
-        return self._client().zrank(key, _enc(self.encode(member)))
+        return self._client().zrank(key, _enc(member))
 
     def zrevrank(self, key: KeyT, member: Any) -> int | None:
-        return self._client().zrevrank(key, _enc(self.encode(member)))
+        return self._client().zrevrank(key, _enc(member))
 
     def zincrby(self, key: KeyT, amount: float, member: Any) -> float:
-        return self._client().zincrby(key, amount, _enc(self.encode(member)))
+        return self._client().zincrby(key, amount, _enc(member))
 
     def zremrangebyrank(self, key: KeyT, start: int, end: int) -> int:
         return self._client().zremrangebyrank(key, start, end)
@@ -1140,7 +1138,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         if withscores:
             args.append(b"WITHSCORES")
         result = self._client().custom_command(args)
-        return _decode_zrange(result, self.decode, withscores=withscores)
+        return _decode_zrange(result, _passthrough, withscores=withscores)
 
     def zrevrange(self, key: KeyT, start: int, end: int, withscores: bool = False) -> list:
         return self.zrange(key, start, end, withscores=withscores, desc=True)
@@ -1149,48 +1147,48 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         args = [b"ZRANGEBYSCORE", key, _enc(mn), _enc(mx)]
         if withscores:
             args.append(b"WITHSCORES")
-        return _decode_zrange(self._client().custom_command(args), self.decode, withscores=withscores)
+        return _decode_zrange(self._client().custom_command(args), _passthrough, withscores=withscores)
 
     def zrevrangebyscore(self, key: KeyT, mx: Any, mn: Any, withscores: bool = False) -> list:
         args = [b"ZREVRANGEBYSCORE", key, _enc(mx), _enc(mn)]
         if withscores:
             args.append(b"WITHSCORES")
-        return _decode_zrange(self._client().custom_command(args), self.decode, withscores=withscores)
+        return _decode_zrange(self._client().custom_command(args), _passthrough, withscores=withscores)
 
     def zpopmin(self, key: KeyT, count: int = 1) -> list[tuple[Any, float]]:
-        return _decode_zpop(self._client().zpopmin(key, count), self.decode)
+        return _decode_zpop(self._client().zpopmin(key, count), _passthrough)
 
     def zpopmax(self, key: KeyT, count: int = 1) -> list[tuple[Any, float]]:
-        return _decode_zpop(self._client().zpopmax(key, count), self.decode)
+        return _decode_zpop(self._client().zpopmax(key, count), _passthrough)
 
     # =========================================================================
     # Lists (sync)
     # =========================================================================
 
     def lpush(self, key: KeyT, *values: Any) -> int:
-        return self._client().lpush(key, [_enc(self.encode(v)) for v in values])
+        return self._client().lpush(key, [_enc(v) for v in values])
 
     def rpush(self, key: KeyT, *values: Any) -> int:
-        return self._client().rpush(key, [_enc(self.encode(v)) for v in values])
+        return self._client().rpush(key, [_enc(v) for v in values])
 
     def lpop(self, key: KeyT, count: int | None = None) -> Any:
         client = self._client()
         if count is None:
             v = client.lpop(key)
-            return None if v is None else self.decode(v)
+            return None if v is None else v
         result = client.lpop_count(key, count)
-        return [self.decode(v) for v in result] if result else []
+        return list(result) if result else []
 
     def rpop(self, key: KeyT, count: int | None = None) -> Any:
         client = self._client()
         if count is None:
             v = client.rpop(key)
-            return None if v is None else self.decode(v)
+            return None if v is None else v
         result = client.rpop_count(key, count)
-        return [self.decode(v) for v in result] if result else []
+        return list(result) if result else []
 
     def lrange(self, key: KeyT, start: int, end: int) -> list:
-        return [self.decode(v) for v in self._client().lrange(key, start, end)]
+        return list(self._client().lrange(key, start, end))
 
     def ltrim(self, key: KeyT, start: int, end: int) -> bool:
         return self._client().ltrim(key, start, end) == "OK"
@@ -1200,13 +1198,13 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
 
     def lindex(self, key: KeyT, index: int) -> Any:
         v = self._client().lindex(key, index)
-        return None if v is None else self.decode(v)
+        return None if v is None else v
 
     def lset(self, key: KeyT, index: int, value: Any) -> bool:
-        return self._client().lset(key, index, _enc(self.encode(value))) == "OK"
+        return self._client().lset(key, index, _enc(value)) == "OK"
 
     def lrem(self, key: KeyT, count: int, value: Any) -> int:
-        return self._client().lrem(key, count, _enc(self.encode(value)))
+        return self._client().lrem(key, count, _enc(value))
 
     def linsert(self, key: KeyT, where: str, pivot: Any, value: Any) -> int:
         return self._client().custom_command(
@@ -1214,13 +1212,13 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
                 b"LINSERT",
                 key,
                 _enc(where.upper()),
-                _enc(self.encode(pivot)),
-                _enc(self.encode(value)),
+                _enc(pivot),
+                _enc(value),
             ],
         )
 
     def lpos(self, key: KeyT, element: Any, **kwargs: Any) -> Any:
-        args: list[Any] = [b"LPOS", key, _enc(self.encode(element))]
+        args: list[Any] = [b"LPOS", key, _enc(element)]
         if "rank" in kwargs:
             args.extend([b"RANK", str(kwargs["rank"]).encode()])
         if "count" in kwargs:
@@ -1231,7 +1229,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
 
     def lmove(self, src: KeyT, dst: KeyT, src_dir: str, dst_dir: str) -> Any:
         v = self._client().custom_command([b"LMOVE", src, dst, _enc(src_dir.upper()), _enc(dst_dir.upper())])
-        return None if v is None else self.decode(v)
+        return None if v is None else v
 
     def blmove(self, src: KeyT, dst: KeyT, src_dir: str, dst_dir: str, timeout: float) -> Any:
         v = self._client().custom_command(
@@ -1244,7 +1242,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
                 str(timeout).encode(),
             ],
         )
-        return None if v is None else self.decode(v)
+        return None if v is None else v
 
     def blpop(self, keys: Any, timeout: float = 0) -> Any:
         ks = list(keys) if isinstance(keys, (list, tuple)) else [keys]
@@ -1261,7 +1259,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
     def xadd(self, key: KeyT, fields: Mapping[Any, Any], id: str = "*", **kwargs: Any) -> str:
         args = [b"XADD", key, _enc(id)]
         for f, v in fields.items():
-            args.extend([_enc(f), _enc(self.encode(v))])
+            args.extend([_enc(f), _enc(v)])
         result = self._client().custom_command(args)
         return result.decode() if isinstance(result, bytes) else result
 
@@ -1391,11 +1389,8 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
     def _pipeline(self, *, transaction: bool = False) -> ValkeyGlidePipelineAdapter:
         return ValkeyGlidePipelineAdapter(self._client(), transaction=transaction)
 
-    def pipeline(self, *, transaction: bool = True, version: int | None = None) -> Pipeline:
-        from django_cachex.adapter.pipeline import Pipeline
-
-        pipeline_adapter = self._pipeline(transaction=transaction)
-        return Pipeline(adapter=self, pipeline_adapter=pipeline_adapter, version=version)
+    def pipeline(self, *, transaction: bool = True) -> BaseKeyValuePipelineAdapter:
+        return self._pipeline(transaction=transaction)
 
     # =========================================================================
     # Async core ops
@@ -1410,7 +1405,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         stampede_prevention: bool | dict | None = None,
     ) -> bool:
         client = await self._aclient()
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -1441,7 +1436,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
 
             if ttl > 0 and should_recompute(ttl, config):
                 return None
-        return self.decode(val)
+        return val
 
     async def aset(
         self,
@@ -1452,7 +1447,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         stampede_prevention: bool | dict | None = None,
     ) -> None:
         client = await self._aclient()
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -1474,7 +1469,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         stampede_prevention: bool | dict | None = None,
     ) -> bool | Any:
         client = await self._aclient()
-        nvalue = self.encode(value)
+        nvalue = value
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -1492,7 +1487,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
 
         result = await client.set(key, _enc(nvalue), **kw)
         if get:
-            return None if result is None else self.decode(result)
+            return None if result is None else result
         return result == "OK"
 
     async def atouch(self, key: KeyT, timeout: int | None) -> bool:
@@ -1532,7 +1527,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
                     if isinstance(ttl, int) and ttl > 0 and should_recompute(ttl, config):
                         del found[k]
 
-        return {k: self.decode(v) for k, v in found.items()}
+        return dict(found.items())
 
     async def ahas_key(self, key: KeyT) -> bool:
         return bool(await (await self._aclient()).exists([key]))
@@ -1559,7 +1554,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         if not data:
             return []
         client = await self._aclient()
-        prepared = {k: _enc(self.encode(v)) for k, v in data.items()}
+        prepared = {k: _enc(v) for k, v in data.items()}
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
 
         if actual_timeout == 0:
@@ -1671,38 +1666,38 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         client = await self._aclient()
         m: dict[Any, Any] = {}
         if field is not None:
-            m[field] = _enc(self.encode(value))
+            m[field] = _enc(value)
         if mapping:
-            m.update({f: _enc(self.encode(v)) for f, v in mapping.items()})
+            m.update({f: _enc(v) for f, v in mapping.items()})
         if items:
             for i in range(0, len(items), 2):
-                m[items[i]] = _enc(self.encode(items[i + 1]))
+                m[items[i]] = _enc(items[i + 1])
         if not m:
             return 0
         return await client.hset(key, m)
 
     async def ahsetnx(self, key: KeyT, field: str, value: Any) -> bool:
-        return await (await self._aclient()).hsetnx(key, field, _enc(self.encode(value)))
+        return await (await self._aclient()).hsetnx(key, field, _enc(value))
 
     async def ahget(self, key: KeyT, field: str) -> Any:
         val = await (await self._aclient()).hget(key, field)
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     async def ahmget(self, key: KeyT, *fields: str) -> list:
         if len(fields) == 1 and isinstance(fields[0], (list, tuple)):
             fields = tuple(fields[0])
         values = await (await self._aclient()).hmget(key, list(fields))
-        return [self.decode(v) if v is not None else None for v in values]
+        return [v if v is not None else None for v in values]
 
     async def ahgetall(self, key: KeyT) -> dict[str, Any]:
         result = await (await self._aclient()).hgetall(key)
-        return {k.decode() if isinstance(k, bytes) else k: self.decode(v) for k, v in result.items()}
+        return {k.decode() if isinstance(k, bytes) else k: v for k, v in result.items()}
 
     async def ahkeys(self, key: KeyT) -> list[str]:
         return [k.decode() if isinstance(k, bytes) else k for k in await (await self._aclient()).hkeys(key)]
 
     async def ahvals(self, key: KeyT) -> list:
-        return [self.decode(v) for v in await (await self._aclient()).hvals(key)]
+        return list(await (await self._aclient()).hvals(key))
 
     async def ahlen(self, key: KeyT) -> int:
         return await (await self._aclient()).hlen(key)
@@ -1724,19 +1719,19 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
     # =========================================================================
 
     async def asadd(self, key: KeyT, *members: Any) -> int:
-        return await (await self._aclient()).sadd(key, [_enc(self.encode(m)) for m in members])
+        return await (await self._aclient()).sadd(key, [_enc(m) for m in members])
 
     async def asrem(self, key: KeyT, *members: Any) -> int:
-        return await (await self._aclient()).srem(key, [_enc(self.encode(m)) for m in members])
+        return await (await self._aclient()).srem(key, [_enc(m) for m in members])
 
     async def asmembers(self, key: KeyT) -> _BuiltinSet[Any]:
-        return {self.decode(m) for m in await (await self._aclient()).smembers(key)}
+        return set(await (await self._aclient()).smembers(key))
 
     async def asismember(self, key: KeyT, member: Any) -> bool:
-        return bool(await (await self._aclient()).sismember(key, _enc(self.encode(member))))
+        return bool(await (await self._aclient()).sismember(key, _enc(member)))
 
     async def asmismember(self, key: KeyT, *members: Any) -> list[bool]:
-        return list(await (await self._aclient()).smismember(key, [_enc(self.encode(m)) for m in members]))
+        return list(await (await self._aclient()).smismember(key, [_enc(m) for m in members]))
 
     async def ascard(self, key: KeyT) -> int:
         return await (await self._aclient()).scard(key)
@@ -1745,27 +1740,27 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         client = await self._aclient()
         if count is None:
             v = await client.spop(key)
-            return None if v is None else self.decode(v)
-        return {self.decode(v) for v in await client.spop_count(key, count)}
+            return None if v is None else v
+        return set(await client.spop_count(key, count))
 
     async def asrandmember(self, key: KeyT, count: int | None = None) -> Any:
         client = await self._aclient()
         if count is None:
             v = await client.srandmember(key)
-            return None if v is None else self.decode(v)
-        return [self.decode(v) for v in await client.srandmember_count(key, count)]
+            return None if v is None else v
+        return list(await client.srandmember_count(key, count))
 
     async def asmove(self, src: KeyT, dst: KeyT, member: Any) -> bool:
-        return bool(await (await self._aclient()).smove(src, dst, _enc(self.encode(member))))
+        return bool(await (await self._aclient()).smove(src, dst, _enc(member)))
 
     async def asinter(self, *keys: KeyT) -> _BuiltinSet[Any]:
-        return {self.decode(m) for m in await (await self._aclient()).sinter(list(keys))}
+        return set(await (await self._aclient()).sinter(list(keys)))
 
     async def asunion(self, *keys: KeyT) -> _BuiltinSet[Any]:
-        return {self.decode(m) for m in await (await self._aclient()).sunion(list(keys))}
+        return set(await (await self._aclient()).sunion(list(keys)))
 
     async def asdiff(self, *keys: KeyT) -> _BuiltinSet[Any]:
-        return {self.decode(m) for m in await (await self._aclient()).sdiff(list(keys))}
+        return set(await (await self._aclient()).sdiff(list(keys)))
 
     async def asinterstore(self, dst: KeyT, *keys: KeyT) -> int:
         return await (await self._aclient()).sinterstore(dst, list(keys))
@@ -1784,7 +1779,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         count: int | None = None,
     ) -> tuple[bytes, list]:
         result = await (await self._aclient()).sscan(key, _enc(cursor), match=match, count=count)
-        return result[0], [self.decode(v) for v in result[1]]
+        return result[0], list(result[1])
 
     async def asscan_iter(self, key: KeyT, match: str | None = None, count: int | None = None):
         client = await self._aclient()
@@ -1793,7 +1788,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
             result = await client.sscan(key, cursor, match=match, count=count)
             cursor, members = result[0], result[1]
             for m in members:
-                yield self.decode(m)
+                yield m
             if cursor in (b"0", "0", 0):
                 return
 
@@ -1814,27 +1809,27 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
             if kwargs.get("incr"):
                 args.append(b"INCR")
             for member, score in mapping.items():
-                args.extend([_enc(score), _enc(self.encode(member))])
+                args.extend([_enc(score), _enc(member)])
             return await client.custom_command(args)
-        return await client.zadd(key, {_enc(self.encode(m)): float(s) for m, s in mapping.items()})
+        return await client.zadd(key, {_enc(m): float(s) for m, s in mapping.items()})
 
     async def azrem(self, key: KeyT, *members: Any) -> int:
-        return await (await self._aclient()).zrem(key, [_enc(self.encode(m)) for m in members])
+        return await (await self._aclient()).zrem(key, [_enc(m) for m in members])
 
     async def azscore(self, key: KeyT, member: Any) -> float | None:
-        return await (await self._aclient()).zscore(key, _enc(self.encode(member)))
+        return await (await self._aclient()).zscore(key, _enc(member))
 
     async def azmscore(self, key: KeyT, members: list[Any]) -> list[float | None]:
-        return list(await (await self._aclient()).zmscore(key, [_enc(self.encode(m)) for m in members]))
+        return list(await (await self._aclient()).zmscore(key, [_enc(m) for m in members]))
 
     async def azrank(self, key: KeyT, member: Any) -> int | None:
-        return await (await self._aclient()).zrank(key, _enc(self.encode(member)))
+        return await (await self._aclient()).zrank(key, _enc(member))
 
     async def azrevrank(self, key: KeyT, member: Any) -> int | None:
-        return await (await self._aclient()).zrevrank(key, _enc(self.encode(member)))
+        return await (await self._aclient()).zrevrank(key, _enc(member))
 
     async def azincrby(self, key: KeyT, amount: float, member: Any) -> float:
-        return await (await self._aclient()).zincrby(key, amount, _enc(self.encode(member)))
+        return await (await self._aclient()).zincrby(key, amount, _enc(member))
 
     async def azremrangebyrank(self, key: KeyT, start: int, end: int) -> int:
         return await (await self._aclient()).zremrangebyrank(key, start, end)
@@ -1854,7 +1849,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
             args.append(b"REV")
         if withscores:
             args.append(b"WITHSCORES")
-        return _decode_zrange(await (await self._aclient()).custom_command(args), self.decode, withscores=withscores)
+        return _decode_zrange(await (await self._aclient()).custom_command(args), _passthrough, withscores=withscores)
 
     async def azrevrange(self, key: KeyT, start: int, end: int, withscores: bool = False) -> list:
         return await self.azrange(key, start, end, withscores=withscores, desc=True)
@@ -1863,48 +1858,48 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         args = [b"ZRANGEBYSCORE", key, _enc(mn), _enc(mx)]
         if withscores:
             args.append(b"WITHSCORES")
-        return _decode_zrange(await (await self._aclient()).custom_command(args), self.decode, withscores=withscores)
+        return _decode_zrange(await (await self._aclient()).custom_command(args), _passthrough, withscores=withscores)
 
     async def azrevrangebyscore(self, key: KeyT, mx: Any, mn: Any, withscores: bool = False) -> list:
         args = [b"ZREVRANGEBYSCORE", key, _enc(mx), _enc(mn)]
         if withscores:
             args.append(b"WITHSCORES")
-        return _decode_zrange(await (await self._aclient()).custom_command(args), self.decode, withscores=withscores)
+        return _decode_zrange(await (await self._aclient()).custom_command(args), _passthrough, withscores=withscores)
 
     async def azpopmin(self, key: KeyT, count: int = 1) -> list[tuple[Any, float]]:
-        return _decode_zpop(await (await self._aclient()).zpopmin(key, count), self.decode)
+        return _decode_zpop(await (await self._aclient()).zpopmin(key, count), _passthrough)
 
     async def azpopmax(self, key: KeyT, count: int = 1) -> list[tuple[Any, float]]:
-        return _decode_zpop(await (await self._aclient()).zpopmax(key, count), self.decode)
+        return _decode_zpop(await (await self._aclient()).zpopmax(key, count), _passthrough)
 
     # =========================================================================
     # Async lists
     # =========================================================================
 
     async def alpush(self, key: KeyT, *values: Any) -> int:
-        return await (await self._aclient()).lpush(key, [_enc(self.encode(v)) for v in values])
+        return await (await self._aclient()).lpush(key, [_enc(v) for v in values])
 
     async def arpush(self, key: KeyT, *values: Any) -> int:
-        return await (await self._aclient()).rpush(key, [_enc(self.encode(v)) for v in values])
+        return await (await self._aclient()).rpush(key, [_enc(v) for v in values])
 
     async def alpop(self, key: KeyT, count: int | None = None) -> Any:
         client = await self._aclient()
         if count is None:
             v = await client.lpop(key)
-            return None if v is None else self.decode(v)
+            return None if v is None else v
         result = await client.lpop_count(key, count)
-        return [self.decode(v) for v in result] if result else []
+        return list(result) if result else []
 
     async def arpop(self, key: KeyT, count: int | None = None) -> Any:
         client = await self._aclient()
         if count is None:
             v = await client.rpop(key)
-            return None if v is None else self.decode(v)
+            return None if v is None else v
         result = await client.rpop_count(key, count)
-        return [self.decode(v) for v in result] if result else []
+        return list(result) if result else []
 
     async def alrange(self, key: KeyT, start: int, end: int) -> list:
-        return [self.decode(v) for v in await (await self._aclient()).lrange(key, start, end)]
+        return list(await (await self._aclient()).lrange(key, start, end))
 
     async def altrim(self, key: KeyT, start: int, end: int) -> bool:
         return (await (await self._aclient()).ltrim(key, start, end)) == "OK"
@@ -1914,13 +1909,13 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
 
     async def alindex(self, key: KeyT, index: int) -> Any:
         v = await (await self._aclient()).lindex(key, index)
-        return None if v is None else self.decode(v)
+        return None if v is None else v
 
     async def alset(self, key: KeyT, index: int, value: Any) -> bool:
-        return (await (await self._aclient()).lset(key, index, _enc(self.encode(value)))) == "OK"
+        return (await (await self._aclient()).lset(key, index, _enc(value))) == "OK"
 
     async def alrem(self, key: KeyT, count: int, value: Any) -> int:
-        return await (await self._aclient()).lrem(key, count, _enc(self.encode(value)))
+        return await (await self._aclient()).lrem(key, count, _enc(value))
 
     async def alinsert(self, key: KeyT, where: str, pivot: Any, value: Any) -> int:
         return await (await self._aclient()).custom_command(
@@ -1928,13 +1923,13 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
                 b"LINSERT",
                 key,
                 _enc(where.upper()),
-                _enc(self.encode(pivot)),
-                _enc(self.encode(value)),
+                _enc(pivot),
+                _enc(value),
             ],
         )
 
     async def alpos(self, key: KeyT, element: Any, **kwargs: Any) -> Any:
-        args: list[Any] = [b"LPOS", key, _enc(self.encode(element))]
+        args: list[Any] = [b"LPOS", key, _enc(element)]
         if "rank" in kwargs:
             args.extend([b"RANK", str(kwargs["rank"]).encode()])
         if "count" in kwargs:
@@ -1947,7 +1942,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
         v = await (await self._aclient()).custom_command(
             [b"LMOVE", src, dst, _enc(src_dir.upper()), _enc(dst_dir.upper())],
         )
-        return None if v is None else self.decode(v)
+        return None if v is None else v
 
     async def ablmove(self, src: KeyT, dst: KeyT, src_dir: str, dst_dir: str, timeout: float) -> Any:
         v = await (await self._aclient()).custom_command(
@@ -1960,7 +1955,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
                 str(timeout).encode(),
             ],
         )
-        return None if v is None else self.decode(v)
+        return None if v is None else v
 
     async def ablpop(self, keys: Any, timeout: float = 0) -> Any:
         ks = list(keys) if isinstance(keys, (list, tuple)) else [keys]
@@ -1977,7 +1972,7 @@ class ValkeyGlideAdapter(BaseKeyValueAdapter):
     async def axadd(self, key: KeyT, fields: Mapping[Any, Any], id: str = "*", **kwargs: Any) -> str:
         args = [b"XADD", key, _enc(id)]
         for f, v in fields.items():
-            args.extend([_enc(f), _enc(self.encode(v))])
+            args.extend([_enc(f), _enc(v)])
         result = await (await self._aclient()).custom_command(args)
         return result.decode() if isinstance(result, bytes) else result
 
@@ -2099,6 +2094,11 @@ def _batched(it: Iterable[Any], n: int) -> Iterable[list[Any]]:
             chunk = []
     if chunk:
         yield chunk
+
+
+def _passthrough(value: Any) -> Any:
+    """No-op decoder. Decoding now happens at the cache layer."""
+    return value
 
 
 def _decode_zrange(result: Any, decoder: Any, *, withscores: bool) -> list:

--- a/django_cachex/adapter/pipeline.py
+++ b/django_cachex/adapter/pipeline.py
@@ -630,12 +630,16 @@ class Pipeline:
 
     def __init__(
         self,
-        adapter: Any,
+        cache: Any,
         pipeline_adapter: BaseKeyValuePipelineAdapter,
         version: int | None = None,
     ) -> None:
         """Initialize the wrapped pipeline."""
-        self._adapter = adapter
+        self._cache = cache
+        # Adapter back-reference for timeout / stampede helpers that still
+        # live on the adapter layer (``_get_timeout_with_buffer`` /
+        # ``_resolve_stampede``). Encoding/decoding lives on the cache.
+        self._adapter = cache.adapter
         self._pipeline_adapter = pipeline_adapter
         self._version = version
         self._key_func: Callable[..., str] | None = None
@@ -676,31 +680,31 @@ class Pipeline:
         """
         if value is None:
             return None
-        return self._adapter.decode(value)
+        return self._cache.decode(value)
 
     def _decode_list(self, value: list[bytes | None]) -> list[Any]:
         """Decode a list of values."""
-        return [self._adapter.decode(item) if item is not None else None for item in value]
+        return [self._cache.decode(item) if item is not None else None for item in value]
 
     def _decode_single_or_list(self, value: bytes | list[bytes | None] | None) -> Any:
         """Decode value that may be single item, list, or None (lpop/rpop with count)."""
         if value is None:
             return None
         if isinstance(value, list):
-            return [self._adapter.decode(item) if item is not None else None for item in value]
-        return self._adapter.decode(value)
+            return [self._cache.decode(item) if item is not None else None for item in value]
+        return self._cache.decode(value)
 
     def _decode_set(self, value: _Set[bytes]) -> _Set[Any]:
         """Decode a set of values."""
-        return {self._adapter.decode(item) for item in value}
+        return {self._cache.decode(item) for item in value}
 
     def _decode_set_or_single(self, value: _Set[bytes] | bytes | None) -> _Set[Any] | Any:
         """Decode spop/srandmember result (set, single value, or None)."""
         if value is None:
             return None
         if isinstance(value, (set, list)):
-            return {self._adapter.decode(item) for item in value}
-        return self._adapter.decode(value)
+            return {self._cache.decode(item) for item in value}
+        return self._cache.decode(value)
 
     def _decode_hash_keys(self, value: list[bytes]) -> list[str]:
         """Decode hash field names (keys are not serialized, just bytes)."""
@@ -708,19 +712,19 @@ class Pipeline:
 
     def _decode_hash_values(self, value: list[bytes | None]) -> list[Any]:
         """Decode hash values (may contain None for missing fields)."""
-        return [self._adapter.decode(v) if v is not None else None for v in value]
+        return [self._cache.decode(v) if v is not None else None for v in value]
 
     def _decode_hash_dict(self, value: dict[bytes, bytes]) -> dict[str, Any]:
         """Decode a full hash (keys are strings, values are decoded)."""
-        return {k.decode(): self._adapter.decode(v) for k, v in value.items()}
+        return {k.decode(): self._cache.decode(v) for k, v in value.items()}
 
     def _decode_zset_members(self, value: list[bytes]) -> list[Any]:
         """Decode sorted set members (without scores)."""
-        return [self._adapter.decode(member) for member in value]
+        return [self._cache.decode(member) for member in value]
 
     def _decode_zset_with_scores(self, value: list[tuple[bytes, float]]) -> list[tuple[Any, float]]:
         """Decode sorted set members with scores."""
-        return [(self._adapter.decode(member), score) for member, score in value]
+        return [(self._cache.decode(member), score) for member, score in value]
 
     def _make_zset_decoder(self, *, withscores: bool) -> Callable[[list[tuple[bytes, float]]], list]:
         """Create decoder based on whether scores are included."""
@@ -732,7 +736,7 @@ class Pipeline:
         """Decode zpopmin/zpopmax result."""
         if not value:
             return []
-        return [(self._adapter.decode(member), score) for member, score in value]
+        return [(self._cache.decode(member), score) for member, score in value]
 
     def _decode_type(self, value: bytes | str) -> str:
         """Decode TYPE result to string."""
@@ -747,7 +751,7 @@ class Pipeline:
         return [
             (
                 entry_id.decode() if isinstance(entry_id, bytes) else entry_id,
-                {k.decode() if isinstance(k, bytes) else k: self._adapter.decode(v) for k, v in fields.items()},
+                {k.decode() if isinstance(k, bytes) else k: self._cache.decode(v) for k, v in fields.items()},
             )
             for entry_id, fields in results
         ]
@@ -795,11 +799,11 @@ class Pipeline:
         v = version if version is not None else self._version
         if self._key_func is not None:
             return self._key_func(key, version=v)
-        return self._adapter.make_key(key, version=v)
+        return self._cache.make_and_validate_key(key, version=v)
 
     def _encode(self, value: Any) -> bytes | int:
         """Encode a value for storage."""
-        return self._adapter.encode(value)
+        return self._cache.encode(value)
 
     # -------------------------------------------------------------------------
     # Core cache operations
@@ -1355,9 +1359,9 @@ class Pipeline:
         # Returns list when count is specified, single value otherwise
         self._decoders.append(
             lambda x: (
-                [self._adapter.decode(item) for item in x]
+                [self._cache.decode(item) for item in x]
                 if isinstance(x, list)
-                else (self._adapter.decode(x) if x is not None else None)
+                else (self._cache.decode(x) if x is not None else None)
             ),
         )
         return self
@@ -1556,7 +1560,7 @@ class Pipeline:
         """Queue HVALS command (get all values)."""
         nkey = self._make_key(key, version)
         self._pipeline_adapter.hvals(nkey)
-        self._decoders.append(lambda x: [self._adapter.decode(v) for v in x])
+        self._decoders.append(lambda x: [self._cache.decode(v) for v in x])
         return self
 
     # -------------------------------------------------------------------------
@@ -2174,8 +2178,8 @@ class Pipeline:
         # Create helpers for pre/post processing
         helpers = ScriptHelpers(
             make_key=self._make_key,
-            encode=self._adapter.encode,
-            decode=self._adapter.decode,
+            encode=self._cache.encode,
+            decode=self._cache.decode,
             version=v,
         )
 

--- a/django_cachex/adapter/rust.py
+++ b/django_cachex/adapter/rust.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable, Iterator, Mapping, Sequence
 
     from django_cachex._driver import RustValkeyDriver
-    from django_cachex.adapter.pipeline import Pipeline
+    from django_cachex.adapter.pipeline import BaseKeyValuePipelineAdapter
     from django_cachex.types import AbsExpiryT, ExpiryT, KeyT, _Set
 
 
@@ -127,7 +127,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         *,
         stampede_prevention: bool | dict | None = None,
     ) -> bool:
-        nvalue = _value_to_bytes(self.encode(value))
+        nvalue = _value_to_bytes(value)
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
         if actual_timeout == 0:
             if self._driver.set_nx(_str_key(key), nvalue, ttl=None):
@@ -145,7 +145,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         *,
         stampede_prevention: bool | dict | None = None,
     ) -> bool:
-        nvalue = _value_to_bytes(self.encode(value))
+        nvalue = _value_to_bytes(value)
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
         if actual_timeout == 0:
             if await self._driver.aset_nx(_str_key(key), nvalue, ttl=None):
@@ -164,7 +164,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
             ttl = self._driver.ttl(_str_key(key))
             if ttl > 0 and should_recompute(ttl, config):
                 return None
-        return self.decode(val)
+        return val
 
     @override
     async def aget(self, key: KeyT, *, stampede_prevention: bool | dict | None = None) -> Any:
@@ -176,7 +176,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
             ttl = await self._driver.attl(_str_key(key))
             if ttl > 0 and should_recompute(ttl, config):
                 return None
-        return self.decode(val)
+        return val
 
     @override
     def set(
@@ -187,7 +187,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         *,
         stampede_prevention: bool | dict | None = None,
     ) -> None:
-        nvalue = _value_to_bytes(self.encode(value))
+        nvalue = _value_to_bytes(value)
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
         if actual_timeout == 0:
             self._driver.delete(_str_key(key))
@@ -203,7 +203,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         *,
         stampede_prevention: bool | dict | None = None,
     ) -> None:
-        nvalue = _value_to_bytes(self.encode(value))
+        nvalue = _value_to_bytes(value)
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
         if actual_timeout == 0:
             await self._driver.adelete(_str_key(key))
@@ -250,7 +250,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         get: bool = False,
         stampede_prevention: bool | dict | None = None,
     ) -> bool | Any:
-        nvalue = _value_to_bytes(self.encode(value))
+        nvalue = _value_to_bytes(value)
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
         if actual_timeout == 0:
             return None if get else False
@@ -261,7 +261,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         )
         if get:
             # SET ... GET returns the previous value (bytes) or nil.
-            return None if result is None else self.decode(result)
+            return None if result is None else result
         # Without GET: Redis's "OK" status surfaces from the driver as ``True``
         # (Value::Okay → Python bool); NX/XX rejection comes through as None.
         return result is True
@@ -278,7 +278,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         get: bool = False,
         stampede_prevention: bool | dict | None = None,
     ) -> bool | Any:
-        nvalue = _value_to_bytes(self.encode(value))
+        nvalue = _value_to_bytes(value)
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
         if actual_timeout == 0:
             return None if get else False
@@ -288,7 +288,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
             self._set_with_flags_argv(nvalue, actual_timeout, nx, xx, get),
         )
         if get:
-            return None if result is None else self.decode(result)
+            return None if result is None else result
         return result is True
 
     @override
@@ -325,7 +325,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
                 ttl = self._driver.ttl(k)
                 if ttl > 0 and should_recompute(ttl, config):
                     del found[k]
-        return {k: self.decode(v) for k, v in found.items()}
+        return dict(found.items())
 
     @override
     async def aget_many(
@@ -346,7 +346,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
                 ttl = await self._driver.attl(k)
                 if ttl > 0 and should_recompute(ttl, config):
                     del found[k]
-        return {k: self.decode(v) for k, v in found.items()}
+        return dict(found.items())
 
     @override
     def has_key(self, key: KeyT) -> bool:
@@ -384,7 +384,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     ) -> list:
         if not data:
             return []
-        prepared = [(_str_key(k), _value_to_bytes(self.encode(v))) for k, v in data.items()]
+        prepared = [(_str_key(k), _value_to_bytes(v)) for k, v in data.items()]
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
         if actual_timeout == 0:
             self._driver.delete_many([k for k, _ in prepared])
@@ -402,7 +402,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     ) -> list:
         if not data:
             return []
-        prepared = [(_str_key(k), _value_to_bytes(self.encode(v))) for k, v in data.items()]
+        prepared = [(_str_key(k), _value_to_bytes(v)) for k, v in data.items()]
         actual_timeout = self._get_timeout_with_buffer(timeout, stampede_prevention)
         if actual_timeout == 0:
             await self._driver.adelete_many([k for k, _ in prepared])
@@ -755,17 +755,10 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     # =========================================================================
 
     @override
-    def pipeline(
-        self,
-        *,
-        transaction: bool = True,
-        version: int | None = None,
-    ) -> Pipeline:
-        from django_cachex.adapter.pipeline import Pipeline
+    def pipeline(self, *, transaction: bool = True) -> BaseKeyValuePipelineAdapter:
         from django_cachex.adapter.pipeline_rust import RustValkeyPipelineAdapter
 
-        pipeline_adapter = RustValkeyPipelineAdapter(self._driver, transaction=transaction)
-        return Pipeline(adapter=self, pipeline_adapter=pipeline_adapter, version=version)
+        return RustValkeyPipelineAdapter(self._driver, transaction=transaction)
 
     # =========================================================================
     # Hashes
@@ -782,13 +775,13 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     ) -> int:
         pairs: list[tuple[str, bytes]] = []
         if field is not None:
-            pairs.append((str(field), _value_to_bytes(self.encode(value))))
+            pairs.append((str(field), _value_to_bytes(value)))
         if mapping:
-            pairs.extend((str(k), _value_to_bytes(self.encode(v))) for k, v in mapping.items())
+            pairs.extend((str(k), _value_to_bytes(v)) for k, v in mapping.items())
         if items:
             it = iter(items)
             for f, v in zip(it, it, strict=False):
-                pairs.append((str(f), _value_to_bytes(self.encode(v))))
+                pairs.append((str(f), _value_to_bytes(v)))
         if not pairs:
             return 0
         if len(pairs) == 1:
@@ -810,13 +803,13 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     ) -> int:
         pairs: list[tuple[str, bytes]] = []
         if field is not None:
-            pairs.append((str(field), _value_to_bytes(self.encode(value))))
+            pairs.append((str(field), _value_to_bytes(value)))
         if mapping:
-            pairs.extend((str(k), _value_to_bytes(self.encode(v))) for k, v in mapping.items())
+            pairs.extend((str(k), _value_to_bytes(v)) for k, v in mapping.items())
         if items:
             it = iter(items)
             for f, v in zip(it, it, strict=False):
-                pairs.append((str(f), _value_to_bytes(self.encode(v))))
+                pairs.append((str(f), _value_to_bytes(v)))
         if not pairs:
             return 0
         if len(pairs) == 1:
@@ -833,7 +826,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         result = self._driver.eval(
             "return redis.call('HSETNX', KEYS[1], ARGV[1], ARGV[2])",
             [_str_key(key)],
-            [str(field).encode("utf-8"), _value_to_bytes(self.encode(value))],
+            [str(field).encode("utf-8"), _value_to_bytes(value)],
         )
         return bool(result)
 
@@ -842,43 +835,43 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         result = await self._driver.aeval(
             "return redis.call('HSETNX', KEYS[1], ARGV[1], ARGV[2])",
             [_str_key(key)],
-            [str(field).encode("utf-8"), _value_to_bytes(self.encode(value))],
+            [str(field).encode("utf-8"), _value_to_bytes(value)],
         )
         return bool(result)
 
     @override
     def hget(self, key: KeyT, field: str) -> Any | None:
         val = self._driver.hget(_str_key(key), str(field))
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     @override
     async def ahget(self, key: KeyT, field: str) -> Any | None:
         val = await self._driver.ahget(_str_key(key), str(field))
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     @override
     def hmget(self, key: KeyT, *fields: str) -> list[Any | None]:
         if not fields:
             return []
         result = self._driver.hmget(_str_key(key), [str(f) for f in fields])
-        return [None if v is None else self.decode(v) for v in result]
+        return [None if v is None else v for v in result]
 
     @override
     async def ahmget(self, key: KeyT, *fields: str) -> list[Any | None]:
         if not fields:
             return []
         result = await self._driver.ahmget(_str_key(key), [str(f) for f in fields])
-        return [None if v is None else self.decode(v) for v in result]
+        return [None if v is None else v for v in result]
 
     @override
     def hgetall(self, key: KeyT) -> dict[str, Any]:
         result = self._driver.hgetall(_str_key(key))
-        return {(k.decode() if isinstance(k, bytes) else k): self.decode(v) for k, v in result.items()}
+        return {(k.decode() if isinstance(k, bytes) else k): v for k, v in result.items()}
 
     @override
     async def ahgetall(self, key: KeyT) -> dict[str, Any]:
         result = await self._driver.ahgetall(_str_key(key))
-        return {(k.decode() if isinstance(k, bytes) else k): self.decode(v) for k, v in result.items()}
+        return {(k.decode() if isinstance(k, bytes) else k): v for k, v in result.items()}
 
     @override
     def hdel(self, key: KeyT, *fields: str) -> int:
@@ -921,12 +914,12 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     @override
     def hvals(self, key: KeyT) -> list[Any]:
         result = self._driver.hvals(_str_key(key))
-        return [self.decode(v) for v in result]
+        return list(result)
 
     @override
     async def ahvals(self, key: KeyT) -> list[Any]:
         result = await self._driver.ahvals(_str_key(key))
-        return [self.decode(v) for v in result]
+        return list(result)
 
     @override
     def hincrby(self, key: KeyT, field: str, amount: int = 1) -> int:
@@ -966,25 +959,25 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     def lpush(self, key: KeyT, *values: Any) -> int:
         if not values:
             return self.llen(key)
-        return int(self._driver.lpush(_str_key(key), [_value_to_bytes(self.encode(v)) for v in values]))
+        return int(self._driver.lpush(_str_key(key), [_value_to_bytes(v) for v in values]))
 
     @override
     def rpush(self, key: KeyT, *values: Any) -> int:
         if not values:
             return self.llen(key)
-        return int(self._driver.rpush(_str_key(key), [_value_to_bytes(self.encode(v)) for v in values]))
+        return int(self._driver.rpush(_str_key(key), [_value_to_bytes(v) for v in values]))
 
     @override
     async def alpush(self, key: KeyT, *values: Any) -> int:
         if not values:
             return await self.allen(key)
-        return int(await self._driver.alpush(_str_key(key), [_value_to_bytes(self.encode(v)) for v in values]))
+        return int(await self._driver.alpush(_str_key(key), [_value_to_bytes(v) for v in values]))
 
     @override
     async def arpush(self, key: KeyT, *values: Any) -> int:
         if not values:
             return await self.allen(key)
-        return int(await self._driver.arpush(_str_key(key), [_value_to_bytes(self.encode(v)) for v in values]))
+        return int(await self._driver.arpush(_str_key(key), [_value_to_bytes(v) for v in values]))
 
     # lpop / rpop / alpop / arpop with the optional ``count`` argument are
     # implemented in the eval-fallback section below.
@@ -1000,43 +993,43 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     @override
     def lrange(self, key: KeyT, start: int, end: int) -> list[Any]:
         result = self._driver.lrange(_str_key(key), start, end)
-        return [self.decode(v) for v in result]
+        return list(result)
 
     @override
     async def alrange(self, key: KeyT, start: int, end: int) -> list[Any]:
         result = await self._driver.alrange(_str_key(key), start, end)
-        return [self.decode(v) for v in result]
+        return list(result)
 
     @override
     def lindex(self, key: KeyT, index: int) -> Any | None:
         val = self._driver.lindex(_str_key(key), index)
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     @override
     async def alindex(self, key: KeyT, index: int) -> Any | None:
         val = await self._driver.alindex(_str_key(key), index)
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     @override
     def lset(self, key: KeyT, index: int, value: Any) -> bool:
-        self._driver.lset(_str_key(key), index, _value_to_bytes(self.encode(value)))
+        self._driver.lset(_str_key(key), index, _value_to_bytes(value))
         return True
 
     @override
     async def alset(self, key: KeyT, index: int, value: Any) -> bool:
-        await self._driver.alset(_str_key(key), index, _value_to_bytes(self.encode(value)))
+        await self._driver.alset(_str_key(key), index, _value_to_bytes(value))
         return True
 
     @override
     def lrem(self, key: KeyT, count: int, value: Any) -> int:
         return int(
-            self._driver.lrem(_str_key(key), count, _value_to_bytes(self.encode(value))),
+            self._driver.lrem(_str_key(key), count, _value_to_bytes(value)),
         )
 
     @override
     async def alrem(self, key: KeyT, count: int, value: Any) -> int:
         return int(
-            await self._driver.alrem(_str_key(key), count, _value_to_bytes(self.encode(value))),
+            await self._driver.alrem(_str_key(key), count, _value_to_bytes(value)),
         )
 
     @override
@@ -1062,8 +1055,8 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
             self._driver.linsert(
                 _str_key(key),
                 before=before,
-                pivot=_value_to_bytes(self.encode(pivot)),
-                value=_value_to_bytes(self.encode(value)),
+                pivot=_value_to_bytes(pivot),
+                value=_value_to_bytes(value),
             ),
         )
 
@@ -1080,8 +1073,8 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
             await self._driver.alinsert(
                 _str_key(key),
                 before=before,
-                pivot=_value_to_bytes(self.encode(pivot)),
-                value=_value_to_bytes(self.encode(value)),
+                pivot=_value_to_bytes(pivot),
+                value=_value_to_bytes(value),
             ),
         )
 
@@ -1093,46 +1086,46 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     def sadd(self, key: KeyT, *members: Any) -> int:
         if not members:
             return 0
-        return int(self._driver.sadd(_str_key(key), [_value_to_bytes(self.encode(m)) for m in members]))
+        return int(self._driver.sadd(_str_key(key), [_value_to_bytes(m) for m in members]))
 
     @override
     async def asadd(self, key: KeyT, *members: Any) -> int:
         if not members:
             return 0
-        return int(await self._driver.asadd(_str_key(key), [_value_to_bytes(self.encode(m)) for m in members]))
+        return int(await self._driver.asadd(_str_key(key), [_value_to_bytes(m) for m in members]))
 
     @override
     def srem(self, key: KeyT, *members: Any) -> int:
         if not members:
             return 0
-        return int(self._driver.srem(_str_key(key), [_value_to_bytes(self.encode(m)) for m in members]))
+        return int(self._driver.srem(_str_key(key), [_value_to_bytes(m) for m in members]))
 
     @override
     async def asrem(self, key: KeyT, *members: Any) -> int:
         if not members:
             return 0
-        return int(await self._driver.asrem(_str_key(key), [_value_to_bytes(self.encode(m)) for m in members]))
+        return int(await self._driver.asrem(_str_key(key), [_value_to_bytes(m) for m in members]))
 
     @override
     def smembers(self, key: KeyT) -> Any:
         result = self._driver.smembers(_str_key(key))
-        return {self.decode(m) for m in result}
+        return set(result)
 
     @override
     async def asmembers(self, key: KeyT) -> Any:
         result = await self._driver.asmembers(_str_key(key))
-        return {self.decode(m) for m in result}
+        return set(result)
 
     @override
     def sismember(self, key: KeyT, member: Any) -> bool:
         return bool(
-            self._driver.sismember(_str_key(key), _value_to_bytes(self.encode(member))),
+            self._driver.sismember(_str_key(key), _value_to_bytes(member)),
         )
 
     @override
     async def asismember(self, key: KeyT, member: Any) -> bool:
         return bool(
-            await self._driver.asismember(_str_key(key), _value_to_bytes(self.encode(member))),
+            await self._driver.asismember(_str_key(key), _value_to_bytes(member)),
         )
 
     @override
@@ -1152,32 +1145,32 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     @override
     def sinter(self, keys: Any) -> Any:
         result = self._driver.sinter(self._coerce_keys_arg(keys))
-        return {self.decode(m) for m in result}
+        return set(result)
 
     @override
     async def asinter(self, keys: Any) -> Any:
         result = await self._driver.asinter(self._coerce_keys_arg(keys))
-        return {self.decode(m) for m in result}
+        return set(result)
 
     @override
     def sunion(self, keys: Any) -> Any:
         result = self._driver.sunion(self._coerce_keys_arg(keys))
-        return {self.decode(m) for m in result}
+        return set(result)
 
     @override
     async def asunion(self, keys: Any) -> Any:
         result = await self._driver.asunion(self._coerce_keys_arg(keys))
-        return {self.decode(m) for m in result}
+        return set(result)
 
     @override
     def sdiff(self, keys: Any) -> Any:
         result = self._driver.sdiff(self._coerce_keys_arg(keys))
-        return {self.decode(m) for m in result}
+        return set(result)
 
     @override
     async def asdiff(self, keys: Any) -> Any:
         result = await self._driver.asdiff(self._coerce_keys_arg(keys))
-        return {self.decode(m) for m in result}
+        return set(result)
 
     # =========================================================================
     # Sorted sets
@@ -1190,30 +1183,30 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     def zrem(self, key: KeyT, *members: Any) -> int:
         if not members:
             return 0
-        return int(self._driver.zrem(_str_key(key), [_value_to_bytes(self.encode(m)) for m in members]))
+        return int(self._driver.zrem(_str_key(key), [_value_to_bytes(m) for m in members]))
 
     @override
     async def azrem(self, key: KeyT, *members: Any) -> int:
         if not members:
             return 0
-        return int(await self._driver.azrem(_str_key(key), [_value_to_bytes(self.encode(m)) for m in members]))
+        return int(await self._driver.azrem(_str_key(key), [_value_to_bytes(m) for m in members]))
 
     @override
     def zscore(self, key: KeyT, member: Any) -> float | None:
-        return self._driver.zscore(_str_key(key), _value_to_bytes(self.encode(member)))
+        return self._driver.zscore(_str_key(key), _value_to_bytes(member))
 
     @override
     async def azscore(self, key: KeyT, member: Any) -> float | None:
-        return await self._driver.azscore(_str_key(key), _value_to_bytes(self.encode(member)))
+        return await self._driver.azscore(_str_key(key), _value_to_bytes(member))
 
     @override
     def zrank(self, key: KeyT, member: Any) -> int | None:
-        result = self._driver.zrank(_str_key(key), _value_to_bytes(self.encode(member)))
+        result = self._driver.zrank(_str_key(key), _value_to_bytes(member))
         return None if result is None else int(result)
 
     @override
     async def azrank(self, key: KeyT, member: Any) -> int | None:
-        result = await self._driver.azrank(_str_key(key), _value_to_bytes(self.encode(member)))
+        result = await self._driver.azrank(_str_key(key), _value_to_bytes(member))
         return None if result is None else int(result)
 
     @override
@@ -1235,26 +1228,26 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     @override
     def zincrby(self, key: KeyT, amount: float, member: Any) -> float:
         return float(
-            self._driver.zincrby(_str_key(key), _value_to_bytes(self.encode(member)), float(amount)),
+            self._driver.zincrby(_str_key(key), _value_to_bytes(member), float(amount)),
         )
 
     @override
     async def azincrby(self, key: KeyT, amount: float, member: Any) -> float:
         return float(
-            await self._driver.azincrby(_str_key(key), _value_to_bytes(self.encode(member)), float(amount)),
+            await self._driver.azincrby(_str_key(key), _value_to_bytes(member), float(amount)),
         )
 
     def _decode_zrange(self, raw: list[Any], *, withscores: bool) -> list[Any]:
         if not withscores:
-            return [self.decode(m) for m in raw]
+            return list(raw)
         # Driver returns either ``[[m, s], [m, s], ...]`` (standard) or a flat
         # ``[m1, s1, m2, s2, ...]`` (cluster) — handle both.
         if raw and isinstance(raw[0], (list, tuple)):
-            return [(self.decode(member), float(score)) for member, score in raw]
+            return [(member, float(score)) for member, score in raw]
         out: list[tuple[Any, float]] = []
         it = iter(raw)
         for member, score in zip(it, it, strict=False):
-            out.append((self.decode(member), float(score)))
+            out.append((member, float(score)))
         return out
 
     @override
@@ -1357,22 +1350,22 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         # Rust driver wants a concrete i64; default-None semantics ("return one")
         # are encoded as count=1 here, mirroring redis-py's no-count call shape.
         raw = self._driver.zpopmin(_str_key(key), 1 if count is None else count)
-        return [(self.decode(m), float(s)) for m, s in raw]
+        return [(m, float(s)) for m, s in raw]
 
     @override
     async def azpopmin(self, key: KeyT, count: int | None = None) -> list[tuple[Any, float]]:
         raw = await self._driver.azpopmin(_str_key(key), 1 if count is None else count)
-        return [(self.decode(m), float(s)) for m, s in raw]
+        return [(m, float(s)) for m, s in raw]
 
     @override
     def zpopmax(self, key: KeyT, count: int | None = None) -> list[tuple[Any, float]]:
         raw = self._driver.zpopmax(_str_key(key), 1 if count is None else count)
-        return [(self.decode(m), float(s)) for m, s in raw]
+        return [(m, float(s)) for m, s in raw]
 
     @override
     async def azpopmax(self, key: KeyT, count: int | None = None) -> list[tuple[Any, float]]:
         raw = await self._driver.azpopmax(_str_key(key), 1 if count is None else count)
-        return [(self.decode(m), float(s)) for m, s in raw]
+        return [(m, float(s)) for m, s in raw]
 
     # =========================================================================
     # Scripts
@@ -1434,33 +1427,33 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     def lpop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         if count is None:
             val = self._driver.lpop(_str_key(key))
-            return None if val is None else self.decode(val)
+            return None if val is None else val
         result = self._eval_call("LPOP", [key], [count])
-        return None if result is None else [self.decode(v) for v in result]
+        return None if result is None else list(result)
 
     @override
     def rpop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         if count is None:
             val = self._driver.rpop(_str_key(key))
-            return None if val is None else self.decode(val)
+            return None if val is None else val
         result = self._eval_call("RPOP", [key], [count])
-        return None if result is None else [self.decode(v) for v in result]
+        return None if result is None else list(result)
 
     @override
     async def alpop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         if count is None:
             val = await self._driver.alpop(_str_key(key))
-            return None if val is None else self.decode(val)
+            return None if val is None else val
         result = await self._aeval_call("LPOP", [key], [count])
-        return None if result is None else [self.decode(v) for v in result]
+        return None if result is None else list(result)
 
     @override
     async def arpop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         if count is None:
             val = await self._driver.arpop(_str_key(key))
-            return None if val is None else self.decode(val)
+            return None if val is None else val
         result = await self._aeval_call("RPOP", [key], [count])
-        return None if result is None else [self.decode(v) for v in result]
+        return None if result is None else list(result)
 
     # ---- zadd flags ----
 
@@ -1491,7 +1484,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         lt: bool = False,
         ch: bool = False,
     ) -> int:
-        pairs = [(_value_to_bytes(self.encode(m)), float(s)) for m, s in mapping.items()]
+        pairs = [(_value_to_bytes(m), float(s)) for m, s in mapping.items()]
         if not pairs:
             return 0
         if not (nx or xx or gt or lt or ch):
@@ -1514,7 +1507,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         lt: bool = False,
         ch: bool = False,
     ) -> int:
-        pairs = [(_value_to_bytes(self.encode(m)), float(s)) for m, s in mapping.items()]
+        pairs = [(_value_to_bytes(m), float(s)) for m, s in mapping.items()]
         if not pairs:
             return 0
         if not (nx or xx or gt or lt or ch):
@@ -1529,19 +1522,19 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
 
     @override
     def zrevrank(self, key: KeyT, member: Any) -> int | None:
-        result = self._eval_call("ZREVRANK", [key], [_value_to_bytes(self.encode(member))])
+        result = self._eval_call("ZREVRANK", [key], [_value_to_bytes(member)])
         return None if result is None else int(result)
 
     @override
     async def azrevrank(self, key: KeyT, member: Any) -> int | None:
-        result = await self._aeval_call("ZREVRANK", [key], [_value_to_bytes(self.encode(member))])
+        result = await self._aeval_call("ZREVRANK", [key], [_value_to_bytes(member)])
         return None if result is None else int(result)
 
     @override
     def zmscore(self, key: KeyT, *members: Any) -> list[float | None]:
         if not members:
             return []
-        argv = [_value_to_bytes(self.encode(m)) for m in members]
+        argv = [_value_to_bytes(m) for m in members]
         result = self._eval_call("ZMSCORE", [key], argv)
         return [None if s is None else float(s) for s in result]
 
@@ -1549,7 +1542,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     async def azmscore(self, key: KeyT, *members: Any) -> list[float | None]:
         if not members:
             return []
-        argv = [_value_to_bytes(self.encode(m)) for m in members]
+        argv = [_value_to_bytes(m) for m in members]
         result = await self._aeval_call("ZMSCORE", [key], argv)
         return [None if s is None else float(s) for s in result]
 
@@ -1615,30 +1608,30 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     def _decode_zrevrangebyscore(self, raw: list, *, withscores: bool) -> list[Any]:
         # ZREVRANGEBYSCORE WITHSCORES returns a flat [m1, s1, m2, s2, ...].
         if not withscores:
-            return [self.decode(m) for m in raw]
+            return list(raw)
         out: list[tuple[Any, float]] = []
         it = iter(raw)
         for member, score in zip(it, it, strict=False):
-            out.append((self.decode(member), float(score)))
+            out.append((member, float(score)))
         return out
 
     # ---- set ops the driver doesn't expose ----
 
     @override
     def smove(self, src: KeyT, dst: KeyT, member: Any) -> bool:
-        return bool(self._eval_call("SMOVE", [src, dst], [_value_to_bytes(self.encode(member))]))
+        return bool(self._eval_call("SMOVE", [src, dst], [_value_to_bytes(member)]))
 
     @override
     async def asmove(self, src: KeyT, dst: KeyT, member: Any) -> bool:
         return bool(
-            await self._aeval_call("SMOVE", [src, dst], [_value_to_bytes(self.encode(member))]),
+            await self._aeval_call("SMOVE", [src, dst], [_value_to_bytes(member)]),
         )
 
     @override
     def smismember(self, key: KeyT, *members: Any) -> list[bool]:
         if not members:
             return []
-        argv = [_value_to_bytes(self.encode(m)) for m in members]
+        argv = [_value_to_bytes(m) for m in members]
         result = self._eval_call("SMISMEMBER", [key], argv)
         return [bool(r) for r in result]
 
@@ -1646,7 +1639,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     async def asmismember(self, key: KeyT, *members: Any) -> list[bool]:
         if not members:
             return []
-        argv = [_value_to_bytes(self.encode(m)) for m in members]
+        argv = [_value_to_bytes(m) for m in members]
         result = await self._aeval_call("SMISMEMBER", [key], argv)
         return [bool(r) for r in result]
 
@@ -1654,25 +1647,25 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     def spop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         if count is None:
             val = self._eval_call("SPOP", [key], [])
-            return None if val is None else self.decode(val)
+            return None if val is None else val
         result = self._eval_call("SPOP", [key], [count])
-        return None if result is None else [self.decode(v) for v in result]
+        return None if result is None else list(result)
 
     @override
     async def aspop(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         if count is None:
             val = await self._aeval_call("SPOP", [key], [])
-            return None if val is None else self.decode(val)
+            return None if val is None else val
         result = await self._aeval_call("SPOP", [key], [count])
-        return None if result is None else [self.decode(v) for v in result]
+        return None if result is None else list(result)
 
     @override
     def srandmember(self, key: KeyT, count: int | None = None) -> Any | list[Any] | None:
         if count is None:
             val = self._eval_call("SRANDMEMBER", [key], [])
-            return None if val is None else self.decode(val)
+            return None if val is None else val
         result = self._eval_call("SRANDMEMBER", [key], [count])
-        return [] if result is None else [self.decode(v) for v in result]
+        return [] if result is None else list(result)
 
     @override
     async def asrandmember(
@@ -1682,9 +1675,9 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     ) -> Any | list[Any] | None:
         if count is None:
             val = await self._aeval_call("SRANDMEMBER", [key], [])
-            return None if val is None else self.decode(val)
+            return None if val is None else val
         result = await self._aeval_call("SRANDMEMBER", [key], [count])
-        return [] if result is None else [self.decode(v) for v in result]
+        return [] if result is None else list(result)
 
     @override
     def sdiffstore(self, dest: KeyT, keys: Any) -> int:
@@ -1721,7 +1714,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     @override
     def lmove(self, src: KeyT, dst: KeyT, wherefrom: str = "LEFT", whereto: str = "RIGHT") -> Any | None:
         val = self._eval_call("LMOVE", [src, dst], [wherefrom.encode(), whereto.encode()])
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     @override
     async def almove(
@@ -1732,7 +1725,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         whereto: str = "RIGHT",
     ) -> Any | None:
         val = await self._aeval_call("LMOVE", [src, dst], [wherefrom.encode(), whereto.encode()])
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     @override
     def lpos(
@@ -1743,7 +1736,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         count: int | None = None,
         maxlen: int | None = None,
     ) -> int | list[int] | None:
-        argv: list[Any] = [_value_to_bytes(self.encode(value))]
+        argv: list[Any] = [_value_to_bytes(value)]
         if rank is not None:
             argv.extend([b"RANK", rank])
         if count is not None:
@@ -1764,7 +1757,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         count: int | None = None,
         maxlen: int | None = None,
     ) -> int | list[int] | None:
-        argv: list[Any] = [_value_to_bytes(self.encode(value))]
+        argv: list[Any] = [_value_to_bytes(value)]
         if rank is not None:
             argv.extend([b"RANK", rank])
         if count is not None:
@@ -1821,7 +1814,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         minid: str | None = None,
         limit: int | None = None,
     ) -> str:
-        encoded = [(str(k), _value_to_bytes(self.encode(v))) for k, v in fields.items()]
+        encoded = [(str(k), _value_to_bytes(v)) for k, v in fields.items()]
         if maxlen is None and minid is None and not nomkstream and limit is None:
             return self._driver.xadd(_str_key(key), entry_id, encoded)
         argv = self._xadd_argv(entry_id, encoded, maxlen, approximate, nomkstream, minid, limit)
@@ -1840,7 +1833,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         minid: str | None = None,
         limit: int | None = None,
     ) -> str:
-        encoded = [(str(k), _value_to_bytes(self.encode(v))) for k, v in fields.items()]
+        encoded = [(str(k), _value_to_bytes(v)) for k, v in fields.items()]
         if maxlen is None and minid is None and not nomkstream and limit is None:
             return await self._driver.axadd(_str_key(key), entry_id, encoded)
         argv = self._xadd_argv(entry_id, encoded, maxlen, approximate, nomkstream, minid, limit)
@@ -1879,22 +1872,22 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     @override
     def blpop(self, keys: Any, timeout: float = 0) -> tuple[str, Any] | None:
         raw = self._driver.blpop(self._coerce_keys_arg(keys), float(timeout))
-        return None if raw is None else (raw[0], self.decode(raw[1]))
+        return None if raw is None else (raw[0], raw[1])
 
     @override
     def brpop(self, keys: Any, timeout: float = 0) -> tuple[str, Any] | None:
         raw = self._driver.brpop(self._coerce_keys_arg(keys), float(timeout))
-        return None if raw is None else (raw[0], self.decode(raw[1]))
+        return None if raw is None else (raw[0], raw[1])
 
     @override
     async def ablpop(self, keys: Any, timeout: float = 0) -> tuple[str, Any] | None:
         raw = await self._driver.ablpop(self._coerce_keys_arg(keys), float(timeout))
-        return None if raw is None else (raw[0], self.decode(raw[1]))
+        return None if raw is None else (raw[0], raw[1])
 
     @override
     async def abrpop(self, keys: Any, timeout: float = 0) -> tuple[str, Any] | None:
         raw = await self._driver.abrpop(self._coerce_keys_arg(keys), float(timeout))
-        return None if raw is None else (raw[0], self.decode(raw[1]))
+        return None if raw is None else (raw[0], raw[1])
 
     @override
     def blmove(
@@ -1907,7 +1900,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
     ) -> Any | None:
         # Driver positional order is (src, dst, wherefrom, whereto, timeout_secs).
         val = self._driver.blmove(_str_key(src), _str_key(dst), wherefrom, whereto, float(timeout))
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     @override
     async def ablmove(
@@ -1919,7 +1912,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
         whereto: str = "RIGHT",
     ) -> Any | None:
         val = await self._driver.ablmove(_str_key(src), _str_key(dst), wherefrom, whereto, float(timeout))
-        return None if val is None else self.decode(val)
+        return None if val is None else val
 
     # ---- streams: range/read/trim signature translations ----
 
@@ -1988,11 +1981,11 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
                 it = iter(kv)
                 for f, v in zip(it, it, strict=False):
                     field_name = f.decode() if isinstance(f, bytes) else str(f)
-                    fields[field_name] = self.decode(v)
+                    fields[field_name] = v
             elif isinstance(kv, dict):
                 for f, v in kv.items():
                     field_name = f.decode() if isinstance(f, bytes) else str(f)
-                    fields[field_name] = self.decode(v)
+                    fields[field_name] = v
             out.append((entry_id, fields))
         return out
 
@@ -2459,7 +2452,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
             argv.extend([b"COUNT", count])
         result = self._eval_call("SSCAN", [key], argv)
         next_cursor = int(result[0]) if isinstance(result[0], (int, str, bytes)) else 0
-        return next_cursor, {self.decode(v) for v in result[1]}
+        return next_cursor, set(result[1])
 
     @override
     async def asscan(
@@ -2476,7 +2469,7 @@ class RustValkeyAdapter(BaseKeyValueAdapter):
             argv.extend([b"COUNT", count])
         result = await self._aeval_call("SSCAN", [key], argv)
         next_cursor = int(result[0]) if isinstance(result[0], (int, str, bytes)) else 0
-        return next_cursor, {self.decode(v) for v in result[1]}
+        return next_cursor, set(result[1])
 
     @override
     def sscan_iter(self, key: KeyT, match: str | None = None, count: int | None = None) -> Iterator[Any]:

--- a/django_cachex/adapter/sentinel.py
+++ b/django_cachex/adapter/sentinel.py
@@ -67,7 +67,6 @@ class BaseKeyValueSentinelAdapter(BaseKeyValueAdapter):
     def __init__(
         self,
         servers: list[str],
-        serializer: str | list | type | None = None,
         pool_class: str | type | None = None,
         parser_class: str | type | None = None,
         **options: Any,
@@ -77,7 +76,7 @@ class BaseKeyValueSentinelAdapter(BaseKeyValueAdapter):
         if servers:
             servers = self._transform_sentinel_urls(servers[0])
 
-        super().__init__(servers, serializer, pool_class, parser_class, **options)
+        super().__init__(servers, pool_class, parser_class, **options)
 
         # Initialize async sentinels dict
         self._async_sentinels = weakref.WeakKeyDictionary()

--- a/django_cachex/admin/cas.py
+++ b/django_cachex/admin/cas.py
@@ -210,7 +210,7 @@ def cas_update_string(
     Returns:
         1 = success, 0 = conflict, -1 = key gone.
     """
-    encoded = cache.adapter.encode(new_value)
+    encoded = cache.encode(new_value)
     return cache.eval_script(
         _CAS_STRING_UPDATE,
         keys=[key],
@@ -231,7 +231,7 @@ def cas_update_hash_field(
     Returns:
         1 = success, 0 = conflict, -1 = field gone.
     """
-    encoded = cache.adapter.encode(new_value)
+    encoded = cache.encode(new_value)
     return cache.eval_script(
         _CAS_HASH_UPDATE,
         keys=[key],
@@ -252,7 +252,7 @@ def cas_update_zset_score(
     Returns:
         1 = success, 0 = conflict, -1 = member gone.
     """
-    encoded_member = cache.adapter.encode(member)
+    encoded_member = cache.encode(member)
     return cache.eval_script(
         _CAS_ZSET_SCORE_UPDATE,
         keys=[key],
@@ -273,7 +273,7 @@ def cas_update_list_element(
     Returns:
         1 = success, 0 = conflict, -1 = index gone.
     """
-    encoded = cache.adapter.encode(new_value)
+    encoded = cache.encode(new_value)
     return cache.eval_script(
         _CAS_LIST_UPDATE,
         keys=[key],

--- a/django_cachex/cache/default.py
+++ b/django_cachex/cache/default.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import inspect
 import re
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, cast, override
 
 from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
 from django.utils.module_loading import import_string
@@ -27,6 +27,7 @@ from django_cachex.adapter.default import (
     RedisAdapter,
     ValkeyAdapter,
 )
+from django_cachex.exceptions import CompressorError, SerializerError
 from django_cachex.script import ScriptHelpers
 
 # Regex for escaping glob special characters
@@ -36,6 +37,15 @@ _special_re = re.compile("([*?[])")
 def _glob_escape(s: str) -> str:
     """Escape glob special characters in a string."""
     return _special_re.sub(r"[\1]", s)
+
+
+def _load_codec(config: str | type | Any) -> Any:
+    """Resolve a serializer/compressor config: dotted-path / class / instance → instance."""
+    if isinstance(config, str):
+        config = import_string(config)
+    if callable(config):
+        return config()
+    return config
 
 
 # =============================================================================
@@ -76,10 +86,87 @@ class KeyValueCache(BaseCache):
         else:
             self._reverse_key_func = None
 
+        # Setup serializer chain (multi-serializer fallback)
+        serializer_config = self._options.get(
+            "serializer",
+            "django_cachex.serializers.pickle.PickleSerializer",
+        )
+        self._serializers: list[Any] = self._create_serializers(serializer_config)
+
+        # Setup compressor chain (optional; empty = no compression)
+        self._compressors: list[Any] = self._create_compressors(self._options.get("compressor"))
+
     @cached_property
     def adapter(self) -> BaseKeyValueAdapter:
         """Get the BaseKeyValueAdapter instance (matches Django's pattern)."""
         return self._adapter_class(self._servers, **self._options)
+
+    # =========================================================================
+    # Serializer / Compressor stack — encoding lives at the cache layer
+    # =========================================================================
+
+    @staticmethod
+    def _create_serializers(config: Any) -> list[Any]:
+        if config is None:
+            config = "django_cachex.serializers.pickle.PickleSerializer"
+        items: list = config if isinstance(config, list) else [config]
+        return [_load_codec(item) for item in items]
+
+    @staticmethod
+    def _create_compressors(config: Any) -> list[Any]:
+        if config is None:
+            return []
+        items: list = config if isinstance(config, list) else [config]
+        return [_load_codec(item) for item in items]
+
+    def _decompress(self, value: bytes) -> bytes:
+        """Decompress with fallback support for multiple compressors.
+
+        Returns ``value`` unchanged when no compressors are configured.
+        Raises ``CompressorError`` if every configured compressor fails. To
+        accept uncompressed payloads alongside compressed ones (e.g.
+        mid-migration), keep the previously-used compressor at the end of
+        the fallback chain.
+        """
+        if not self._compressors:
+            return value
+        last_error: CompressorError | None = None
+        for compressor in self._compressors:
+            try:
+                return compressor.decompress(value)
+            except CompressorError as e:
+                last_error = e
+        raise last_error if last_error is not None else CompressorError("decompression failed")
+
+    def _deserialize(self, value: bytes) -> Any:
+        """Deserialize with fallback support for multiple serializers."""
+        last_error: SerializerError | None = None
+        for serializer in self._serializers:
+            try:
+                return serializer.loads(value)
+            except SerializerError as e:
+                last_error = e
+                continue
+        if last_error is not None:
+            raise last_error
+        raise SerializerError("No serializers configured")
+
+    def encode(self, value: Any) -> bytes | int:
+        """Encode a value for storage (serialize + compress). Plain ints pass through unchanged."""
+        if isinstance(value, bool) or not isinstance(value, int):
+            value = self._serializers[0].dumps(value)
+            if self._compressors:
+                return self._compressors[0].compress(value)
+            return value
+        return value
+
+    def decode(self, value: Any) -> Any:
+        """Decode a value from storage. Returns int directly if parseable, otherwise decompress + deserialize."""
+        try:
+            return int(value)
+        except ValueError, TypeError:
+            value = self._decompress(value)
+            return self._deserialize(value)
 
     def get_backend_timeout(self, timeout: float | None = DEFAULT_TIMEOUT) -> int | None:
         """Convert timeout to backend format (matches Django's RedisCache).
@@ -128,7 +215,12 @@ class KeyValueCache(BaseCache):
     ) -> bool:
         """Set a value only if the key doesn't exist."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.add(key, value, self.get_backend_timeout(timeout), stampede_prevention=stampede_prevention)
+        return self.adapter.add(
+            key,
+            self.encode(value),
+            self.get_backend_timeout(timeout),
+            stampede_prevention=stampede_prevention,
+        )
 
     @override
     async def aadd(
@@ -144,7 +236,7 @@ class KeyValueCache(BaseCache):
         key = self.make_and_validate_key(key, version=version)
         return await self.adapter.aadd(
             key,
-            value,
+            self.encode(value),
             self.get_backend_timeout(timeout),
             stampede_prevention=stampede_prevention,
         )
@@ -163,7 +255,7 @@ class KeyValueCache(BaseCache):
         value = self.adapter.get(key, stampede_prevention=stampede_prevention)
         if value is None:
             return default
-        return value
+        return self.decode(value)
 
     @override
     async def aget(
@@ -179,7 +271,7 @@ class KeyValueCache(BaseCache):
         value = await self.adapter.aget(key, stampede_prevention=stampede_prevention)
         if value is None:
             return default
-        return value
+        return self.decode(value)
 
     @override
     async def aset(
@@ -202,16 +294,26 @@ class KeyValueCache(BaseCache):
         get = kwargs.get("get", False)
         key = self.make_and_validate_key(key, version=version)
         if nx or xx or get:
-            return await self.adapter.aset_with_flags(
+            result = await self.adapter.aset_with_flags(
                 key,
-                value,
+                self.encode(value),
                 self.get_backend_timeout(timeout),
                 nx=nx,
                 xx=xx,
                 get=get,
                 stampede_prevention=stampede_prevention,
             )
-        await self.adapter.aset(key, value, self.get_backend_timeout(timeout), stampede_prevention=stampede_prevention)
+            # set_with_flags returns the previous value when get=True (bytes or None);
+            # otherwise a bool indicating NX/XX success.
+            if get:
+                return self.decode(result) if result is not None else None
+            return result
+        await self.adapter.aset(
+            key,
+            self.encode(value),
+            self.get_backend_timeout(timeout),
+            stampede_prevention=stampede_prevention,
+        )
         return None
 
     @override
@@ -236,17 +338,25 @@ class KeyValueCache(BaseCache):
         get = kwargs.get("get", False)
         key = self.make_and_validate_key(key, version=version)
         if nx or xx or get:
-            return self.adapter.set_with_flags(
+            result = self.adapter.set_with_flags(
                 key,
-                value,
+                self.encode(value),
                 self.get_backend_timeout(timeout),
                 nx=nx,
                 xx=xx,
                 get=get,
                 stampede_prevention=stampede_prevention,
             )
+            if get:
+                return self.decode(result) if result is not None else None
+            return result
         # Use standard Django method - returns None
-        self.adapter.set(key, value, self.get_backend_timeout(timeout), stampede_prevention=stampede_prevention)
+        self.adapter.set(
+            key,
+            self.encode(value),
+            self.get_backend_timeout(timeout),
+            stampede_prevention=stampede_prevention,
+        )
         return None
 
     @override
@@ -284,7 +394,7 @@ class KeyValueCache(BaseCache):
         """Retrieve many keys."""
         key_map = {self.make_and_validate_key(key, version=version): key for key in keys}
         ret = self.adapter.get_many(key_map.keys(), stampede_prevention=stampede_prevention)
-        return {key_map[k]: v for k, v in ret.items()}  # type: ignore[index]  # ty: ignore[invalid-argument-type]
+        return {key_map[k]: self.decode(v) for k, v in ret.items()}  # type: ignore[index]  # ty: ignore[invalid-argument-type]
 
     @override
     async def aget_many(  # type: ignore[override]
@@ -297,7 +407,7 @@ class KeyValueCache(BaseCache):
         """Retrieve many keys asynchronously."""
         key_map = {self.make_and_validate_key(key, version=version): key for key in keys}
         ret = await self.adapter.aget_many(key_map.keys(), stampede_prevention=stampede_prevention)
-        return {key_map[k]: v for k, v in ret.items()}  # type: ignore[index]  # ty: ignore[invalid-argument-type]
+        return {key_map[k]: self.decode(v) for k, v in ret.items()}  # type: ignore[index]  # ty: ignore[invalid-argument-type]
 
     @override
     def has_key(self, key: KeyT, version: int | None = None) -> bool:
@@ -393,7 +503,9 @@ class KeyValueCache(BaseCache):
         """Set multiple values."""
         if not data:
             return []
-        safe_data = {self.make_and_validate_key(key, version=version): value for key, value in data.items()}
+        safe_data = {
+            self.make_and_validate_key(key, version=version): self.encode(value) for key, value in data.items()
+        }
         self.adapter.set_many(safe_data, self.get_backend_timeout(timeout), stampede_prevention=stampede_prevention)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         return []
 
@@ -409,7 +521,9 @@ class KeyValueCache(BaseCache):
         """Set multiple values asynchronously."""
         if not data:
             return []
-        safe_data = {self.make_and_validate_key(key, version=version): value for key, value in data.items()}
+        safe_data = {
+            self.make_and_validate_key(key, version=version): self.encode(value) for key, value in data.items()
+        }
         await self.adapter.aset_many(
             safe_data,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             self.get_backend_timeout(timeout),
@@ -750,13 +864,14 @@ class KeyValueCache(BaseCache):
         version: int | None = None,
     ) -> Pipeline:
         """Create a pipeline for batched operations."""
-        pipe = self.adapter.pipeline(
-            transaction=transaction,
-            version=version if version is not None else self.version,
-        )
+        from django_cachex.adapter.pipeline import Pipeline
+
+        v = version if version is not None else self.version
+        pipeline_adapter = self.adapter.pipeline(transaction=transaction)
+        pipe = Pipeline(cache=self, pipeline_adapter=pipeline_adapter, version=v)
         # Set key_func for proper key prefixing
         pipe._key_func = self.make_and_validate_key
-        pipe._cache_version = version if version is not None else self.version
+        pipe._cache_version = v
         return pipe
 
     # =========================================================================
@@ -807,7 +922,10 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Set hash field(s). Use field/value, mapping, or items (flat key-value pairs)."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.hset(key, field, value, mapping=mapping, items=items)
+        nvalue = self.encode(value) if field is not None else None
+        nmapping = {f: self.encode(v) for f, v in mapping.items()} if mapping else None
+        nitems = [self.encode(v) if i % 2 else v for i, v in enumerate(items)] if items else None
+        return self.adapter.hset(key, field, nvalue, mapping=nmapping, items=nitems)
 
     def hdel(
         self,
@@ -827,7 +945,7 @@ class KeyValueCache(BaseCache):
     def hkeys(self, key: KeyT, version: int | None = None) -> list[str]:
         """Get all field names in hash at key."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.hkeys(key)
+        return [f.decode() if isinstance(f, bytes) else f for f in self.adapter.hkeys(key)]
 
     def hexists(
         self,
@@ -847,7 +965,8 @@ class KeyValueCache(BaseCache):
     ) -> Any:
         """Get value of field in hash at key."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.hget(key, field)
+        result = self.adapter.hget(key, field)
+        return self.decode(result) if result is not None else None
 
     def hgetall(
         self,
@@ -856,7 +975,9 @@ class KeyValueCache(BaseCache):
     ) -> dict[str, Any]:
         """Get all fields and values in hash at key."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.hgetall(key)
+        return {
+            (f.decode() if isinstance(f, bytes) else f): self.decode(v) for f, v in self.adapter.hgetall(key).items()
+        }
 
     def hmget(
         self,
@@ -866,7 +987,7 @@ class KeyValueCache(BaseCache):
     ) -> list[Any]:
         """Get values of multiple fields in hash."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.hmget(key, *fields)
+        return [self.decode(v) if v is not None else None for v in self.adapter.hmget(key, *fields)]
 
     def hincrby(
         self,
@@ -899,7 +1020,7 @@ class KeyValueCache(BaseCache):
     ) -> bool:
         """Set field in hash only if it doesn't exist."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.hsetnx(key, field, value)
+        return self.adapter.hsetnx(key, field, self.encode(value))
 
     def hvals(
         self,
@@ -908,7 +1029,7 @@ class KeyValueCache(BaseCache):
     ) -> list[Any]:
         """Get all values in hash at key."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.hvals(key)
+        return [self.decode(v) for v in self.adapter.hvals(key)]
 
     async def ahset(
         self,
@@ -921,7 +1042,10 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Set hash field(s) asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.ahset(key, field, value, mapping=mapping, items=items)
+        nvalue = self.encode(value) if field is not None else None
+        nmapping = {f: self.encode(v) for f, v in mapping.items()} if mapping else None
+        nitems = [self.encode(v) if i % 2 else v for i, v in enumerate(items)] if items else None
+        return await self.adapter.ahset(key, field, nvalue, mapping=nmapping, items=nitems)
 
     async def ahdel(
         self,
@@ -941,7 +1065,7 @@ class KeyValueCache(BaseCache):
     async def ahkeys(self, key: KeyT, version: int | None = None) -> list[str]:
         """Get all field names in hash at key asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.ahkeys(key)
+        return [f.decode() if isinstance(f, bytes) else f for f in await self.adapter.ahkeys(key)]
 
     async def ahexists(
         self,
@@ -961,7 +1085,8 @@ class KeyValueCache(BaseCache):
     ) -> Any:
         """Get value of field in hash at key asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.ahget(key, field)
+        result = await self.adapter.ahget(key, field)
+        return self.decode(result) if result is not None else None
 
     async def ahgetall(
         self,
@@ -970,7 +1095,8 @@ class KeyValueCache(BaseCache):
     ) -> dict[str, Any]:
         """Get all fields and values in hash at key asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.ahgetall(key)
+        raw = await self.adapter.ahgetall(key)
+        return {(f.decode() if isinstance(f, bytes) else f): self.decode(v) for f, v in raw.items()}
 
     async def ahmget(
         self,
@@ -980,7 +1106,7 @@ class KeyValueCache(BaseCache):
     ) -> list[Any]:
         """Get values of multiple fields in hash asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.ahmget(key, *fields)
+        return [self.decode(v) if v is not None else None for v in await self.adapter.ahmget(key, *fields)]
 
     async def ahincrby(
         self,
@@ -1013,7 +1139,7 @@ class KeyValueCache(BaseCache):
     ) -> bool:
         """Set field in hash only if it doesn't exist asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.ahsetnx(key, field, value)
+        return await self.adapter.ahsetnx(key, field, self.encode(value))
 
     async def ahvals(
         self,
@@ -1022,7 +1148,7 @@ class KeyValueCache(BaseCache):
     ) -> list[Any]:
         """Get all values in hash at key asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.ahvals(key)
+        return [self.decode(v) for v in await self.adapter.ahvals(key)]
 
     # =========================================================================
     # List Operations
@@ -1036,7 +1162,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Push values onto head of list at key."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.lpush(key, *values)
+        return self.adapter.lpush(key, *(self.encode(v) for v in values))
 
     def rpush(
         self,
@@ -1046,7 +1172,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Push values onto tail of list at key."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.rpush(key, *values)
+        return self.adapter.rpush(key, *(self.encode(v) for v in values))
 
     def lpop(
         self,
@@ -1056,7 +1182,12 @@ class KeyValueCache(BaseCache):
     ) -> Any | list[Any] | None:
         """Remove and return element(s) from head of list."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.lpop(key, count=count)
+        result = self.adapter.lpop(key, count=count)
+        if result is None:
+            return None
+        if isinstance(result, list):
+            return [self.decode(v) for v in result]
+        return self.decode(result)
 
     def rpop(
         self,
@@ -1066,7 +1197,12 @@ class KeyValueCache(BaseCache):
     ) -> Any | list[Any] | None:
         """Remove and return element(s) from tail of list."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.rpop(key, count=count)
+        result = self.adapter.rpop(key, count=count)
+        if result is None:
+            return None
+        if isinstance(result, list):
+            return [self.decode(v) for v in result]
+        return self.decode(result)
 
     def lrange(
         self,
@@ -1077,7 +1213,7 @@ class KeyValueCache(BaseCache):
     ) -> list[Any]:
         """Get a range of elements from list."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.lrange(key, start, end)
+        return [self.decode(v) for v in self.adapter.lrange(key, start, end)]
 
     def lindex(
         self,
@@ -1087,7 +1223,8 @@ class KeyValueCache(BaseCache):
     ) -> Any:
         """Get element at index in list."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.lindex(key, index)
+        result = self.adapter.lindex(key, index)
+        return self.decode(result) if result is not None else None
 
     def llen(self, key: KeyT, version: int | None = None) -> int:
         """Get length of list at key."""
@@ -1105,7 +1242,7 @@ class KeyValueCache(BaseCache):
     ) -> int | list[int] | None:
         """Find position(s) of element in list."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.lpos(key, value, rank=rank, count=count, maxlen=maxlen)
+        return self.adapter.lpos(key, self.encode(value), rank=rank, count=count, maxlen=maxlen)
 
     def lmove(
         self,
@@ -1122,7 +1259,8 @@ class KeyValueCache(BaseCache):
         dst_ver = version_dst if version_dst is not None else version
         src = self.make_and_validate_key(src, version=src_ver)
         dst = self.make_and_validate_key(dst, version=dst_ver)
-        return self.adapter.lmove(src, dst, wherefrom, whereto)
+        result = self.adapter.lmove(src, dst, wherefrom, whereto)
+        return self.decode(result) if result is not None else None
 
     def lrem(
         self,
@@ -1133,7 +1271,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Remove elements equal to value from list."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.lrem(key, count, value)
+        return self.adapter.lrem(key, count, self.encode(value))
 
     def ltrim(
         self,
@@ -1155,7 +1293,7 @@ class KeyValueCache(BaseCache):
     ) -> bool:
         """Set element at index in list."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.lset(key, index, value)
+        return self.adapter.lset(key, index, self.encode(value))
 
     def linsert(
         self,
@@ -1167,7 +1305,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Insert value before or after pivot in list."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.linsert(key, where, pivot, value)
+        return self.adapter.linsert(key, where, self.encode(pivot), self.encode(value))
 
     def blpop(
         self,
@@ -1182,7 +1320,7 @@ class KeyValueCache(BaseCache):
         if result is None:
             return None
         # Reverse the key back to original
-        return (self.reverse_key(result[0]), result[1])
+        return (self.reverse_key(result[0]), self.decode(result[1]))
 
     def brpop(
         self,
@@ -1197,7 +1335,7 @@ class KeyValueCache(BaseCache):
         if result is None:
             return None
         # Reverse the key back to original
-        return (self.reverse_key(result[0]), result[1])
+        return (self.reverse_key(result[0]), self.decode(result[1]))
 
     def blmove(
         self,
@@ -1215,7 +1353,8 @@ class KeyValueCache(BaseCache):
         dst_ver = version_dst if version_dst is not None else version
         src = self.make_and_validate_key(src, version=src_ver)
         dst = self.make_and_validate_key(dst, version=dst_ver)
-        return self.adapter.blmove(src, dst, timeout, wherefrom, whereto)
+        result = self.adapter.blmove(src, dst, timeout, wherefrom, whereto)
+        return self.decode(result) if result is not None else None
 
     async def alpush(
         self,
@@ -1225,7 +1364,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Push values onto head of list at key asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.alpush(key, *values)
+        return await self.adapter.alpush(key, *(self.encode(v) for v in values))
 
     async def arpush(
         self,
@@ -1235,7 +1374,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Push values onto tail of list at key asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.arpush(key, *values)
+        return await self.adapter.arpush(key, *(self.encode(v) for v in values))
 
     async def alpop(
         self,
@@ -1245,7 +1384,12 @@ class KeyValueCache(BaseCache):
     ) -> Any | list[Any] | None:
         """Remove and return element(s) from head of list asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.alpop(key, count=count)
+        result = await self.adapter.alpop(key, count=count)
+        if result is None:
+            return None
+        if isinstance(result, list):
+            return [self.decode(v) for v in result]
+        return self.decode(result)
 
     async def arpop(
         self,
@@ -1255,7 +1399,12 @@ class KeyValueCache(BaseCache):
     ) -> Any | list[Any] | None:
         """Remove and return element(s) from tail of list asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.arpop(key, count=count)
+        result = await self.adapter.arpop(key, count=count)
+        if result is None:
+            return None
+        if isinstance(result, list):
+            return [self.decode(v) for v in result]
+        return self.decode(result)
 
     async def alrange(
         self,
@@ -1266,7 +1415,7 @@ class KeyValueCache(BaseCache):
     ) -> list[Any]:
         """Get a range of elements from list asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.alrange(key, start, end)
+        return [self.decode(v) for v in await self.adapter.alrange(key, start, end)]
 
     async def alindex(
         self,
@@ -1276,7 +1425,8 @@ class KeyValueCache(BaseCache):
     ) -> Any:
         """Get element at index in list asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.alindex(key, index)
+        result = await self.adapter.alindex(key, index)
+        return self.decode(result) if result is not None else None
 
     async def allen(self, key: KeyT, version: int | None = None) -> int:
         """Get length of list at key asynchronously."""
@@ -1294,7 +1444,7 @@ class KeyValueCache(BaseCache):
     ) -> int | list[int] | None:
         """Find position(s) of element in list asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.alpos(key, value, rank=rank, count=count, maxlen=maxlen)
+        return await self.adapter.alpos(key, self.encode(value), rank=rank, count=count, maxlen=maxlen)
 
     async def almove(
         self,
@@ -1311,7 +1461,8 @@ class KeyValueCache(BaseCache):
         dst_ver = version_dst if version_dst is not None else version
         src = self.make_and_validate_key(src, version=src_ver)
         dst = self.make_and_validate_key(dst, version=dst_ver)
-        return await self.adapter.almove(src, dst, wherefrom, whereto)
+        result = await self.adapter.almove(src, dst, wherefrom, whereto)
+        return self.decode(result) if result is not None else None
 
     async def alrem(
         self,
@@ -1322,7 +1473,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Remove elements equal to value from list asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.alrem(key, count, value)
+        return await self.adapter.alrem(key, count, self.encode(value))
 
     async def altrim(
         self,
@@ -1344,7 +1495,7 @@ class KeyValueCache(BaseCache):
     ) -> bool:
         """Set element at index in list asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.alset(key, index, value)
+        return await self.adapter.alset(key, index, self.encode(value))
 
     async def alinsert(
         self,
@@ -1356,7 +1507,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Insert value before or after pivot in list asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.alinsert(key, where, pivot, value)
+        return await self.adapter.alinsert(key, where, self.encode(pivot), self.encode(value))
 
     async def ablpop(
         self,
@@ -1370,7 +1521,7 @@ class KeyValueCache(BaseCache):
         result = await self.adapter.ablpop(nkeys, timeout=timeout)
         if result is None:
             return None
-        return (self.reverse_key(result[0]), result[1])
+        return (self.reverse_key(result[0]), self.decode(result[1]))
 
     async def abrpop(
         self,
@@ -1384,7 +1535,7 @@ class KeyValueCache(BaseCache):
         result = await self.adapter.abrpop(nkeys, timeout=timeout)
         if result is None:
             return None
-        return (self.reverse_key(result[0]), result[1])
+        return (self.reverse_key(result[0]), self.decode(result[1]))
 
     async def ablmove(
         self,
@@ -1402,7 +1553,8 @@ class KeyValueCache(BaseCache):
         dst_ver = version_dst if version_dst is not None else version
         src = self.make_and_validate_key(src, version=src_ver)
         dst = self.make_and_validate_key(dst, version=dst_ver)
-        return await self.adapter.ablmove(src, dst, timeout, wherefrom, whereto)
+        result = await self.adapter.ablmove(src, dst, timeout, wherefrom, whereto)
+        return self.decode(result) if result is not None else None
 
     # =========================================================================
     # Set Operations
@@ -1416,7 +1568,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Add members to a set."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.sadd(key, *members)
+        return self.adapter.sadd(key, *(self.encode(m) for m in members))
 
     def scard(self, key: KeyT, version: int | None = None) -> int:
         """Get the number of members in a set."""
@@ -1431,7 +1583,7 @@ class KeyValueCache(BaseCache):
         """Return the difference between the first set and all successive sets."""
         keys = [keys] if isinstance(keys, (str, bytes, memoryview)) else keys
         nkeys = [self.make_and_validate_key(k, version=version) for k in keys]
-        return self.adapter.sdiff(nkeys)
+        return {self.decode(m) for m in self.adapter.sdiff(nkeys)}
 
     def sdiffstore(
         self,
@@ -1458,7 +1610,7 @@ class KeyValueCache(BaseCache):
         """Return the intersection of all sets."""
         keys = [keys] if isinstance(keys, (str, bytes, memoryview)) else keys
         nkeys = [self.make_and_validate_key(k, version=version) for k in keys]
-        return self.adapter.sinter(nkeys)
+        return {self.decode(m) for m in self.adapter.sinter(nkeys)}
 
     def sinterstore(
         self,
@@ -1485,7 +1637,7 @@ class KeyValueCache(BaseCache):
     ) -> bool:
         """Check if member is in set."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.sismember(key, member)
+        return self.adapter.sismember(key, self.encode(member))
 
     def smembers(
         self,
@@ -1494,7 +1646,7 @@ class KeyValueCache(BaseCache):
     ) -> _Set[Any]:
         """Get all members of a set."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.smembers(key)
+        return {self.decode(m) for m in self.adapter.smembers(key)}
 
     def smove(
         self,
@@ -1510,7 +1662,7 @@ class KeyValueCache(BaseCache):
         dst_ver = version_dst if version_dst is not None else version
         src = self.make_and_validate_key(src, version=src_ver)
         dst = self.make_and_validate_key(dst, version=dst_ver)
-        return self.adapter.smove(src, dst, member)
+        return self.adapter.smove(src, dst, self.encode(member))
 
     def spop(
         self,
@@ -1520,7 +1672,12 @@ class KeyValueCache(BaseCache):
     ) -> Any | list[Any] | None:
         """Remove and return random member(s) from set."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.spop(key, count)
+        result = self.adapter.spop(key, count)
+        if result is None:
+            return None
+        if isinstance(result, (list, set)):
+            return type(result)(self.decode(m) for m in result)
+        return self.decode(result)
 
     def srandmember(
         self,
@@ -1530,7 +1687,12 @@ class KeyValueCache(BaseCache):
     ) -> Any | list[Any]:
         """Get random member(s) from set without removing."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.srandmember(key, count)
+        result = self.adapter.srandmember(key, count)
+        if result is None:
+            return None
+        if isinstance(result, list):
+            return [self.decode(m) for m in result]
+        return self.decode(result)
 
     def srem(
         self,
@@ -1540,7 +1702,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Remove members from a set."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.srem(key, *members)
+        return self.adapter.srem(key, *(self.encode(m) for m in members))
 
     def sunion(
         self,
@@ -1550,7 +1712,7 @@ class KeyValueCache(BaseCache):
         """Return the union of all sets."""
         keys = [keys] if isinstance(keys, (str, bytes, memoryview)) else keys
         nkeys = [self.make_and_validate_key(k, version=version) for k in keys]
-        return self.adapter.sunion(nkeys)
+        return {self.decode(m) for m in self.adapter.sunion(nkeys)}
 
     def sunionstore(
         self,
@@ -1577,7 +1739,7 @@ class KeyValueCache(BaseCache):
     ) -> list[bool]:
         """Check if multiple values are members of a set."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.smismember(key, *members)
+        return self.adapter.smismember(key, *(self.encode(m) for m in members))
 
     def sscan(
         self,
@@ -1589,7 +1751,8 @@ class KeyValueCache(BaseCache):
     ) -> tuple[int, _Set[Any]]:
         """Incrementally iterate over set members."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.sscan(key, cursor=cursor, match=match, count=count)
+        new_cursor, members = self.adapter.sscan(key, cursor=cursor, match=match, count=count)
+        return (new_cursor, {self.decode(m) for m in members})
 
     def sscan_iter(
         self,
@@ -1600,7 +1763,8 @@ class KeyValueCache(BaseCache):
     ) -> Iterator[Any]:
         """Iterate over set members using SSCAN."""
         key = self.make_and_validate_key(key, version=version)
-        yield from self.adapter.sscan_iter(key, match=match, count=count)
+        for member in self.adapter.sscan_iter(key, match=match, count=count):
+            yield self.decode(member)
 
     async def asadd(
         self,
@@ -1610,7 +1774,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Add members to a set asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.asadd(key, *members)
+        return await self.adapter.asadd(key, *(self.encode(m) for m in members))
 
     async def ascard(self, key: KeyT, version: int | None = None) -> int:
         """Get the number of members in a set asynchronously."""
@@ -1625,7 +1789,7 @@ class KeyValueCache(BaseCache):
         """Return the difference between the first set and all successive sets asynchronously."""
         keys = [keys] if isinstance(keys, (str, bytes, memoryview)) else keys
         nkeys = [self.make_and_validate_key(k, version=version) for k in keys]
-        return await self.adapter.asdiff(nkeys)
+        return {self.decode(m) for m in await self.adapter.asdiff(nkeys)}
 
     async def asdiffstore(
         self,
@@ -1651,7 +1815,7 @@ class KeyValueCache(BaseCache):
         """Return the intersection of all sets asynchronously."""
         keys = [keys] if isinstance(keys, (str, bytes, memoryview)) else keys
         nkeys = [self.make_and_validate_key(k, version=version) for k in keys]
-        return await self.adapter.asinter(nkeys)
+        return {self.decode(m) for m in await self.adapter.asinter(nkeys)}
 
     async def asinterstore(
         self,
@@ -1677,7 +1841,7 @@ class KeyValueCache(BaseCache):
     ) -> bool:
         """Check if member is in set asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.asismember(key, member)
+        return await self.adapter.asismember(key, self.encode(member))
 
     async def asmembers(
         self,
@@ -1686,7 +1850,7 @@ class KeyValueCache(BaseCache):
     ) -> _Set[Any]:
         """Get all members of a set asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.asmembers(key)
+        return {self.decode(m) for m in await self.adapter.asmembers(key)}
 
     async def asmove(
         self,
@@ -1702,7 +1866,7 @@ class KeyValueCache(BaseCache):
         dst_ver = version_dst if version_dst is not None else version
         src = self.make_and_validate_key(src, version=src_ver)
         dst = self.make_and_validate_key(dst, version=dst_ver)
-        return await self.adapter.asmove(src, dst, member)
+        return await self.adapter.asmove(src, dst, self.encode(member))
 
     async def aspop(
         self,
@@ -1712,7 +1876,12 @@ class KeyValueCache(BaseCache):
     ) -> Any | list[Any] | None:
         """Remove and return random member(s) from set asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.aspop(key, count)
+        result = await self.adapter.aspop(key, count)
+        if result is None:
+            return None
+        if isinstance(result, (list, set)):
+            return type(result)(self.decode(m) for m in result)
+        return self.decode(result)
 
     async def asrandmember(
         self,
@@ -1722,7 +1891,12 @@ class KeyValueCache(BaseCache):
     ) -> Any | list[Any]:
         """Get random member(s) from set without removing asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.asrandmember(key, count)
+        result = await self.adapter.asrandmember(key, count)
+        if result is None:
+            return None
+        if isinstance(result, list):
+            return [self.decode(m) for m in result]
+        return self.decode(result)
 
     async def asrem(
         self,
@@ -1732,7 +1906,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Remove members from a set asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.asrem(key, *members)
+        return await self.adapter.asrem(key, *(self.encode(m) for m in members))
 
     async def asunion(
         self,
@@ -1742,7 +1916,7 @@ class KeyValueCache(BaseCache):
         """Return the union of all sets asynchronously."""
         keys = [keys] if isinstance(keys, (str, bytes, memoryview)) else keys
         nkeys = [self.make_and_validate_key(k, version=version) for k in keys]
-        return await self.adapter.asunion(nkeys)
+        return {self.decode(m) for m in await self.adapter.asunion(nkeys)}
 
     async def asunionstore(
         self,
@@ -1768,7 +1942,7 @@ class KeyValueCache(BaseCache):
     ) -> list[bool]:
         """Check if multiple values are members of a set asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.asmismember(key, *members)
+        return await self.adapter.asmismember(key, *(self.encode(m) for m in members))
 
     async def asscan(
         self,
@@ -1780,7 +1954,8 @@ class KeyValueCache(BaseCache):
     ) -> tuple[int, _Set[Any]]:
         """Incrementally iterate over set members asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.asscan(key, cursor=cursor, match=match, count=count)
+        new_cursor, members = await self.adapter.asscan(key, cursor=cursor, match=match, count=count)
+        return (new_cursor, {self.decode(m) for m in members})
 
     async def asscan_iter(
         self,
@@ -1792,7 +1967,7 @@ class KeyValueCache(BaseCache):
         """Iterate over set members using SSCAN asynchronously."""
         key = self.make_and_validate_key(key, version=version)
         async for member in self.adapter.asscan_iter(key, match=match, count=count):
-            yield member
+            yield self.decode(member)
 
     # =========================================================================
     # Sorted Set Operations
@@ -1812,7 +1987,8 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Add members to a sorted set."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zadd(key, mapping, nx=nx, xx=xx, ch=ch, gt=gt, lt=lt)
+        encoded = {self.encode(member): score for member, score in mapping.items()}
+        return self.adapter.zadd(key, encoded, nx=nx, xx=xx, ch=ch, gt=gt, lt=lt)
 
     def zcard(self, key: KeyT, version: int | None = None) -> int:
         """Get the number of members in a sorted set."""
@@ -1839,7 +2015,7 @@ class KeyValueCache(BaseCache):
     ) -> float:
         """Increment the score of a member."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zincrby(key, amount, member)
+        return self.adapter.zincrby(key, amount, self.encode(member))
 
     def zpopmax(
         self,
@@ -1849,7 +2025,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[Any, float]]:
         """Remove and return members with highest scores."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zpopmax(key, count)
+        return [(self.decode(m), s) for m, s in self.adapter.zpopmax(key, count)]
 
     def zpopmin(
         self,
@@ -1859,7 +2035,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[Any, float]]:
         """Remove and return members with lowest scores."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zpopmin(key, count)
+        return [(self.decode(m), s) for m, s in self.adapter.zpopmin(key, count)]
 
     def zrange(
         self,
@@ -1872,7 +2048,10 @@ class KeyValueCache(BaseCache):
     ) -> list[Any] | list[tuple[Any, float]]:
         """Return a range of members by index."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zrange(key, start, end, withscores=withscores)
+        result = self.adapter.zrange(key, start, end, withscores=withscores)
+        if withscores:
+            return [(self.decode(m), s) for m, s in result]
+        return [self.decode(m) for m in result]
 
     def zrangebyscore(
         self,
@@ -1887,7 +2066,10 @@ class KeyValueCache(BaseCache):
     ) -> list[Any] | list[tuple[Any, float]]:
         """Return members with scores between min and max."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zrangebyscore(key, min_score, max_score, withscores=withscores, start=start, num=num)
+        result = self.adapter.zrangebyscore(key, min_score, max_score, withscores=withscores, start=start, num=num)
+        if withscores:
+            return [(self.decode(m), s) for m, s in result]
+        return [self.decode(m) for m in result]
 
     def zrank(
         self,
@@ -1897,7 +2079,7 @@ class KeyValueCache(BaseCache):
     ) -> int | None:
         """Get the rank of a member (0-based, lowest score first)."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zrank(key, member)
+        return self.adapter.zrank(key, self.encode(member))
 
     def zrem(
         self,
@@ -1907,7 +2089,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Remove members from a sorted set."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zrem(key, *members)
+        return self.adapter.zrem(key, *(self.encode(m) for m in members))
 
     def zremrangebyscore(
         self,
@@ -1942,7 +2124,10 @@ class KeyValueCache(BaseCache):
     ) -> list[Any] | list[tuple[Any, float]]:
         """Return a range of members by index, highest to lowest."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zrevrange(key, start, end, withscores=withscores)
+        result = self.adapter.zrevrange(key, start, end, withscores=withscores)
+        if withscores:
+            return [(self.decode(m), s) for m, s in result]
+        return [self.decode(m) for m in result]
 
     def zrevrangebyscore(
         self,
@@ -1957,7 +2142,10 @@ class KeyValueCache(BaseCache):
     ) -> list[Any] | list[tuple[Any, float]]:
         """Return members with scores between max and min, highest first."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zrevrangebyscore(key, max_score, min_score, withscores=withscores, start=start, num=num)
+        result = self.adapter.zrevrangebyscore(key, max_score, min_score, withscores=withscores, start=start, num=num)
+        if withscores:
+            return [(self.decode(m), s) for m, s in result]
+        return [self.decode(m) for m in result]
 
     def zscore(
         self,
@@ -1967,7 +2155,7 @@ class KeyValueCache(BaseCache):
     ) -> float | None:
         """Get the score of a member."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zscore(key, member)
+        return self.adapter.zscore(key, self.encode(member))
 
     def zrevrank(
         self,
@@ -1977,7 +2165,7 @@ class KeyValueCache(BaseCache):
     ) -> int | None:
         """Get the rank of a member (0-based, highest score first)."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zrevrank(key, member)
+        return self.adapter.zrevrank(key, self.encode(member))
 
     def zmscore(
         self,
@@ -1987,7 +2175,7 @@ class KeyValueCache(BaseCache):
     ) -> list[float | None]:
         """Get the scores of multiple members."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.zmscore(key, *members)
+        return self.adapter.zmscore(key, *(self.encode(m) for m in members))
 
     async def azadd(
         self,
@@ -2003,7 +2191,8 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Add members to a sorted set asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azadd(key, mapping, nx=nx, xx=xx, ch=ch, gt=gt, lt=lt)
+        encoded = {self.encode(member): score for member, score in mapping.items()}
+        return await self.adapter.azadd(key, encoded, nx=nx, xx=xx, ch=ch, gt=gt, lt=lt)
 
     async def azcard(self, key: KeyT, version: int | None = None) -> int:
         """Get the number of members in a sorted set asynchronously."""
@@ -2030,7 +2219,7 @@ class KeyValueCache(BaseCache):
     ) -> float:
         """Increment the score of a member asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azincrby(key, amount, member)
+        return await self.adapter.azincrby(key, amount, self.encode(member))
 
     async def azpopmax(
         self,
@@ -2040,7 +2229,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[Any, float]]:
         """Remove and return members with highest scores asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azpopmax(key, count)
+        return [(self.decode(m), s) for m, s in await self.adapter.azpopmax(key, count)]
 
     async def azpopmin(
         self,
@@ -2050,7 +2239,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[Any, float]]:
         """Remove and return members with lowest scores asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azpopmin(key, count)
+        return [(self.decode(m), s) for m, s in await self.adapter.azpopmin(key, count)]
 
     async def azrange(
         self,
@@ -2063,7 +2252,10 @@ class KeyValueCache(BaseCache):
     ) -> list[Any] | list[tuple[Any, float]]:
         """Return a range of members by index asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azrange(key, start, end, withscores=withscores)
+        result = await self.adapter.azrange(key, start, end, withscores=withscores)
+        if withscores:
+            return [(self.decode(m), s) for m, s in result]
+        return [self.decode(m) for m in result]
 
     async def azrangebyscore(
         self,
@@ -2078,7 +2270,17 @@ class KeyValueCache(BaseCache):
     ) -> list[Any] | list[tuple[Any, float]]:
         """Return members with scores between min and max asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azrangebyscore(key, min_score, max_score, withscores=withscores, start=start, num=num)
+        result = await self.adapter.azrangebyscore(
+            key,
+            min_score,
+            max_score,
+            withscores=withscores,
+            start=start,
+            num=num,
+        )
+        if withscores:
+            return [(self.decode(m), s) for m, s in result]
+        return [self.decode(m) for m in result]
 
     async def azrank(
         self,
@@ -2088,7 +2290,7 @@ class KeyValueCache(BaseCache):
     ) -> int | None:
         """Get the rank of a member (0-based, lowest score first) asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azrank(key, member)
+        return await self.adapter.azrank(key, self.encode(member))
 
     async def azrem(
         self,
@@ -2098,7 +2300,7 @@ class KeyValueCache(BaseCache):
     ) -> int:
         """Remove members from a sorted set asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azrem(key, *members)
+        return await self.adapter.azrem(key, *(self.encode(m) for m in members))
 
     async def azremrangebyscore(
         self,
@@ -2133,7 +2335,10 @@ class KeyValueCache(BaseCache):
     ) -> list[Any] | list[tuple[Any, float]]:
         """Return a range of members by index, highest to lowest, asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azrevrange(key, start, end, withscores=withscores)
+        result = await self.adapter.azrevrange(key, start, end, withscores=withscores)
+        if withscores:
+            return [(self.decode(m), s) for m, s in result]
+        return [self.decode(m) for m in result]
 
     async def azrevrangebyscore(
         self,
@@ -2148,7 +2353,7 @@ class KeyValueCache(BaseCache):
     ) -> list[Any] | list[tuple[Any, float]]:
         """Return members with scores between max and min, highest first, asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azrevrangebyscore(
+        result = await self.adapter.azrevrangebyscore(
             key,
             max_score,
             min_score,
@@ -2156,6 +2361,9 @@ class KeyValueCache(BaseCache):
             start=start,
             num=num,
         )
+        if withscores:
+            return [(self.decode(m), s) for m, s in result]
+        return [self.decode(m) for m in result]
 
     async def azscore(
         self,
@@ -2165,7 +2373,7 @@ class KeyValueCache(BaseCache):
     ) -> float | None:
         """Get the score of a member asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azscore(key, member)
+        return await self.adapter.azscore(key, self.encode(member))
 
     async def azrevrank(
         self,
@@ -2175,7 +2383,7 @@ class KeyValueCache(BaseCache):
     ) -> int | None:
         """Get the rank of a member (0-based, highest score first) asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azrevrank(key, member)
+        return await self.adapter.azrevrank(key, self.encode(member))
 
     async def azmscore(
         self,
@@ -2185,7 +2393,7 @@ class KeyValueCache(BaseCache):
     ) -> list[float | None]:
         """Get the scores of multiple members asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.azmscore(key, *members)
+        return await self.adapter.azmscore(key, *(self.encode(m) for m in members))
 
     # =========================================================================
     # Stream Operations
@@ -2205,9 +2413,10 @@ class KeyValueCache(BaseCache):
     ) -> str:
         """Add an entry to a stream."""
         key = self.make_and_validate_key(key, version=version)
+        encoded_fields = {f: self.encode(v) for f, v in fields.items()}
         return self.adapter.xadd(
             key,
-            fields,
+            encoded_fields,
             entry_id,
             maxlen=maxlen,
             approximate=approximate,
@@ -2230,9 +2439,10 @@ class KeyValueCache(BaseCache):
     ) -> str:
         """Add an entry to a stream asynchronously."""
         key = self.make_and_validate_key(key, version=version)
+        encoded_fields = {f: self.encode(v) for f, v in fields.items()}
         return await self.adapter.axadd(
             key,
-            fields,
+            encoded_fields,
             entry_id,
             maxlen=maxlen,
             approximate=approximate,
@@ -2251,6 +2461,13 @@ class KeyValueCache(BaseCache):
         key = self.make_and_validate_key(key, version=version)
         return await self.adapter.axlen(key)
 
+    def _decode_stream_entries(
+        self,
+        entries: list[tuple[str, dict[str, Any]]],
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Decode field values in a list of (entry_id, fields_dict) entries."""
+        return [(entry_id, {f: self.decode(v) for f, v in fields.items()}) for entry_id, fields in entries]
+
     def xrange(
         self,
         key: KeyT,
@@ -2261,7 +2478,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[str, dict[str, Any]]]:
         """Get entries from a stream in ascending order."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.xrange(key, start, end, count=count)
+        return self._decode_stream_entries(self.adapter.xrange(key, start, end, count=count))
 
     async def axrange(
         self,
@@ -2273,7 +2490,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[str, dict[str, Any]]]:
         """Get entries from a stream in ascending order asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.axrange(key, start, end, count=count)
+        return self._decode_stream_entries(await self.adapter.axrange(key, start, end, count=count))
 
     def xrevrange(
         self,
@@ -2285,7 +2502,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[str, dict[str, Any]]]:
         """Get entries from a stream in descending order."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.xrevrange(key, end, start, count=count)
+        return self._decode_stream_entries(self.adapter.xrevrange(key, end, start, count=count))
 
     async def axrevrange(
         self,
@@ -2297,7 +2514,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[str, dict[str, Any]]]:
         """Get entries from a stream in descending order asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.axrevrange(key, end, start, count=count)
+        return self._decode_stream_entries(await self.adapter.axrevrange(key, end, start, count=count))
 
     def xread(
         self,
@@ -2312,7 +2529,7 @@ class KeyValueCache(BaseCache):
         result = self.adapter.xread(nstreams, count=count, block=block)
         if result is None:
             return None
-        return {str(key_map.get(k, k)): v for k, v in result.items()}
+        return {str(key_map.get(k, k)): self._decode_stream_entries(v) for k, v in result.items()}
 
     async def axread(
         self,
@@ -2327,7 +2544,7 @@ class KeyValueCache(BaseCache):
         result = await self.adapter.axread(nstreams, count=count, block=block)
         if result is None:
             return None
-        return {str(key_map.get(k, k)): v for k, v in result.items()}
+        return {str(key_map.get(k, k)): self._decode_stream_entries(v) for k, v in result.items()}
 
     def xtrim(
         self,
@@ -2481,7 +2698,7 @@ class KeyValueCache(BaseCache):
         result = self.adapter.xreadgroup(group, consumer, nstreams, count=count, block=block, noack=noack)
         if result is None:
             return None
-        return {str(key_map.get(k, k)): v for k, v in result.items()}
+        return {str(key_map.get(k, k)): self._decode_stream_entries(v) for k, v in result.items()}
 
     async def axreadgroup(
         self,
@@ -2499,7 +2716,7 @@ class KeyValueCache(BaseCache):
         result = await self.adapter.axreadgroup(group, consumer, nstreams, count=count, block=block, noack=noack)
         if result is None:
             return None
-        return {str(key_map.get(k, k)): v for k, v in result.items()}
+        return {str(key_map.get(k, k)): self._decode_stream_entries(v) for k, v in result.items()}
 
     def xack(self, key: KeyT, group: str, *entry_ids: str, version: int | None = None) -> int:
         """Acknowledge message processing."""
@@ -2557,7 +2774,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[str, dict[str, Any]]] | list[str]:
         """Claim pending messages."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.xclaim(
+        result = self.adapter.xclaim(
             key,
             group,
             consumer,
@@ -2569,6 +2786,10 @@ class KeyValueCache(BaseCache):
             force=force,
             justid=justid,
         )
+        # justid=True returns list[str] (entry IDs only); else list[(id, fields_dict)].
+        if justid:
+            return result
+        return self._decode_stream_entries(cast("list[tuple[str, dict[str, Any]]]", result))
 
     async def axclaim(
         self,
@@ -2586,7 +2807,7 @@ class KeyValueCache(BaseCache):
     ) -> list[tuple[str, dict[str, Any]]] | list[str]:
         """Claim pending messages asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.axclaim(
+        result = await self.adapter.axclaim(
             key,
             group,
             consumer,
@@ -2598,6 +2819,9 @@ class KeyValueCache(BaseCache):
             force=force,
             justid=justid,
         )
+        if justid:
+            return result
+        return self._decode_stream_entries(cast("list[tuple[str, dict[str, Any]]]", result))
 
     def xautoclaim(
         self,
@@ -2612,7 +2836,18 @@ class KeyValueCache(BaseCache):
     ) -> tuple[str, list[tuple[str, dict[str, Any]]] | list[str], list[str]]:
         """Auto-claim pending messages that have been idle."""
         key = self.make_and_validate_key(key, version=version)
-        return self.adapter.xautoclaim(key, group, consumer, min_idle_time, start_id, count=count, justid=justid)
+        next_id, claimed, deleted = self.adapter.xautoclaim(
+            key,
+            group,
+            consumer,
+            min_idle_time,
+            start_id,
+            count=count,
+            justid=justid,
+        )
+        if justid:
+            return (next_id, claimed, deleted)
+        return (next_id, self._decode_stream_entries(cast("list[tuple[str, dict[str, Any]]]", claimed)), deleted)
 
     async def axautoclaim(
         self,
@@ -2627,7 +2862,18 @@ class KeyValueCache(BaseCache):
     ) -> tuple[str, list[tuple[str, dict[str, Any]]] | list[str], list[str]]:
         """Auto-claim pending messages asynchronously."""
         key = self.make_and_validate_key(key, version=version)
-        return await self.adapter.axautoclaim(key, group, consumer, min_idle_time, start_id, count=count, justid=justid)
+        next_id, claimed, deleted = await self.adapter.axautoclaim(
+            key,
+            group,
+            consumer,
+            min_idle_time,
+            start_id,
+            count=count,
+            justid=justid,
+        )
+        if justid:
+            return (next_id, claimed, deleted)
+        return (next_id, self._decode_stream_entries(cast("list[tuple[str, dict[str, Any]]]", claimed)), deleted)
 
     # =========================================================================
     # Direct Client Access
@@ -2760,8 +3006,8 @@ class KeyValueCache(BaseCache):
         """Create a ScriptHelpers instance for script processing."""
         return ScriptHelpers(
             make_key=self.make_and_validate_key,
-            encode=self.adapter.encode,
-            decode=self.adapter.decode,
+            encode=self.encode,
+            decode=self.decode,
             version=version if version is not None else self.version,
         )
 

--- a/tests/cache/test_basic.py
+++ b/tests/cache/test_basic.py
@@ -122,7 +122,7 @@ class TestDataTypePersistence:
         assert result == "café résumé"
 
     def test_dictionary_with_datetime(self, cache: KeyValueCache):
-        if isinstance(cache.adapter._serializers[0], JSONSerializer | MessagePackSerializer):
+        if isinstance(cache._serializers[0], JSONSerializer | MessagePackSerializer):
             timestamp: str | datetime.datetime = datetime.datetime.now().isoformat()
         else:
             timestamp = datetime.datetime.now()
@@ -693,7 +693,7 @@ class TestAsyncDataTypePersistence:
 
     @pytest.mark.asyncio
     async def test_adictionary_with_datetime(self, cache: KeyValueCache):
-        if isinstance(cache.adapter._serializers[0], JSONSerializer | MessagePackSerializer):
+        if isinstance(cache._serializers[0], JSONSerializer | MessagePackSerializer):
             timestamp: str | datetime.datetime = datetime.datetime.now().isoformat()
         else:
             timestamp = datetime.datetime.now()

--- a/tests/cache/test_cluster_client.py
+++ b/tests/cache/test_cluster_client.py
@@ -107,13 +107,13 @@ class TestRedisClusterAdapter:
         # Using hash tags that hash to different slots
         result = client.get_many(["{a}key1", "{b}key2", "{c}key3"])
 
-        # Should return decoded values
+        # Adapter returns raw bytes (cache layer is responsible for decoding).
         assert len(result) == 3
         # mget_nonatomic is called once with all keys
         mock_cluster.mget_nonatomic.assert_called_once()
-        assert "value_a" in result.values()
-        assert "value_b" in result.values()
-        assert "value_c" in result.values()
+        assert pickle.dumps("value_a") in result.values()
+        assert pickle.dumps("value_b") in result.values()
+        assert pickle.dumps("value_c") in result.values()
 
     def test_get_many_empty_keys(self):
         client = setup_cluster_client()

--- a/tests/cache/test_compressor_fallback.py
+++ b/tests/cache/test_compressor_fallback.py
@@ -2,6 +2,7 @@
 
 import gzip
 import zlib
+from typing import Any
 
 
 class TestDefaultClientCompressorConfig:
@@ -104,42 +105,49 @@ class TestDefaultClientCompressorConfig:
             cache.delete("new_key")
 
 
+def _make_cache(*, compressor: Any = None, serializer: Any = None) -> Any:
+    """Construct a :class:`RedisCache` purely to exercise the encoding stack.
+
+    ``_decompress`` / ``_deserialize`` / ``encode`` / ``decode`` live on the
+    cache layer; the adapter is wire-only. The cache's ``adapter`` property
+    is lazy, so we never actually open a connection.
+    """
+    from django_cachex.cache import RedisCache
+
+    options: dict[str, Any] = {}
+    if compressor is not None:
+        options["compressor"] = compressor
+    if serializer is not None:
+        options["serializer"] = serializer
+    return RedisCache(server="redis://localhost:6379", params={"OPTIONS": options})
+
+
 class TestDecompressFallback:
-    """Tests for the _decompress fallback logic."""
+    """Tests for the _decompress fallback logic on the cache layer."""
 
     def test_decompress_gzip_with_multiple_compressors(self):
-        from django_cachex.adapter import RedisAdapter
-
-        client = RedisAdapter(
-            servers=["redis://localhost:6379"],
+        cache = _make_cache(
             compressor=[
                 "django_cachex.compressors.gzip.GzipCompressor",
                 "django_cachex.compressors.zlib.ZlibCompressor",
             ],
         )
-
         data = b"Test data for compression! " * 50
         gzip_data = gzip.compress(data)
-
-        assert client._decompress(gzip_data) == data
+        assert cache._decompress(gzip_data) == data
 
     def test_decompress_zlib_with_fallback(self):
         """Test that _decompress falls back to zlib for zlib-compressed data."""
-        from django_cachex.adapter import RedisAdapter
-
-        client = RedisAdapter(
-            servers=["redis://localhost:6379"],
+        cache = _make_cache(
             compressor=[
                 "django_cachex.compressors.gzip.GzipCompressor",
                 "django_cachex.compressors.zlib.ZlibCompressor",
             ],
         )
-
         data = b"Test data for compression! " * 50
         zlib_data = zlib.compress(data)
-
         # gzip will fail, zlib should succeed
-        assert client._decompress(zlib_data) == data
+        assert cache._decompress(zlib_data) == data
 
     def test_decompress_raises_when_all_compressors_fail(self):
         """When every configured compressor fails, _decompress raises CompressorError.
@@ -150,48 +158,32 @@ class TestDecompressFallback:
         """
         import pytest
 
-        from django_cachex.adapter import RedisAdapter
         from django_cachex.exceptions import CompressorError
 
-        client = RedisAdapter(
-            servers=["redis://localhost:6379"],
-            compressor=[
-                "django_cachex.compressors.gzip.GzipCompressor",
-            ],
-        )
-
+        cache = _make_cache(compressor=["django_cachex.compressors.gzip.GzipCompressor"])
         # Plain data that isn't gzip — the only configured compressor fails.
         data = b"Plain uncompressed data"
         with pytest.raises(CompressorError):
-            client._decompress(data)
+            cache._decompress(data)
 
     def test_decompress_raises_after_full_chain_fails(self):
         """_decompress walks the full chain before raising; raises when none succeed."""
         import pytest
 
-        from django_cachex.adapter import RedisAdapter
         from django_cachex.exceptions import CompressorError
 
-        client = RedisAdapter(
-            servers=["redis://localhost:6379"],
+        cache = _make_cache(
             compressor=[
                 "django_cachex.compressors.gzip.GzipCompressor",
                 "django_cachex.compressors.zlib.ZlibCompressor",
             ],
         )
-
         # Looks like gzip (magic bytes) but isn't valid; zlib also fails.
         fake_gzip = b"\x1f\x8bNot actually valid gzip data"
         with pytest.raises(CompressorError):
-            client._decompress(fake_gzip)
+            cache._decompress(fake_gzip)
 
     def test_decompress_with_no_compressors_returns_raw(self):
-        from django_cachex.adapter import RedisAdapter
-
-        client = RedisAdapter(
-            servers=["redis://localhost:6379"],
-            compressor=None,
-        )
-
+        cache = _make_cache(compressor=None)
         data = b"Plain uncompressed data"
-        assert client._decompress(data) == data
+        assert cache._decompress(data) == data

--- a/tests/cache/test_internals.py
+++ b/tests/cache/test_internals.py
@@ -102,13 +102,13 @@ class TestRedisCacheInternals:
         Django's test checks _serializer.dumps() but our architecture uses encode().
         """
         # Integers are stored directly (no serialization overhead)
-        assert cache.adapter.encode(123) == 123
+        assert cache.encode(123) == 123
 
         # Booleans are serialized to bytes
-        assert isinstance(cache.adapter.encode(True), bytes)
+        assert isinstance(cache.encode(True), bytes)
 
         # Strings are serialized to bytes
-        assert isinstance(cache.adapter.encode("abc"), bytes)
+        assert isinstance(cache.encode("abc"), bytes)
 
     def test_redis_pool_options(self, redis_container: RedisContainerInfo):
         from contextlib import suppress

--- a/tests/cache/test_scripts.py
+++ b/tests/cache/test_scripts.py
@@ -113,8 +113,8 @@ class TestScriptHelpers:
     def test_script_helpers_make_keys(self, cache: KeyValueCache):
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
-            encode=cache.adapter.encode,
-            decode=cache.adapter.decode,
+            encode=cache.encode,
+            decode=cache.decode,
             version=1,
         )
 
@@ -127,8 +127,8 @@ class TestScriptHelpers:
     def test_script_helpers_encode_decode(self, cache: KeyValueCache):
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
-            encode=cache.adapter.encode,
-            decode=cache.adapter.decode,
+            encode=cache.encode,
+            decode=cache.decode,
             version=1,
         )
 
@@ -146,8 +146,8 @@ class TestPreBuiltHooks:
         """Test keys_only_pre helper."""
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
-            encode=cache.adapter.encode,
-            decode=cache.adapter.decode,
+            encode=cache.encode,
+            decode=cache.decode,
             version=1,
         )
 
@@ -164,8 +164,8 @@ class TestPreBuiltHooks:
     def test_full_encode_pre(self, cache: KeyValueCache):
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
-            encode=cache.adapter.encode,
-            decode=cache.adapter.decode,
+            encode=cache.encode,
+            decode=cache.decode,
             version=1,
         )
 
@@ -183,8 +183,8 @@ class TestPreBuiltHooks:
     def test_decode_single_post(self, cache: KeyValueCache):
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
-            encode=cache.adapter.encode,
-            decode=cache.adapter.decode,
+            encode=cache.encode,
+            decode=cache.decode,
             version=1,
         )
 
@@ -200,8 +200,8 @@ class TestPreBuiltHooks:
     def test_decode_list_post(self, cache: KeyValueCache):
         helpers = ScriptHelpers(
             make_key=cache.make_and_validate_key,
-            encode=cache.adapter.encode,
-            decode=cache.adapter.decode,
+            encode=cache.encode,
+            decode=cache.decode,
             version=1,
         )
 

--- a/tests/cache/test_serializer_fallback.py
+++ b/tests/cache/test_serializer_fallback.py
@@ -2,40 +2,51 @@
 
 import json
 import pickle
+from typing import Any
 
 import pytest
 
-from django_cachex.adapter import RedisAdapter
 from django_cachex.exceptions import SerializerError
 from django_cachex.serializers.json import JSONSerializer
 from django_cachex.serializers.pickle import PickleSerializer
 
 
+def _make_cache(*, serializer: Any) -> Any:
+    """Construct a :class:`RedisCache` purely to exercise the encoding stack.
+
+    ``_deserialize`` / ``encode`` / ``decode`` live on the cache layer; the
+    cache's ``adapter`` property is lazy, so we never actually open a
+    connection in these tests.
+    """
+    from django_cachex.cache import RedisCache
+
+    return RedisCache(
+        server="redis://localhost:6379/0",
+        params={"OPTIONS": {"serializer": serializer}},
+    )
+
+
 class TestDefaultClientSerializerConfig:
-    """Tests for RedisAdapter serializer configuration handling."""
+    """Tests for KeyValueCache serializer configuration handling."""
 
     def test_single_string_config_backwards_compatible(self, redis_container):
         """Test that a single string config still works (backwards compatibility)."""
-        client = RedisAdapter(
-            servers=["redis://localhost:6379/0"],
-            serializer="django_cachex.serializers.pickle.PickleSerializer",
-        )
+        cache = _make_cache(serializer="django_cachex.serializers.pickle.PickleSerializer")
 
-        assert len(client._serializers) == 1
-        assert client._serializers[0].__class__.__name__ == "PickleSerializer"
+        assert len(cache._serializers) == 1
+        assert cache._serializers[0].__class__.__name__ == "PickleSerializer"
 
     def test_list_config_with_fallback(self, redis_container):
-        client = RedisAdapter(
-            servers=["redis://localhost:6379/0"],
+        cache = _make_cache(
             serializer=[
                 "django_cachex.serializers.json.JSONSerializer",
                 "django_cachex.serializers.pickle.PickleSerializer",
             ],
         )
 
-        assert len(client._serializers) == 2
-        assert client._serializers[0].__class__.__name__ == "JSONSerializer"
-        assert client._serializers[1].__class__.__name__ == "PickleSerializer"
+        assert len(cache._serializers) == 2
+        assert cache._serializers[0].__class__.__name__ == "JSONSerializer"
+        assert cache._serializers[1].__class__.__name__ == "PickleSerializer"
 
     def test_migration_scenario(self, redis_container):
         """Test a realistic migration scenario from pickle to JSON."""
@@ -88,67 +99,51 @@ class TestDefaultClientSerializerConfig:
 
 
 class TestDeserializeFallback:
-    """Tests for the _deserialize fallback logic."""
+    """Tests for the _deserialize fallback logic on the cache layer."""
 
     def test_deserialize_json_with_multiple_serializers(self, redis_container):
-        client = RedisAdapter(
-            servers=["redis://localhost:6379/0"],
+        cache = _make_cache(
             serializer=[
                 "django_cachex.serializers.json.JSONSerializer",
                 "django_cachex.serializers.pickle.PickleSerializer",
             ],
         )
-
         data = {"key": "value", "number": 42}
         json_data = json.dumps(data).encode()
-
-        assert client._deserialize(json_data) == data
+        assert cache._deserialize(json_data) == data
 
     def test_deserialize_pickle_with_json_first(self, redis_container):
-        client = RedisAdapter(
-            servers=["redis://localhost:6379/0"],
+        cache = _make_cache(
             serializer=[
                 "django_cachex.serializers.json.JSONSerializer",
                 "django_cachex.serializers.pickle.PickleSerializer",
             ],
         )
-
         data = {"key": "value", "number": 42}
         pickle_data = pickle.dumps(data)
-
         # JSON will fail, pickle should succeed
-        assert client._deserialize(pickle_data) == data
+        assert cache._deserialize(pickle_data) == data
 
     def test_deserialize_raises_when_all_fail(self, redis_container):
         """Test that _deserialize raises SerializerError when all serializers fail."""
-        client = RedisAdapter(
-            servers=["redis://localhost:6379/0"],
-            serializer=[
-                "django_cachex.serializers.json.JSONSerializer",
-            ],
-        )
-
+        cache = _make_cache(serializer=["django_cachex.serializers.json.JSONSerializer"])
         # Invalid data that can't be deserialized as JSON
         invalid_data = b"\x80\x04\x95\x00\x00\x00\x00"  # Pickle header, not JSON
-
         with pytest.raises(SerializerError):
-            client._deserialize(invalid_data)
+            cache._deserialize(invalid_data)
 
     def test_deserialize_continues_on_failure(self, redis_container):
-        client = RedisAdapter(
-            servers=["redis://localhost:6379/0"],
+        cache = _make_cache(
             serializer=[
                 "django_cachex.serializers.json.JSONSerializer",
                 "django_cachex.serializers.pickle.PickleSerializer",
             ],
         )
-
         # Data that is valid pickle but not valid JSON
         data = {"key": "value"}
         pickle_data = pickle.dumps(data)
-
         # JSON fails, falls through to pickle
-        assert client._deserialize(pickle_data) == data
+        assert cache._deserialize(pickle_data) == data
 
 
 class TestSerializerError:


### PR DESCRIPTION
The serializer / compressor / encode / decode stack now lives on KeyValueCache. The Adapter layer is bytes-in, bytes-out — pure wire ops, no Python serialization knowledge.

Why: previously each adapter (default / rust / glide) carried its own copy of the encoding pipeline and called self.encode / self.decode in ~377 method bodies. With encoding centralised on the cache, an adapter becomes a near-trivial forward to the underlying driver — which is what unblocks the upcoming redis-rs adapter collapse.

Changes:
- KeyValueCache.__init__ owns _serializers / _compressors and exposes encode / decode / _decompress / _deserialize. Native caches (LocMemCache, DatabaseCache) are unaffected; they store Python values directly and never needed wire encoding.
- BaseKeyValueAdapter no longer touches serializer / compressor; the serializer kwarg is gone from its constructor (options dict still passes through, with serializer / compressor keys silently ignored).
- adapter/default.py, rust.py, glide.py, cluster.py have all self.encode / self.decode calls stripped (~377 sites).
- KeyValueCache cachex methods (~120 sync+async pairs) wrap each adapter call with the right encode/decode pattern: zadd encodes members but not scores, hgetall decodes values but bytes-decodes field names, zrange withscores decodes members but leaves scores, stream entries decode field values, etc.
- Pipeline wrapper now takes a cache reference (was: adapter) and sources encode/decode from the cache. Adapter.pipeline() returns the raw BaseKeyValuePipelineAdapter; KeyValueCache.pipeline() wraps it.
- ScriptHelpers wiring switched from adapter.encode/decode to cache.encode/decode; admin/cas.py updated likewise.

Test updates:
- test_serializer_fallback / test_compressor_fallback now construct a RedisCache (lazy adapter — no connection opened) to exercise the encode stack.
- test_cluster_client.test_get_many_uses_mget_nonatomic asserts raw bytes from the adapter (decoding is the cache layer's job now).
- 9039 tests pass; mypy / ruff / ty all clean.